### PR TITLE
30% opacity on SVG export gene annotations

### DIFF
--- a/app/scripts/HorizontalGeneAnnotationsTrack.js
+++ b/app/scripts/HorizontalGeneAnnotationsTrack.js
@@ -674,6 +674,7 @@ class HorizontalGeneAnnotationsTrack extends HorizontalTiled1DPixiTrack {
           } else {
             r.setAttribute('fill', this.options.minusStrandColor);
           }
+          r.setAttribute('opacity', '0.3');
 
           gTile.appendChild(r);
         });


### PR DESCRIPTION
To match canvas