### PR TITLE
Create a separate datastructure which both renderers use

### DIFF
--- a/app/scripts/HorizontalLine1DPixiTrack.js
+++ b/app/scripts/HorizontalLine1DPixiTrack.js
@@ -162,32 +162,39 @@ class HorizontalLine1DPixiTrack extends HorizontalTiled1DPixiTrack {
     const strokeWidth = this.options.lineStrokeWidth ? this.options.lineStrokeWidth : 1;
     graphics.lineStyle(strokeWidth, stroke, 1);
 
-    const logScaling = this.options.valueScaling === 'log';
+    tile.segments = [];
+    let currentSegment = [];
 
     for (let i = 0; i < tileValues.length; i++) {
       const xPos = this._xScale(tileXScale(i));
       const yPos = this.valueScale(tileValues[i] + offsetValue);
 
-      tile.xValues[i] = xPos;
-      tile.yValues[i] = yPos;
-
-      if (i === 0) {
-        graphics.moveTo(xPos, yPos);
+      if (this.options.valueScaling === 'log' && tileValues[i] === 0) {
+        if (currentSegment.length > 1) {
+          tile.segments.push(currentSegment);
+        }
+        // Just ignore 1-element segments.
+        currentSegment = [];
         continue;
       }
 
       if (tileXScale(i) > this.tilesetInfo.max_pos[0]) {
-        // this data is in the last tile and extends beyond the length
-        // of the coordinate system
+        // Data is in the last tile and extends beyond the coordinate system.
         break;
       }
 
-      // if we're using log scaling and there's a 0 value, we shouldn't draw it
-      // because it's invalid
-      if (logScaling && tileValues[i] === 0) {
-        graphics.moveTo(xPos, yPos);
-      } else {
-        graphics.lineTo(xPos, yPos);
+      currentSegment.push([xPos, yPos]);
+    }
+    if (currentSegment.length > 1) {
+      tile.segments.push(currentSegment);
+    }
+
+    for (const segment of tile.segments) {
+      const first = segment[0];
+      const rest = segment.slice(1);
+      graphics.moveTo(first[0], first[1]);
+      for (const point of rest) {
+        graphics.lineTo(point[0], point[1]);
       }
     }
   }
@@ -250,10 +257,17 @@ class HorizontalLine1DPixiTrack extends HorizontalTiled1DPixiTrack {
       const g = document.createElement('path');
       g.setAttribute('fill', 'transparent');
       g.setAttribute('stroke', stroke);
-      let d = `M${tile.xValues[0]} ${tile.yValues[0]}`;
-      for (let i = 0; i < tile.xValues.length; i++) {
-        d += `L${tile.xValues[i]} ${tile.yValues[i]}`;
+      let d = '';
+
+      for (const segment of tile.segments) {
+        const first = segment[0];
+        const rest = segment.slice(1);
+        d += `M${first[0]} ${first[1]}`;
+        for (const point of rest) {
+          d += `L${point[0]} ${point[1]}`;
+        }
       }
+
       g.setAttribute('d', d);
       output.appendChild(g);
     });


### PR DESCRIPTION
## Description

What was changed in this pull request?
- We first create a list of segments, and then both renders use the same data structure for drawing.

Why is it necessary?
- Previously, when the log was taken of 0, the chart would appear to be clipped, with different behavior on the rising and falling slopes. It is now consistent and correct between renderers

Fixes #345

## Checklist

- [ ] Unit tests added or updated ... but the easiest way to test this would be a unit test just around the segment data structure... but to do that, I'd want to pull out these changes and put them in a helper function. Would that be good? 
- [ ] Documentation added or updated
- [ ] Example added or updated
- [X] Screenshot for visual changes (e.g. new tracks)


![screen shot 2018-11-15 at 5 06 05 pm](https://user-images.githubusercontent.com/730388/48585023-5f68bb00-e8f9-11e8-8f7e-dc859d7c6d9d.png)
