### PR TITLE
make zoomTo example non-degenerate

### DIFF
--- a/docs/higlass_developer.rst
+++ b/docs/higlass_developer.rst
@@ -231,9 +231,9 @@ to each other.
 ``end1: Number``
     The right x coordinate of the region to zoom to.
 ``start2: Number``
-    The left x coordinate of the region to zoom to.
+    The left y coordinate of the region to zoom to.
 ``end2: Number``
-    The right x coordinate of the region to zoom to.
+    The right y coordinate of the region to zoom to.
 ``animateTime [default: 0]``
     The duration of the zoom transition in milliseconds.
 
@@ -242,7 +242,7 @@ to each other.
 .. code-block:: javascript
 
   // Absolute coordinates
-  hgApi.zoomTo('view1', 1000000, 1000000, 2000000, 2000000, 500);
+  hgApi.zoomTo('view1', 1000000, 1100000, 2000000, 2100000, 500);
 
   // Chromosomal coordinates
   hglib


### PR DESCRIPTION
... but these docs don't actually match [docs-dev.higlass.io](http://docs-dev.higlass.io/javascript_api.html#zoomTo). There is also [api.js](https://github.com/higlass/higlass/blob/2f1b7b4b38fe3a706381b4b41bcc00aa9ad00a72/app/scripts/api.js#L397) ... and I guess I'll make a similar edit there. [higlass-docs](https://github.com/higlass/higlass-docs/blob/develop/_build/html/javascript_api.html#L391) doesn't seem like the right place to edit... I wouldn't think the built html should even be checked in?