### PR TITLE
Shrinkify rects and triangles by 2px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Change component height when a new viewconf is passed in
 - Add a fudge factor to ensure that the entire view is shown in the grid layout
 - Fix minified build
+- Fix a minor visual glitch in the gene annotation track
 
 ## v1.2.8
 

--- a/app/scripts/HorizontalGeneAnnotationsTrack.js
+++ b/app/scripts/HorizontalGeneAnnotationsTrack.js
@@ -51,6 +51,11 @@ class HorizontalGeneAnnotationsTrack extends HorizontalTiled1DPixiTrack {
     this.fontSize = +this.options.fontSize || FONT_SIZE;
     this.geneLabelPos = this.options.geneLabelPosition || GENE_LABEL_POS;
     this.geneRectHeight = +this.options.geneAnnotationHeight || GENE_RECT_HEIGHT;
+
+    // Don't ask me why but rectangles and triangles seem to be drawn 2px larger
+    // than they should be
+    this.geneRectHeight -= 2;
+
     this.geneTriangleHeight = 0.6 * this.geneRectHeight || TRIANGLE_HEIGHT;
     this.geneStrandSpacing = +this.options.geneStrandSpacing || GENE_STRAND_SPACING;
     this.geneStrandHSpacing = this.geneStrandSpacing / 2;
@@ -361,7 +366,7 @@ class HorizontalGeneAnnotationsTrack extends HorizontalTiled1DPixiTrack {
       ? this.halfRectHHeight - this.geneStrandHSpacing - this.geneRectHHeight - lineHHeight
       : this.halfRectHHeight + this.geneStrandHSpacing + this.geneRectHHeight - lineHHeight;
 
-    const yExonPos = yPos - (exonHeight / 2) + (lineHeight / 2);
+    const yExonPos = yPos - this.geneRectHHeight + lineHHeight;
 
     const polys = [];
     let poly = [


### PR DESCRIPTION
Somehow PIXI draws triangles 2px larger than expected which can cause an ugly effect when overlaying gene labels over the text.

In the examples below look at IFNA1:

**Before**

![screen shot 2018-11-07 at 3 12 53 pm](https://user-images.githubusercontent.com/932103/48158138-b5a58080-e29f-11e8-8975-4267b2ee74e6.png)

**After**

![screen shot 2018-11-07 at 3 12 27 pm](https://user-images.githubusercontent.com/932103/48158141-b76f4400-e29f-11e8-907a-3e95fa6c82b9.png)