### PR TITLE
Fix duplicated wheel forwarding

### DIFF
--- a/app/scripts/TrackRenderer.js
+++ b/app/scripts/TrackRenderer.js
@@ -384,12 +384,8 @@ class TrackRenderer extends React.Component {
    * @param  {Object}  e  Event to be dispatched.
    */
   dispatchEvent(e) {
-    // console.log('de e:', e);
-    if (e.sourceUid === this.uid) {
-      if (e.type !== 'contextmenu') {
-        // console.log('forwarding', this.element);
-        forwardEvent(e, this.element);
-      }
+    if (e.sourceUid === this.uid && e.type !== 'contextmenu') {
+      forwardEvent(e, this.element);
     }
   }
 
@@ -1831,20 +1827,9 @@ class TrackRenderer extends React.Component {
 
     this.eventTracker = this.eventTrackerOld;
 
-    /*
-    this.element.addEventListener('mousewheel', (evt) => {
-      console.log('element mw', evt)
-    })
-    
-    this.element.addEventListener('wheel', (evt) => {
-      console.log('wheel', evt);
-    })
-    */
-
     this.eventTracker.addEventListener('click', this.boundForwardEvent);
     this.eventTracker.addEventListener('contextmenu', this.boundForwardContextMenu);
     this.eventTracker.addEventListener('dblclick', this.boundForwardEvent);
-    this.eventTracker.addEventListener('mousewheel', this.boundForwardEvent);
     this.eventTracker.addEventListener('wheel', this.boundForwardEvent);
     this.eventTracker.addEventListener('dragstart', this.boundForwardEvent);
     this.eventTracker.addEventListener('selectstart', this.boundForwardEvent);
@@ -1880,7 +1865,7 @@ class TrackRenderer extends React.Component {
     this.eventTracker.removeEventListener('click', this.boundForwardEvent);
     this.eventTracker.removeEventListener('contextmenu', this.boundForwardContextMenu);
     this.eventTracker.removeEventListener('dblclick', this.boundForwardEvent);
-    this.eventTracker.removeEventListener('mousewheel', this.boundForwardEvent);
+    this.eventTracker.removeEventListener('wheel', this.boundForwardEvent);
     this.eventTracker.removeEventListener('dragstart', this.boundForwardEvent);
     this.eventTracker.removeEventListener('selectstart', this.boundForwardEvent);
 
@@ -1909,14 +1894,13 @@ class TrackRenderer extends React.Component {
     window.removeEventListener('scroll', this.boundScrollEvent);
   }
 
-  scrollEvent(e) {
+  scrollEvent() {
     this.elementPos = this.element.getBoundingClientRect();
   }
 
   forwardEvent(e) {
-    // console.log('fe e:', e);
-    
     e.sourceUid = this.uid;
+    e.forwarded = true;
     pubSub.publish('app.event', e);
   }
 

--- a/app/scripts/utils/clone-event.js
+++ b/app/scripts/utils/clone-event.js
@@ -4,13 +4,12 @@
  * @param   {object}  event  Source event to be cloned.
  * @return  {object}  Cloned event
  */
-const cloneEvent = event => {
-    // console.log('event:', event);
-    const newEvent = new event.constructor(event.type, event);
-    newEvent.sourceUid = event.sourceUid;
-    newEvent.forwarded = event.forwarded;
+const cloneEvent = (event) => {
+  const newEvent = new event.constructor(event.type, event);
+  newEvent.sourceUid = event.sourceUid;
+  newEvent.forwarded = event.forwarded;
 
-    return newEvent;
+  return newEvent;
 };
 
 export default cloneEvent;

--- a/app/scripts/utils/forward-event.js
+++ b/app/scripts/utils/forward-event.js
@@ -6,11 +6,7 @@ import cloneEvent from './clone-event';
  * @param   {object}  target  Target HTML element for the event.
  */
 const forwardEvent = (event, target) => {
-const newEvent = cloneEvent(event);
-    if (event.type === 'mousewheel') {
-        console.log('fede newEvent', target)
-    }
-  target.dispatchEvent(newEvent);
+  target.dispatchEvent(cloneEvent(event));
 };
 
 export default forwardEvent;


### PR DESCRIPTION
The key aspect is in `TrackRenderer` line 1903. Setting `e.forwarded = true;` in the `TrackRenderer`ensures that the `wheelHandler` in `HiGlassComponent` doesn't fire again when the wheel event from `track-renderer-event` bubbled all the way up to the `window` which the `domEvent` service is listening to.

## Description

Remove duplicated wheel events

Why is it necessary?

Fixes #417 

## Checklist

- [x] Unit tests added or updated