### PR TITLE
Expose version

### DIFF
--- a/app/scripts/api.js
+++ b/app/scripts/api.js
@@ -39,6 +39,9 @@ const createApi = function api(context, pubSub) {
        * @return {string} Version number
        */
       get version() {
+        // Note, `VERSION` is exposed by webpack across the entire app. I.e.,
+        // it's globally available within the build but not outside. See
+        // `plugins` in `webpack.config.js`
         return VERSION;
       },
 

--- a/app/scripts/api.js
+++ b/app/scripts/api.js
@@ -35,6 +35,14 @@ const createApi = function api(context, pubSub) {
     // Public API
     public: {
       /**
+       * HiGlass version
+       * @return {string} Version number
+       */
+      get version() {
+        return VERSION;
+      },
+
+      /**
        * Set an auth header to be included with all tile requests.
        *
        * @param {string} newHeader The contensts of the header to be included.

--- a/test/APITests.js
+++ b/test/APITests.js
@@ -6,6 +6,7 @@ import {
 } from '../app/scripts/utils';
 
 import {
+  emptyConf,
   simpleCenterViewConfig,
   simple1And2dAnnotations,
 } from './view-configs';
@@ -120,6 +121,14 @@ describe('Simple HiGlassComponent', () => {
           done();
         });
       });
+    });
+
+    it('has version', (done) => {
+      [div, api] = createElementAndApi(emptyConf, { editable: false });
+
+      expect(api.version).toEqual(VERSION);
+
+      done();
     });
 
     it('APIs are independent', (done) => {

--- a/test/view-configs.js
+++ b/test/view-configs.js
@@ -1,3 +1,37 @@
+export const emptyConf = {
+  editable: true,
+  zoomFixed: false,
+  trackSourceServers: [],
+  exportViewUrl: '',
+  views: [
+    {
+      uid: 'aa',
+      initialXDomain: [0, 100],
+      autocompleteSource: '',
+      genomePositionSearchBox: {},
+      chromInfoPath: '',
+      tracks: {
+        top: [],
+        left: [],
+        center: [],
+        right: [],
+        bottom: [],
+        whole: [],
+        gallery: []
+      },
+      layout: {
+        w: 12,
+        h: 12,
+        x: 0,
+        y: 0,
+        moved: false,
+        static: false
+      },
+      genomePositionSearchBoxVisible: true
+    }
+  ],
+};
+
 export const osmConf = {
   editable: true,
   zoomFixed: false,


### PR DESCRIPTION
Can be useful for debugging

## Description

> What was changed in this pull request?

Adds `version` to HgApi.

> Why is it necessary?

To be able to determine the version of Hglib dynamically with JS. Useful for the version dialog in HGA.

## Checklist

- [x] Unit tests added or updated
- [x] Documentation added or updated
- ~~[ ] Example added or updated~~
- ~~[ ] Screenshot for visual changes (e.g. new tracks)~~
