### PR TITLE
SVG Axis was missing bits from Pixi

### DIFF
--- a/app/scripts/AxisPixi.js
+++ b/app/scripts/AxisPixi.js
@@ -221,12 +221,13 @@ class AxisPixi {
 
     let stroke = 'black';
 
-    if (this.track) {
-      stroke = this.track.options.lineStrokeColor
-        ? this.track.options.lineStrokeColor
-        : 'blue';
+    if (this.track && this.track.options.lineStrokeColor) {
+      stroke = this.track.options.lineStrokeColor;
     }
-
+    // TODO: On the canvas, there is no vertical line beside the scale,
+    // but it also has the draggable control to the right.
+    // Confirm that this difference between SVG and Canvas is intentional,
+    // and if not, remove this.
     if (getDarkTheme()) stroke = '#cccccc';
 
     const line = document.createElement('path');
@@ -248,10 +249,8 @@ class AxisPixi {
     // factor out the styling for axis lines
     let stroke = 'black';
 
-    if (this.track) {
-      stroke = this.track.options.lineStrokeColor
-        ? this.track.options.lineStrokeColor
-        : 'blue';
+    if (this.track && this.track.options.lineStrokeColor) {
+      stroke = this.track.options.lineStrokeColor;
     }
 
     if (getDarkTheme()) stroke = '#cccccc';
@@ -280,12 +279,6 @@ class AxisPixi {
 
   exportAxisLeftSVG(valueScale, axisHeight) {
     const gAxis = this.exportVerticalAxis(axisHeight);
-
-    const line = this.createAxisSVGLine();
-    gAxis.appendChild(line);
-
-    line.setAttribute('d',
-      `M0,0 L${-(TICK_MARGIN + TICK_LENGTH)},0`);
 
     for (let i = 0; i < this.axisTexts.length; i++) {
       const tick = this.tickValues[i];

--- a/app/scripts/HeatmapTiledPixiTrack.js
+++ b/app/scripts/HeatmapTiledPixiTrack.js
@@ -746,7 +746,7 @@ class HeatmapTiledPixiTrack extends TiledPixiTrack {
     );
 
     const colorbarAreaHeight = Math.min(
-      this.dimensions[1], COLORBAR_MAX_HEIGHT,
+      this.dimensions[1] / 2, COLORBAR_MAX_HEIGHT,
     );
     this.colorbarHeight = colorbarAreaHeight - (2 * COLORBAR_MARGIN);
     const colorbarAreaWidth = COLORBAR_WIDTH + COLORBAR_LABELS_WIDTH + (2 * COLORBAR_MARGIN);
@@ -791,16 +791,18 @@ class HeatmapTiledPixiTrack extends TiledPixiTrack {
 
     let gAxis = null;
 
+    const axisValueScale = this.valueScale.copy()
+      .range([this.colorbarHeight, 0]);
     if (
       this.options.colorbarPosition === 'topLeft'
       || this.options.colorbarPosition === 'bottomLeft'
     ) {
-      gAxis = this.axis.exportAxisRightSVG(this.valueScale, this.colorbarHeight);
+      gAxis = this.axis.exportAxisRightSVG(axisValueScale, this.colorbarHeight);
     } else if (
       this.options.colorbarPosition === 'topRight'
       || this.options.colorbarPosition === 'bottomRight'
     ) {
-      gAxis = this.axis.exportAxisLeftSVG(this.valueScale, this.colorbarHeight);
+      gAxis = this.axis.exportAxisLeftSVG(axisValueScale, this.colorbarHeight);
     }
 
     gAxisHolder.appendChild(gAxis);


### PR DESCRIPTION
## Description

What was changed in this pull request?
- Heatmap scales in SVG export have the correct scale, and color defaults to black.

Fixes #344 

Related to PR #363, but that only handled problems relating to the colors drawn, not to the axis numbers and ticks.

## Checklist

- [ ] Unit tests added or updated: none, but the real problem here is the copy-and-pasting of code, and I think cleaning up that would be the better investment of time. Thoughts?
- [ ] Documentation added or updated
- [ ] Example added or updated
- [X] Screenshot for visual changes (e.g. new tracks)

left: before / right: after
top: pixi / bottom: svg

![screen shot 2018-11-15 at 9 08 06 pm](https://user-images.githubusercontent.com/730388/48593643-b1bad380-e91b-11e8-8b5a-7be916d0ef73.png)