### PR TITLE
Mccalluc/more linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -36,7 +36,7 @@
     "guard-for-in": 0,
     "jsx-quotes": 1,
     "no-bitwise": 0,
-    "no-console": 0,
+    "no-console": ["error", { "allow": ["warn", "error"] }],
     "no-continue": 0,
     "no-mixed-operators": ["error", { "allowSamePrecedence": true }],
     "no-multi-spaces": ["error", { "ignoreEOLComments": true }],

--- a/.eslintrc
+++ b/.eslintrc
@@ -36,6 +36,7 @@
     "guard-for-in": 0,
     "jsx-quotes": 1,
     "no-bitwise": 0,
+    "no-console": 0,
     "no-continue": 0,
     "no-mixed-operators": ["error", { "allowSamePrecedence": true }],
     "no-multi-spaces": ["error", { "ignoreEOLComments": true }],

--- a/app/scripts/services/chrom-info.js
+++ b/app/scripts/services/chrom-info.js
@@ -6,7 +6,7 @@ const cache = {};
 const getFromCache = (url, fallback) => (cache[url] ? Promise.resolve(cache[url]) : fallback(url));
 
 const parseChromInfo = (text) => {
-  if (text.length == 0) return null;
+  if (text.length === 0) return null;
 
   const tsv = tsvParseRows(text);
   return parseChromsizesRows(tsv);

--- a/app/scripts/services/chrom-info.js
+++ b/app/scripts/services/chrom-info.js
@@ -3,18 +3,16 @@ import { parseChromsizesRows } from '../ChromosomeInfo';
 
 const cache = {};
 
-const getFromCache = (url, fallback) =>
-  (cache[url] ? Promise.resolve(cache[url]) : fallback(url));
+const getFromCache = (url, fallback) => (cache[url] ? Promise.resolve(cache[url]) : fallback(url));
 
 const parseChromInfo = (text) => {
-  if (text.length == 0)
-    return null;
+  if (text.length == 0) return null;
 
   const tsv = tsvParseRows(text);
   return parseChromsizesRows(tsv);
 };
 
-const getFromRemote = url => fetch(url, {credentials: 'same-origin'})
+const getFromRemote = url => fetch(url, { credentials: 'same-origin' })
   .then(response => response.text())
   .then(text => parseChromInfo(text))
   .catch((error) => {

--- a/app/scripts/services/pub-sub.js
+++ b/app/scripts/services/pub-sub.js
@@ -62,7 +62,9 @@ const publish = (stack = STACK) => (event, news) => {
 
   stack[event].forEach((listener, i) => {
     listener(news);
-    if (!(stack.__times[event][i] -= 1)) unsubscriber(event, listener);
+    if (!(stack.__times[event][i] -= 1)) { // eslint-disable-line no-cond-assign
+      unsubscriber(event, listener);
+    }
   });
 };
 

--- a/app/scripts/services/pub-sub.js
+++ b/app/scripts/services/pub-sub.js
@@ -37,8 +37,7 @@ const unsubscribe = (stack = STACK) => (event, callback) => {
   if (!stack[event]) return;
 
   if (typeof event === 'object') {
-    event = event.event; // eslint-disable-line no-param-reassign
-    callback = event.callback; // eslint-disable-line no-param-reassign
+    ({ event, callback } = event); // eslint-disable-line no-param-reassign
   }
 
   const id = stack[event].indexOf(callback);

--- a/app/scripts/services/tile-proxy.js
+++ b/app/scripts/services/tile-proxy.js
@@ -1,12 +1,9 @@
-import { scaleLog, scaleLinear } from 'd3-scale';
 import { range } from 'd3-array';
 import slugid from 'slugid';
 
 import {
   workerGetTiles,
-  workerFetchTiles,
   workerSetPix,
-  tileResponseToData,
 } from '../worker';
 
 /*

--- a/app/scripts/services/tile-proxy.js
+++ b/app/scripts/services/tile-proxy.js
@@ -37,7 +37,8 @@ setPixPool.run(function(params, done) {
 const fetchTilesPool = new Pool(10);
 fetchTilesPool.run(function(params, done) {
   try {
-    worker.workerGetTiles(params.outUrl, params.server, params.theseTileIds, params.authHeader, done);
+    worker.workerGetTiles(params.outUrl, params.server, params.theseTileIds,
+    params.authHeader, done);
     // done.transfer({
     // pixData: pixData
     // }, [pixData.buffer]);
@@ -59,7 +60,7 @@ const MAX_FETCH_TILES = 15;
 
 const sessionId = slugid.nice();
 export let requestsInFlight = 0; // eslint-disable-line import/no-mutable-exports
-export let authHeader = null;
+export let authHeader = null; // eslint-disable-line import/no-mutable-exports
 
 const debounce = (func, wait) => {
   let timeout;
@@ -121,8 +122,7 @@ export const setTileProxyAuthHeader = (newHeader) => {
 export const getTileProxyAuthHeader = () => authHeader;
 
 export function fetchMultiRequestTiles(req) {
-  const sessionId = req.sessionId;
-  const requests = req.requests;
+  const requests = req.requests; // eslint-disable-line prefer-destructuring
   const fetchPromises = [];
 
   const requestsByServer = {};
@@ -152,6 +152,8 @@ export function fetchMultiRequestTiles(req) {
       const renderParams = theseTileIds.map(x => `d=${x}`).join('&');
       const outUrl = `${server}/tiles/?${renderParams}&s=${sessionId}`;
 
+      /* eslint-disable no-loop-func */
+      /* eslint-disable no-unused-vars */
       const p = new Promise(((resolve, reject) => {
         pubSub.publish('requestSent', outUrl);
         const params = {};
@@ -161,7 +163,8 @@ export function fetchMultiRequestTiles(req) {
         params.theseTileIds = theseTileIds;
         params.authHeader = authHeader;
 
-        workerGetTiles(params.outUrl, params.server, params.theseTileIds, params.authHeader, resolve);
+        workerGetTiles(params.outUrl, params.server, params.theseTileIds,
+          params.authHeader, resolve);
 
         /*
         fetchTilesPool.send(params)

--- a/app/scripts/services/tile-proxy.js
+++ b/app/scripts/services/tile-proxy.js
@@ -318,8 +318,8 @@ export const calculateZoomLevel = (scale, minX, maxX, binsPerTile) => {
  * @param {Number} position: The position (in absolute coordinates) to caculate
  *                 the tile and position in tile for
  */
-export const calculateTileAndPosInTile = function (tilesetInfo, maxDim,
-  dataStartPos, zoomLevel, position) {
+export function calculateTileAndPosInTile(tilesetInfo, maxDim, dataStartPos,
+  zoomLevel, position) {
   let tileWidth = null;
   const PIXELS_PER_TILE = tilesetInfo.bins_per_dimension || 256;
 
@@ -333,7 +333,7 @@ export const calculateTileAndPosInTile = function (tilesetInfo, maxDim,
   const posInTile = Math.floor(PIXELS_PER_TILE * (position - (tilePos * tileWidth)) / tileWidth);
 
   return [tilePos, posInTile];
-};
+}
 
 /**
  * Calculate the tiles that should be visible get a data domain
@@ -438,7 +438,8 @@ export const calculateTilesFromResolution = (resolution, scale, minX, maxX, pixe
 export const trackInfo = (server, tilesetUid, doneCb, errorCb) => {
   const url = `${tts(server)}/tileset_info/?d=${tilesetUid}&s=${sessionId}`;
   pubSub.publish('requestSent', url);
-  json(url, (error, data) => {
+  // TODO: Is this used?
+  json(url, (error, data) => { // eslint-disable-line
     pubSub.publish('requestReceived', url);
     if (error) {
       // console.log('error:', error);

--- a/app/scripts/services/tile-proxy.js
+++ b/app/scripts/services/tile-proxy.js
@@ -9,8 +9,6 @@ import {
   tileResponseToData,
 } from '../worker';
 
-const MAX_FETCH_TILES = 15;
-
 /*
 const str = document.currentScript.src
 const pathName = str.substring(0, str.lastIndexOf("/"));
@@ -59,6 +57,8 @@ import { trimTrailingSlash as tts } from '../utils';
 
 // Config
 import { TILE_FETCH_DEBOUNCE } from '../configs';
+
+const MAX_FETCH_TILES = 15;
 
 const sessionId = slugid.nice();
 export let requestsInFlight = 0; // eslint-disable-line import/no-mutable-exports
@@ -121,9 +121,7 @@ export const setTileProxyAuthHeader = (newHeader) => {
   authHeader = newHeader;
 };
 
-export const getTileProxyAuthHeader = () => {
-  return authHeader;
-};
+export const getTileProxyAuthHeader = () => authHeader;
 
 export function fetchMultiRequestTiles(req) {
   const sessionId = req.sessionId;
@@ -159,7 +157,7 @@ export function fetchMultiRequestTiles(req) {
 
       const p = new Promise(((resolve, reject) => {
         pubSub.publish('requestSent', outUrl);
-        const params = {}
+        const params = {};
 
         params.outUrl = outUrl;
         params.server = server;
@@ -317,7 +315,7 @@ export const calculateZoomLevel = (scale, minX, maxX, binsPerTile) => {
  * @param {int} zoomLevel: The current zoomLevel
  * @param {Number} position: The position (in absolute coordinates) to caculate the tile and position in tile for
  */
-export const calculateTileAndPosInTile = function(tilesetInfo, maxDim, dataStartPos, zoomLevel, position) {
+export const calculateTileAndPosInTile = function (tilesetInfo, maxDim, dataStartPos, zoomLevel, position) {
   let tileWidth = null;
   const PIXELS_PER_TILE = tilesetInfo.bins_per_dimension || 256;
 
@@ -331,7 +329,7 @@ export const calculateTileAndPosInTile = function(tilesetInfo, maxDim, dataStart
   const posInTile = Math.floor(PIXELS_PER_TILE * (position - tilePos * tileWidth) / tileWidth);
 
   return [tilePos, posInTile];
-}
+};
 
 /**
  * Calculate the tiles that should be visible get a data domain
@@ -380,10 +378,10 @@ export const calculateTiles = (
 
 export const calculateTileWidth = (tilesetInfo, zoomLevel, binsPerTile) => {
   if (tilesetInfo.resolutions) {
-    const sortedResolutions = tilesetInfo.resolutions.map(x => +x).sort((a,b) => b-a)
+    const sortedResolutions = tilesetInfo.resolutions.map(x => +x).sort((a, b) => b - a);
     return sortedResolutions[zoomLevel] * binsPerTile;
   }
-  return tilesetInfo.max_width / (2 ** zoomLevel)
+  return tilesetInfo.max_width / (2 ** zoomLevel);
 };
 
 /**
@@ -410,7 +408,8 @@ export const calculateTilesFromResolution = (resolution, scale, minX, maxX, pixe
     Math.max(0, Math.floor((scale.domain()[0] - minX) / tileWidth)),
     Math.ceil(Math.min(
       maxX,
-      ((scale.domain()[1] - minX) - epsilon)) / tileWidth),
+      ((scale.domain()[1] - minX) - epsilon)
+    ) / tileWidth),
   );
 
   if (tileRange.length > MAX_TILES) {
@@ -432,25 +431,24 @@ export const calculateTilesFromResolution = (resolution, scale, minX, maxX, pixe
  * @param {func} errorCb: A callback that gets called when there is an error
  */
 export const trackInfo = (server, tilesetUid, doneCb, errorCb) => {
-  const url =
-    `${tts(server)}/tileset_info/?d=${tilesetUid}&s=${sessionId}`;
-    pubSub.publish('requestSent', url);
-    json(url, (error, data) => {
-      pubSub.publish('requestReceived', url);
-      if (error) {
-        // console.log('error:', error);
-        // don't do anything
-        // no tileset info just means we can't do anything with this file...
-        if (errorCb) {
-          errorCb(`Error retrieving tilesetInfo from: ${server}`);
-        }  else {
-          console.warn("Error retrieving: ", url);
-        }
+  const url = `${tts(server)}/tileset_info/?d=${tilesetUid}&s=${sessionId}`;
+  pubSub.publish('requestSent', url);
+  json(url, (error, data) => {
+    pubSub.publish('requestReceived', url);
+    if (error) {
+      // console.log('error:', error);
+      // don't do anything
+      // no tileset info just means we can't do anything with this file...
+      if (errorCb) {
+        errorCb(`Error retrieving tilesetInfo from: ${server}`);
       } else {
-        // console.log('got data', data);
-        doneCb(data);
+        console.warn('Error retrieving: ', url);
       }
-    });
+    } else {
+      // console.log('got data', data);
+      doneCb(data);
+    }
+  });
 };
 
 /**

--- a/app/scripts/services/tile-proxy.js
+++ b/app/scripts/services/tile-proxy.js
@@ -330,7 +330,7 @@ export const calculateTileAndPosInTile = function (tilesetInfo, maxDim,
   }
 
   const tilePos = Math.floor((position - dataStartPos) / tileWidth);
-  const posInTile = Math.floor(PIXELS_PER_TILE * (position - tilePos * tileWidth) / tileWidth);
+  const posInTile = Math.floor(PIXELS_PER_TILE * (position - (tilePos * tileWidth)) / tileWidth);
 
   return [tilePos, posInTile];
 };
@@ -368,7 +368,8 @@ export const calculateTiles = (
 
   /*
   console.log('minX:', minX, 'zoomLevel:', zoomLevel);
-  console.log('domain:', scale.domain(), scale.domain()[0] - minX, ((scale.domain()[0] - minX) / tileWidth))
+  console.log('domain:', scale.domain(), scale.domain()[0] - minX,
+  ((scale.domain()[0] - minX) / tileWidth))
   */
 
   return range(
@@ -405,7 +406,7 @@ export const calculateTilesFromResolution = (resolution, scale, minX, maxX, pixe
   // console.log('PIXELS_PER_TILE:', PIXELS_PER_TILE);
 
   if (!maxX) {
-    maxX = Number.MAX_VALUE;
+    maxX = Number.MAX_VALUE; // eslint-disable-line no-param-reassign
   }
 
   let tileRange = range(

--- a/app/scripts/services/tile-proxy.js
+++ b/app/scripts/services/tile-proxy.js
@@ -2,6 +2,7 @@ import { range } from 'd3-array';
 import slugid from 'slugid';
 
 import {
+  workerFetchTiles, // eslint-disable-line import/named
   workerGetTiles,
   workerSetPix,
 } from '../worker';
@@ -310,12 +311,15 @@ export const calculateZoomLevel = (scale, minX, maxX, binsPerTile) => {
  * the given element.
  *
  * @param {object} tilesetInfo: The information about this tileset
- * @param {Number} maxDim: The maximum width of the dataset (only used for tilesets without resolutions)
+ * @param {Number} maxDim: The maximum width of the dataset (only used for
+ *        tilesets without resolutions)
  * @param {Number} dataStartPos: The position where the data begins
  * @param {int} zoomLevel: The current zoomLevel
- * @param {Number} position: The position (in absolute coordinates) to caculate the tile and position in tile for
+ * @param {Number} position: The position (in absolute coordinates) to caculate
+ *                 the tile and position in tile for
  */
-export const calculateTileAndPosInTile = function (tilesetInfo, maxDim, dataStartPos, zoomLevel, position) {
+export const calculateTileAndPosInTile = function (tilesetInfo, maxDim,
+  dataStartPos, zoomLevel, position) {
   let tileWidth = null;
   const PIXELS_PER_TILE = tilesetInfo.bins_per_dimension || 256;
 

--- a/test.sh
+++ b/test.sh
@@ -8,7 +8,7 @@ die() { set +v; echo "$*" 1>&2 ; sleep 1; exit 1; }
 # https://github.com/travis-ci/travis-ci/issues/6018
 
 start eslint
-./node_modules/eslint/bin/eslint.js karma.conf.js
+./node_modules/eslint/bin/eslint.js karma.conf.js app/scripts/services
 end eslint
 
 start compile


### PR DESCRIPTION
Add app/scripts/services to lint coverage. This is obviously not a priority, but... 
- It's a prompt for me to skim a lot of code.
- It helps me internalize coding practices on this project.
- and it adds a few files to the set of those that will be linted on each push.

If the fix is straight-forward, I've gone ahead a made it... but if it seemed weird, I've added an ignore, rather that superficially cleaning up the syntax, and potentially hiding a deeper problem.

Thoughts?