### PR TITLE
Base-10 log on heatmap mouseover

### DIFF
--- a/app/scripts/HeatmapTiledPixiTrack.js
+++ b/app/scripts/HeatmapTiledPixiTrack.js
@@ -1266,7 +1266,7 @@ class HeatmapTiledPixiTrack extends TiledPixiTrack {
 
     if (this.options && this.options.heatmapValueScaling === 'log') {
       if (data > 0) {
-        return `${positionText}<b>Value:</b> 1e${format('.3f')(Math.log(data))}`;
+        return `${positionText}<b>Value:</b> 1e${format('.3f')(Math.log(data) / Math.log(10))}`;
       }
 
       if (data === 0) {


### PR DESCRIPTION
## Description

The heatmap mouseover value was change to match the color scale and use base 10 values.

Fixes #395

Small change, no checklist...
