### PR TITLE
Replaced uglify with terser

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "react-test-renderer": "^16.5.0",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.18.2",
-    "uglifyjs-webpack-plugin": "^2.0.1",
+    "terser-webpack-plugin": "^1.1.0",
     "webpack": "^4.25.1",
     "webpack-bundle-analyzer": "^3.0.3",
     "webpack-cli": "^3.1.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,8 @@ const webpack = require('webpack');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const UnminifiedWebpackPlugin = require('unminified-webpack-plugin');
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
+
 
 // const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
@@ -47,7 +48,7 @@ module.exports = (env, argv) => ({
   optimization: {
     minimize: argv.mode === 'production',
     minimizer: [
-      new UglifyJsPlugin({
+      new TerserPlugin({
         include: /\.min\.js$/,
       }),
       new OptimizeCSSAssetsPlugin()


### PR DESCRIPTION
There was a problem with the UglifyJs plugin not supporting ES6, not creating the minified script and breaking the build (https://travis-ci.org/higlass/higlass/builds/452686746).

This fixes that issue by replacing UglifyJS with the Terser plugin.

