### PR TITLE
Mccalluc/fix console error on default

### DIFF
--- a/app/scripts/BarTrack.js
+++ b/app/scripts/BarTrack.js
@@ -167,6 +167,7 @@ class BarTrack extends HorizontalLine1DPixiTrack {
 
       if (isTopAligned) yPos = 0;
 
+      if (Number.isNaN(height) || height < 0 || yPos < 0) continue;
       this.addSVGInfo(tile, xPos, yPos, width, height, color);
 
       // this data is in the last tile and extends beyond the length

--- a/app/scripts/HorizontalLine1DPixiTrack.js
+++ b/app/scripts/HorizontalLine1DPixiTrack.js
@@ -169,7 +169,7 @@ class HorizontalLine1DPixiTrack extends HorizontalTiled1DPixiTrack {
       const xPos = this._xScale(tileXScale(i));
       const yPos = this.valueScale(tileValues[i] + offsetValue);
 
-      if (this.options.valueScaling === 'log' && tileValues[i] === 0) {
+      if ((this.options.valueScaling === 'log' && tileValues[i] === 0) || Number.isNaN(yPos)) {
         if (currentSegment.length > 1) {
           tile.segments.push(currentSegment);
         }

--- a/docs/examples/svg/index.html
+++ b/docs/examples/svg/index.html
@@ -77,7 +77,7 @@ fetch(
     });
     
     hgApi.on('viewConfig', (event) => {
-      console.log('viewConfig event', event);
+      console.log('viewConfig event', JSON.parse(event));
       renderPreview();
     });
   });


### PR DESCRIPTION
## Description

This gets rid of the console errors we had when trying to render the default svg.
(It's possible that the invalid values should not have gotten even this far, but this much feels like an improvement.)

I do not see any visual changes.

Also, in the SVG example, log the viewconf as an object, to keep the logs tidier.

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example added or updated
- [ ] Screenshot for visual changes (e.g. new tracks)
