### PR TITLE
"cross-rule" is a another special case which is not waiting for anything

### DIFF
--- a/app/scripts/utils/test-helpers.js
+++ b/app/scripts/utils/test-helpers.js
@@ -137,6 +137,7 @@ export const isWaitingOnTiles = (hgc) => {
       || track.track.type === 'horizontal-1d-annotations'
       || track.track.type === 'vertical-1d-annotations'
       || track.track.type === '2d-chromosome-annotations'
+      || track.track.type === 'cross-rule'
     ) continue;
 
     if (trackObj.originalTrack) { trackObj = trackObj.originalTrack; }

--- a/app/scripts/utils/test-helpers.js
+++ b/app/scripts/utils/test-helpers.js
@@ -128,29 +128,23 @@ export const isWaitingOnTiles = (hgc) => {
   for (const track of hgc.iterateOverTracks()) {
     let trackObj = getTrackObjectFromHGC(hgc, track.viewId, track.trackId);
 
-    if (
-      track.track.type === 'viewport-projection-vertical'
-      || track.track.type === 'viewport-projection-horizontal'
-      || track.track.type === 'viewport-projection-center'
-      || track.track.type === 'osm-tiles'
-      || track.track.type === 'osm-2d-tile-ids'
-      || track.track.type === 'horizontal-1d-annotations'
-      || track.track.type === 'vertical-1d-annotations'
-      || track.track.type === '2d-chromosome-annotations'
-      || track.track.type === 'cross-rule'
-    ) continue;
+    if (!track.track.server && !track.track.tilesetUid) {
+      continue;
+    } else if (track.track.server && track.track.tilesetUid) {
+      if (trackObj.originalTrack) { trackObj = trackObj.originalTrack; }
 
-    if (trackObj.originalTrack) { trackObj = trackObj.originalTrack; }
+      if (!(trackObj.tilesetInfo || trackObj.chromInfo)) {
+        console.warn(
+          `Track uuid:${trackObj.uuid} has no tileset or chromosome info`
+        );
+        return true;
+      }
 
-    if (!(trackObj.tilesetInfo || trackObj.chromInfo)) {
-      console.warn(
-        `Track uuid:${trackObj.uuid} has no tileset or chromosome info`
-      );
-      return true;
-    }
-
-    if (trackObj.fetching && trackObj.fetching.size) {
-      return true;
+      if (trackObj.fetching && trackObj.fetching.size) {
+        return true;
+      }
+    } else {
+      throw Error('"server" and "tilesetUid" belong together');
     }
   }
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,6 +15,7 @@ module.exports = (config) => {
       'node_modules/bootstrap/dist/css/bootstrap.min.css',
       'build/hglib.css',
       'test/**/*.+(js|jsx)',
+      // 'test/MinimalViewconfTest.js'
       // 'test/AxisTests.js',
       // 'test/PngExportTest.js',
       // 'test/OSMTests.js',

--- a/test/MinimalViewconfTest.js
+++ b/test/MinimalViewconfTest.js
@@ -1,0 +1,88 @@
+/* eslint-env node, jasmine, mocha */
+import {
+  configure,
+  // render,
+} from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import { expect } from 'chai';
+// Utils
+import {
+  mountHGComponent,
+  removeHGComponent,
+} from '../app/scripts/utils';
+
+configure({ adapter: new Adapter() });
+describe('Minimal viewconfs', () => {
+  describe('Crazy minimal', () => {
+    const viewconf = {};
+    let hgc = null;
+    let div = null;
+    beforeAll((done) => {
+      [div, hgc] = mountHGComponent(div, hgc, viewconf, done);
+    });
+    it('can load and unload', () => {
+      expect(true).to.equal(true);
+    });
+    afterAll(() => {
+      removeHGComponent(div);
+    });
+  });
+  describe('Reasonably minimal', () => {
+    const viewconf = {
+      views: [
+        {
+          tracks: {
+            top: [],
+            left: [],
+            center: [],
+            right: [],
+            bottom: [],
+            whole: [],
+            gallery: []
+          }
+        }
+      ]
+    };
+    let hgc = null;
+    let div = null;
+    beforeAll((done) => {
+      [div, hgc] = mountHGComponent(div, hgc, viewconf, done);
+    });
+    it('can load and unload', () => {
+      expect(true).to.equal(true);
+    });
+    afterAll(() => {
+      removeHGComponent(div);
+    });
+  });
+  describe('Minimal with CrossRule', () => {
+    const viewconf = {
+      views: [
+        {
+          initialXDomain: [0, 200],
+          initialYDomain: [0, 200],
+          tracks: {
+            whole: [
+              {
+                type: 'cross-rule',
+                x: 100,
+                y: 100
+              }
+            ]
+          }
+        }
+      ]
+    };
+    let hgc = null;
+    let div = null;
+    beforeAll((done) => {
+      [div, hgc] = mountHGComponent(div, hgc, viewconf, done);
+    });
+    it('can load and unload', () => {
+      expect(true).to.equal(true);
+    });
+    afterAll(() => {
+      removeHGComponent(div);
+    });
+  });
+});

--- a/test/view-configs.js
+++ b/test/view-configs.js
@@ -1138,8 +1138,6 @@ export const divisionViewConfig = {
                 name: 'Chromosome Grid (hg19)',
                 chromInfoPath: '//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv',
                 thumbnail: null,
-                server: '',
-                tilesetUid: 'TIlwFtqxTX-ndtM7Y9k1bw',
                 uid: 'LUVqXXu2QYiO8XURIwyUyA',
                 options: {
                   lineStrokeWidth: 1,
@@ -1208,8 +1206,6 @@ export const simpleCenterViewConfig = {
             name: 'Top Axis',
             thumbnail: {},
             defaultOptions: {},
-            server: '',
-            tilesetUid: 'UKZhWC_FSCG1xHlN0c2bqQ',
             uid: 'd8focpO5TKKd2TB8QONd9w',
             options: {},
             width: 20,
@@ -1225,8 +1221,6 @@ export const simpleCenterViewConfig = {
             name: 'Left Axis',
             thumbnail: {},
             minWidth: 100,
-            server: '',
-            tilesetUid: 'Np6Sa4zwQa6bERCm5xBnGA',
             uid: 'RhdSji35SgOOJyqcy81zcg',
             options: {},
             width: 100,
@@ -1435,8 +1429,6 @@ export const rectangleDomains = {
                 name: 'Chromosome Grid (hg19)',
                 chromInfoPath: '//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv',
                 thumbnail: null,
-                server: '',
-                tilesetUid: 'TIlwFtqxTX-ndtM7Y9k1bw',
                 uid: 'LUVqXXu2QYiO8XURIwyUyA',
                 options: {
                   lineStrokeWidth: 1,
@@ -8576,8 +8568,6 @@ export const valueIntervalTrackViewConf = {
             name: 'Chromosome Axis (mm9)',
             chromInfoPath: '//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv',
             thumbnail: null,
-            server: '',
-            tilesetUid: 'bdM4fbUGQVuAv09iWcOefQ',
             uid: 'K8ctyFcBQGCXnHBSeCQpaQ',
             options: {},
             width: 20,
@@ -8615,8 +8605,6 @@ export const valueIntervalTrackViewConf = {
             // server: 'http://higlass.io/api/v1',
             // tilesetUid: 'N12wVGG9SPiTkk03yUayUw',
             thumbnail: null,
-            server: '',
-            tilesetUid: 'HZ8jVQNAQFCd4DCcWPrR8A',
             uid: 'Boe4m22pQwS2D7QqVpaV6w',
             options: {},
             width: 30,
@@ -8871,7 +8859,7 @@ export const paperFigure1 = {
     tracks: {
       bottom: [],
       top: [{
-        orientation: '1d-horizontal', name: 'Chromosome Axis (mm9)', tilesetUid: 'cGSJELSNRyOaExsJL0KejQ', local: true, minHeight: 30, thumbnail: null, server: '', width: 462, chromInfoPath: '//s3.amazonaws.com/pkerp/data/mm9/chromSizes.tsv', position: 'top', height: 30, type: 'horizontal-chromosome-labels', options: {}, uid: 'EsCrHgpLQoSO8fJo8PX-9w'
+        orientation: '1d-horizontal', name: 'Chromosome Axis (mm9)', local: true, minHeight: 30, thumbnail: null, width: 462, chromInfoPath: '//s3.amazonaws.com/pkerp/data/mm9/chromSizes.tsv', position: 'top', height: 30, type: 'horizontal-chromosome-labels', options: {}, uid: 'EsCrHgpLQoSO8fJo8PX-9w'
       }, {
         name: 'Gene Annotations (mm9)',
         maxWidth: 4294967296,
@@ -8967,7 +8955,7 @@ export const paperFigure1 = {
         options: {}
       }],
       left: [{
-        orientation: '1d-vertical', name: 'Chromosome Axis (mm9)', tilesetUid: 'BmjsajIaREq4P3lXQGsmXw', local: true, minHeight: 30, thumbnail: null, server: '', minWidth: 30, width: 30, chromInfoPath: '//s3.amazonaws.com/pkerp/data/mm9/chromSizes.tsv', position: 'left', height: 30, type: 'vertical-chromosome-labels', options: {}, uid: 'NlkjnKsoSGmfsrWKRfgBYA'
+        orientation: '1d-vertical', name: 'Chromosome Axis (mm9)', local: true, minHeight: 30, thumbnail: null, minWidth: 30, width: 30, chromInfoPath: '//s3.amazonaws.com/pkerp/data/mm9/chromSizes.tsv', position: 'left', height: 30, type: 'vertical-chromosome-labels', options: {}, uid: 'NlkjnKsoSGmfsrWKRfgBYA'
       }]
     },
     chromInfoPath: '//s3.amazonaws.com/pkerp/data/mm9/chromSizes.tsv',
@@ -8983,7 +8971,7 @@ export const paperFigure1 = {
     tracks: {
       bottom: [],
       top: [{
-        orientation: '1d-horizontal', name: 'Chromosome Axis (mm19)', tilesetUid: 'W1N2NIDPRZSckKMlHAKzwA', local: true, minHeight: 30, thumbnail: null, server: '', width: 472, chromInfoPath: '//s3.amazonaws.com/pkerp/data/mm9/chromSizes.tsv', position: 'top', height: 30, type: 'horizontal-chromosome-labels', options: {}, uid: 'AWcBqpmASpmA01tpfgwWOg'
+        orientation: '1d-horizontal', name: 'Chromosome Axis (mm19)', local: true, minHeight: 30, thumbnail: null, width: 472, chromInfoPath: '//s3.amazonaws.com/pkerp/data/mm9/chromSizes.tsv', position: 'top', height: 30, type: 'horizontal-chromosome-labels', options: {}, uid: 'AWcBqpmASpmA01tpfgwWOg'
       }, {
         name: 'Gene Annotations (mm9)',
         maxWidth: 4294967296,
@@ -9051,7 +9039,7 @@ export const paperFigure1 = {
         options: {}
       }],
       left: [{
-        orientation: '1d-vertical', name: 'Chromosome Axis (mm9)', tilesetUid: 'WeUIOO4oQO6FO6g2PWPhnw', local: true, minHeight: 30, thumbnail: null, server: '', minWidth: 30, width: 30, chromInfoPath: '//s3.amazonaws.com/pkerp/data/mm9/chromSizes.tsv', position: 'left', height: 30, type: 'vertical-chromosome-labels', options: {}, uid: 'UqH0mt73TqSebs_nFzqHvw'
+        orientation: '1d-vertical', name: 'Chromosome Axis (mm9)', local: true, minHeight: 30, thumbnail: null, minWidth: 30, width: 30, chromInfoPath: '//s3.amazonaws.com/pkerp/data/mm9/chromSizes.tsv', position: 'left', height: 30, type: 'vertical-chromosome-labels', options: {}, uid: 'UqH0mt73TqSebs_nFzqHvw'
       }, {
         name: 'Schwarzer et al (2016) NIPBL H3K27ac (chr14)',
         maxWidth: 134217728,
@@ -9109,7 +9097,7 @@ export const paperFigure1 = {
         },
         uid: 'M2YZ4JBQSWS0rR--oiDKhA'
       }, {
-        orientation: '1d-horizontal', name: 'Chromosome Axis (mm9)', tilesetUid: 'cGSJELSNRyOaExsJL0KejQ', local: true, minHeight: 30, thumbnail: null, server: '', width: 615, chromInfoPath: '//s3.amazonaws.com/pkerp/data/mm9/chromSizes.tsv', position: 'top', height: 30, type: 'horizontal-chromosome-labels', options: {}, uid: 'EsCrHgpLQoSO8fJo8PX-9w'
+        orientation: '1d-horizontal', name: 'Chromosome Axis (mm9)', local: true, minHeight: 30, thumbnail: null, width: 615, chromInfoPath: '//s3.amazonaws.com/pkerp/data/mm9/chromSizes.tsv', position: 'top', height: 30, type: 'horizontal-chromosome-labels', options: {}, uid: 'EsCrHgpLQoSO8fJo8PX-9w'
       }],
       right: [],
       center: [{
@@ -9144,7 +9132,7 @@ export const paperFigure1 = {
         options: {}
       }],
       left: [{
-        orientation: '1d-vertical', name: 'Chromosome Axis (mm9)', tilesetUid: 'fs487zYMSMG5XLPXsakQ3g', local: true, minHeight: 30, thumbnail: null, server: '', minWidth: 30, width: 30, chromInfoPath: '//s3.amazonaws.com/pkerp/data/mm9/chromSizes.tsv', position: 'left', height: 30, type: 'vertical-chromosome-labels', options: {}, uid: 'aiYnl3phRPCMfwyKxKaSow'
+        orientation: '1d-vertical', name: 'Chromosome Axis (mm9)', local: true, minHeight: 30, thumbnail: null, minWidth: 30, width: 30, chromInfoPath: '//s3.amazonaws.com/pkerp/data/mm9/chromSizes.tsv', position: 'left', height: 30, type: 'vertical-chromosome-labels', options: {}, uid: 'aiYnl3phRPCMfwyKxKaSow'
       }]
     },
     chromInfoPath: '//s3.amazonaws.com/pkerp/data/mm9/chromSizes.tsv',
@@ -9174,7 +9162,7 @@ export const paperFigure1 = {
         },
         uid: 'Fw793pB8RGOBLJETFtQLsQ'
       }, {
-        orientation: '1d-horizontal', name: 'Chromosome Axis (mm19)', tilesetUid: 'W1N2NIDPRZSckKMlHAKzwA', local: true, minHeight: 30, thumbnail: null, server: '', width: 615, chromInfoPath: '//s3.amazonaws.com/pkerp/data/mm9/chromSizes.tsv', position: 'top', height: 30, type: 'horizontal-chromosome-labels', options: {}, uid: 'AWcBqpmASpmA01tpfgwWOg'
+        orientation: '1d-horizontal', name: 'Chromosome Axis (mm19)', local: true, minHeight: 30, thumbnail: null, width: 615, chromInfoPath: '//s3.amazonaws.com/pkerp/data/mm9/chromSizes.tsv', position: 'top', height: 30, type: 'horizontal-chromosome-labels', options: {}, uid: 'AWcBqpmASpmA01tpfgwWOg'
       }],
       right: [],
       center: [{
@@ -9209,7 +9197,7 @@ export const paperFigure1 = {
         options: {}
       }],
       left: [{
-        orientation: '1d-vertical', name: 'Chromosome Axis (mm9)', tilesetUid: 'Wf4p2PxkQNqy5EC5RzhanQ', local: true, minHeight: 30, thumbnail: null, server: '', minWidth: 30, width: 76, chromInfoPath: '//s3.amazonaws.com/pkerp/data/mm9/chromSizes.tsv', position: 'left', height: 324, type: 'vertical-chromosome-labels', options: {}, uid: 'XRk4dwN7QGyMpfvd06k1bA'
+        orientation: '1d-vertical', name: 'Chromosome Axis (mm9)', local: true, minHeight: 30, thumbnail: null, minWidth: 30, width: 76, chromInfoPath: '//s3.amazonaws.com/pkerp/data/mm9/chromSizes.tsv', position: 'left', height: 324, type: 'vertical-chromosome-labels', options: {}, uid: 'XRk4dwN7QGyMpfvd06k1bA'
       }]
     },
     chromInfoPath: '//s3.amazonaws.com/pkerp/data/mm9/chromSizes.tsv',


### PR DESCRIPTION
## Description

What was changed in this pull request?
- Add tests for trivial viewconfs. (Though maybe these are too trivial... should there be an error in cases like these?)
- Add another special case to test-helpers.js: `cross-rule` is another instance where we do not need to wait for tiles. (Would there be any way to determine from the outside if a particular track type is one we should wait for?)

Why is it necessary?
- I stalled out on the cross-rule svg export earlier because the test I wanted to write kept failing, and I didn't understand why.

## Checklist

- [X] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example added or updated
- [ ] Screenshot for visual changes (e.g. new tracks)
- [ ] Updated CHANGELOG.md
