### PR TITLE
Provide fake pubSub by default for convenience

### DIFF
--- a/app/scripts/ChromosomeInfo.js
+++ b/app/scripts/ChromosomeInfo.js
@@ -2,6 +2,8 @@ import { tsvParseRows } from 'd3-dsv';
 import { tileProxy } from './services';
 import { absToChr, chrToAbs } from './utils';
 
+import { fake as fakePubSub } from './hocs/with-pub-sub';
+
 export function parseChromsizesRows(data) {
   const cumValues = [];
   const chromLengths = {};
@@ -32,7 +34,7 @@ export function parseChromsizesRows(data) {
   };
 }
 
-function ChromosomeInfo(filepath, success, pubSub) {
+function ChromosomeInfo(filepath, success, pubSub = fakePubSub) {
   const ret = {};
 
   ret.absToChr = absPos => (ret.chrPositions


### PR DESCRIPTION
## Description

What was changed in this pull request?

By default a fake pubSub object is provided so that ChromosomeInfo is backwards compatible

Why is it necessary?

For convenience
