### PR TITLE
linting: arrow linebreak and jsx prop sorting

### DIFF
--- a/.eslintrc-minimal
+++ b/.eslintrc-minimal
@@ -36,7 +36,6 @@
     "arrow-parens": 0,
     "consistent-return": 0,
     "global-require": 0,
-    "implicit-arrow-linebreak": 0,
     "import/no-extraneous-dependencies": 0,
     "import/no-named-as-default": 0,
     "import/prefer-default-export": 0,

--- a/.eslintrc-minimal
+++ b/.eslintrc-minimal
@@ -79,8 +79,12 @@
     "react/prefer-stateless-function": 0,
     "react/require-default-props": 0,
     
+    // By default, this is a warning, but most properties were in order,
+    // and the few exceptions added a lot of noise to the logs.
+    "react/jsx-sort-props": ["error"],
+
     // Below here should match .eslintrc,
-    // except where we've turned off some rules completely.
+    // except for the properties tweaked above.
     "class-methods-use-this": 0,
     "comma-dangle": 0,
     "guard-for-in": 0,
@@ -112,7 +116,6 @@
     "react/jsx-no-literals": 0,
     "react/jsx-no-undef": 1,
     "react/jsx-pascal-case": 1,
-    "react/jsx-sort-props": 1,
     "react/jsx-uses-react": 1,
     "react/jsx-uses-vars": 1,
     "no-restricted-syntax": 0,

--- a/app/scripts/Autocomplete.js
+++ b/app/scripts/Autocomplete.js
@@ -323,6 +323,7 @@ class Autocomplete extends React.Component {
       >
         <input
           {...inputProps}
+          ref={el => this.inputEl = el}
           aria-autocomplete="list"
           autoComplete="off"
           onBlur={this.composeEventHandlers(
@@ -346,7 +347,6 @@ class Autocomplete extends React.Component {
             this.handleKeyUp.bind(this),
             inputProps.onKeyUp && inputProps.onKeyUp.bind(this),
           )}
-          ref={el => this.inputEl = el}
           role="combobox"
           value={this.props.value}
         />

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -3548,15 +3548,12 @@ class HiGlassComponent extends React.Component {
             horizontalMargin={this.horizontalMargin}
             initialXDomain={view.initialXDomain}
             initialYDomain={view.initialYDomain}
-            xDomainLimits={view.xDomainLimits}
-            yDomainLimits={view.yDomainLimits}
-            zoomLimits={view.zoomLimits}
-            zoomToDataExtentOnInit={this.zoomToDataExtentOnInit.has(view.uid)}
+            metaTracks={view.metaTracks}
             mouseTool={this.state.mouseTool}
-            onChangeTrackType={(trackId, newType) => (
-              this.handleChangeTrackType(view.uid, trackId, newType))}
             onChangeTrackData={(trackId, newData) => (
               this.handleChangeTrackData(view.uid, trackId, newData))}
+            onChangeTrackType={(trackId, newType) => (
+              this.handleChangeTrackType(view.uid, trackId, newType))}
             onCloseTrack={uid => this.handleCloseTrack(view.uid, uid)}
             onDataDomainChanged={(xDomain, yDomain) => (
               this.handleDataDomainChanged(view.uid, xDomain, yDomain))}
@@ -3573,6 +3570,7 @@ class HiGlassComponent extends React.Component {
               this.handleTracksAdded(view.uid, newTracks, position, host))}
             onUnlockValueScale={uid => this.handleUnlockValueScale(view.uid, uid)}
             onValueScaleChanged={uid => this.syncValueScales(view.uid, uid)}
+            overlays={view.overlays}
             pixiStage={this.pixiStage}
             pluginTracks={this.state.pluginTracks}
             rangeSelection1dSize={this.state.rangeSelection1dSize}
@@ -3583,15 +3581,17 @@ class HiGlassComponent extends React.Component {
               this.removeDraggingChangedListener(view.uid, view.uid, listener))}
             setCentersFunction={(c) => { this.setCenters[view.uid] = c; }}
             svgElement={this.state.svgElement}
-            trackSourceServers={this.props.viewConfig.trackSourceServers}
-            overlays={view.overlays}
             tracks={view.tracks}
-            viewOptions={view.options}
-            metaTracks={view.metaTracks}
+            trackSourceServers={this.props.viewConfig.trackSourceServers}
             uid={view.uid}
             verticalMargin={this.verticalMargin}
+            viewOptions={view.options}
             // dragging={this.state.dragging}
+            xDomainLimits={view.xDomainLimits}
+            yDomainLimits={view.yDomainLimits}
             zoomable={!zoomFixed}
+            zoomLimits={view.zoomLimits}
+            zoomToDataExtentOnInit={this.zoomToDataExtentOnInit.has(view.uid)}
           />
         );
 
@@ -3629,10 +3629,7 @@ class HiGlassComponent extends React.Component {
 
         const multiTrackHeader = this.isEditable() && !this.state.viewConfig.hideHeader ? (
           <ViewHeader
-            // Reserved props
             ref={(c) => { this.viewHeaders[view.uid] = c; }}
-
-            // Custom props
             getGenomePositionSearchBox={getGenomePositionSearchBox}
             isGenomePositionSearchBoxVisible={
               view.genomePositionSearchBox && view.genomePositionSearchBox.visible
@@ -3641,8 +3638,8 @@ class HiGlassComponent extends React.Component {
             onAddView={() => this.handleAddView(view)}
             onClearView={() => this.handleClearView(view.uid)}
             onCloseView={() => this.handleCloseView(view.uid)}
-            onExportSVG={this.handleExportSVG.bind(this)}
             onExportPNG={this.handleExportPNG.bind(this)}
+            onExportSVG={this.handleExportSVG.bind(this)}
             onExportViewsAsJSON={this.handleExportViewAsJSON.bind(this)}
             onExportViewsAsLink={this.handleExportViewsAsLink.bind(this)}
             onLockLocation={uid => (
@@ -3664,13 +3661,13 @@ class HiGlassComponent extends React.Component {
             }}
             onTogglePositionSearchBox={this.handleTogglePositionSearchBox.bind(this)}
             onTrackPositionChosen={position => this.handleTrackPositionChosen(view.uid, position)}
-            onViewOptionsChanged={newOptions => this.handleViewOptionsChanged(view.uid, newOptions)}
             onUnlockLocation={uid => this.handleUnlock(uid, this.locationLocks)}
             onUnlockZoom={uid => this.handleUnlock(uid, this.zoomLocks)}
             onUnlockZoomAndLocation={(uid) => {
               this.handleUnlock(uid, this.zoomLocks);
               this.handleUnlock(uid, this.locationLocks);
             }}
+            onViewOptionsChanged={newOptions => this.handleViewOptionsChanged(view.uid, newOptions)}
             onYankLocation={uid => (
               this.handleYankFunction(uid, this.handleLocationYanked.bind(this)))}
             onYankZoom={uid => this.handleYankFunction(uid, this.handleZoomYanked.bind(this))}
@@ -3720,7 +3717,6 @@ class HiGlassComponent extends React.Component {
 
         // Custom props
         cols={12}
-        width={this.state.width}
         draggableHandle={`.${stylesMTHeader['multitrack-header-grabber']}`}
         isDraggable={this.isEditable()}
         isResizable={this.isEditable()}
@@ -3741,6 +3737,7 @@ class HiGlassComponent extends React.Component {
         // `useCSSTransforms` (it's default `true`)
         // and set `measureBeforeMount={true}`.
         useCSSTransforms={this.mounted}
+        width={this.state.width}
       >
         {this.tiledAreas}
       </ReactGridLayout>

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -3553,43 +3553,34 @@ class HiGlassComponent extends React.Component {
             zoomLimits={view.zoomLimits}
             zoomToDataExtentOnInit={this.zoomToDataExtentOnInit.has(view.uid)}
             mouseTool={this.state.mouseTool}
-            onChangeTrackType={(trackId, newType) =>
-              this.handleChangeTrackType(view.uid, trackId, newType)}
-            onChangeTrackData={(trackId, newData) =>
-              this.handleChangeTrackData(view.uid, trackId, newData)}
+            onChangeTrackType={(trackId, newType) => (
+              this.handleChangeTrackType(view.uid, trackId, newType))}
+            onChangeTrackData={(trackId, newData) => (
+              this.handleChangeTrackData(view.uid, trackId, newData))}
             onCloseTrack={uid => this.handleCloseTrack(view.uid, uid)}
-            onDataDomainChanged={
-              (xDomain, yDomain) =>
-                this.handleDataDomainChanged(view.uid, xDomain, yDomain)
-            }
+            onDataDomainChanged={(xDomain, yDomain) => (
+              this.handleDataDomainChanged(view.uid, xDomain, yDomain))}
             onLockValueScale={uid => this.handleLockValueScale(view.uid, uid)}
             onMouseMoveZoom={this.mouseMoveZoomHandler.bind(this)}
             onNewTilesLoaded={trackUid => this.handleNewTilesLoaded(view.uid, trackUid)}
             onNoTrackAdded={this.handleNoTrackAdded.bind(this)}
             onRangeSelection={this.rangeSelectionHandler.bind(this)}
             onScalesChanged={(x, y) => this.handleScalesChanged(view.uid, x, y)}
-            onTrackOptionsChanged={
-              (trackId, options) =>
-                this.handleTrackOptionsChanged(view.uid, trackId, options)
-            }
+            onTrackOptionsChanged={(trackId, options) => (
+              this.handleTrackOptionsChanged(view.uid, trackId, options))}
             onTrackPositionChosen={this.handleTrackPositionChosen.bind(this)}
-            onTracksAdded={
-              (newTracks, position, host) =>
-                this.handleTracksAdded(view.uid, newTracks, position, host)
-            }
+            onTracksAdded={(newTracks, position, host) => (
+              this.handleTracksAdded(view.uid, newTracks, position, host))}
             onUnlockValueScale={uid => this.handleUnlockValueScale(view.uid, uid)}
             onValueScaleChanged={uid => this.syncValueScales(view.uid, uid)}
             pixiStage={this.pixiStage}
             pluginTracks={this.state.pluginTracks}
             rangeSelection1dSize={this.state.rangeSelection1dSize}
             rangeSelectionToInt={this.state.rangeSelectionToInt}
-            registerDraggingChangedListener={(listener) => {
-              this.addDraggingChangedListener(view.uid, view.uid, listener);
-            }}
-            removeDraggingChangedListener={
-              listener =>
-                this.removeDraggingChangedListener(view.uid, view.uid, listener)
-            }
+            registerDraggingChangedListener={listener => (
+              this.addDraggingChangedListener(view.uid, view.uid, listener))}
+            removeDraggingChangedListener={listener => (
+              this.removeDraggingChangedListener(view.uid, view.uid, listener))}
             setCentersFunction={(c) => { this.setCenters[view.uid] = c; }}
             svgElement={this.state.svgElement}
             trackSourceServers={this.props.viewConfig.trackSourceServers}
@@ -3622,14 +3613,14 @@ class HiGlassComponent extends React.Component {
               // the chromInfoId is either specified in the viewconfig or guessed based on
               // the visible tracks (see createGenomePositionSearchBoxEntry)
               onFocus={onFocus}
-              onSelectedAssemblyChanged={(x, y, server) =>
-                this.handleSelectedAssemblyChanged(view.uid, x, y, server)}
-              registerViewportChangedListener={listener =>
-                this.addScalesChangedListener(view.uid, view.uid, listener)}
-              removeViewportChangedListener={() =>
-                this.removeScalesChangedListener(view.uid, view.uid)}
-              setCenters={(centerX, centerY, k, animateTime) =>
-                this.setCenters[view.uid](centerX, centerY, k, false, animateTime)}
+              onSelectedAssemblyChanged={(x, y, server) => (
+                this.handleSelectedAssemblyChanged(view.uid, x, y, server))}
+              registerViewportChangedListener={listener => (
+                this.addScalesChangedListener(view.uid, view.uid, listener))}
+              removeViewportChangedListener={() => (
+                this.removeScalesChangedListener(view.uid, view.uid))}
+              setCenters={(centerX, centerY, k, animateTime) => (
+                this.setCenters[view.uid](centerX, centerY, k, false, animateTime))}
               trackSourceServers={this.state.viewConfig.trackSourceServers}
               twoD={true}
             />
@@ -3654,10 +3645,10 @@ class HiGlassComponent extends React.Component {
             onExportPNG={this.handleExportPNG.bind(this)}
             onExportViewsAsJSON={this.handleExportViewAsJSON.bind(this)}
             onExportViewsAsLink={this.handleExportViewsAsLink.bind(this)}
-            onLockLocation={uid =>
-              this.handleYankFunction(uid, this.handleLocationLockChosen.bind(this))}
-            onLockZoom={uid =>
-              this.handleYankFunction(uid, this.handleZoomLockChosen.bind(this))}
+            onLockLocation={uid => (
+              this.handleYankFunction(uid, this.handleLocationLockChosen.bind(this)))}
+            onLockZoom={uid => (
+              this.handleYankFunction(uid, this.handleZoomLockChosen.bind(this)))}
             onLockZoomAndLocation={uid => this.handleYankFunction(uid, (a, b) => {
               this.handleZoomLockChosen(a, b);
               this.handleLocationLockChosen(a, b);
@@ -3673,23 +3664,21 @@ class HiGlassComponent extends React.Component {
             }}
             onTogglePositionSearchBox={this.handleTogglePositionSearchBox.bind(this)}
             onTrackPositionChosen={position => this.handleTrackPositionChosen(view.uid, position)}
-            onViewOptionsChanged={
-              (newOptions) => this.handleViewOptionsChanged(view.uid, newOptions)}
+            onViewOptionsChanged={newOptions => this.handleViewOptionsChanged(view.uid, newOptions)}
             onUnlockLocation={uid => this.handleUnlock(uid, this.locationLocks)}
             onUnlockZoom={uid => this.handleUnlock(uid, this.zoomLocks)}
             onUnlockZoomAndLocation={(uid) => {
               this.handleUnlock(uid, this.zoomLocks);
               this.handleUnlock(uid, this.locationLocks);
             }}
-            onYankLocation={uid =>
-              this.handleYankFunction(uid, this.handleLocationYanked.bind(this))}
+            onYankLocation={uid => (
+              this.handleYankFunction(uid, this.handleLocationYanked.bind(this)))}
             onYankZoom={uid => this.handleYankFunction(uid, this.handleZoomYanked.bind(this))}
-            onYankZoomAndLocation={uid =>
+            onYankZoomAndLocation={uid => (
               this.handleYankFunction(uid, (a, b) => {
                 this.handleZoomYanked(a, b);
                 this.handleLocationYanked(a, b);
-              })
-            }
+              }))}
             onZoomToData={uid => this.handleZoomToData(uid)}
             viewUid={view.uid}
           />

--- a/app/scripts/TiledPlot.js
+++ b/app/scripts/TiledPlot.js
@@ -1469,18 +1469,17 @@ class TiledPlot extends React.Component {
             closeMenu={this.closeMenus.bind(this)}
             coords={[this.state.contextMenuDataX, this.state.contextMenuDataY]}
             customItems={this.state.contextMenuCustomItems}
+            onAddDivisor={this.handleAddDivisor.bind(this)}
             onAddSeries={this.handleAddSeries.bind(this)}
             // Can only add one new track at a time
             // because "whole" tracks are always drawn on top of each other,
             // the notion of Series is unnecessary and so 'host' is null
             onAddTrack={(newTrack) => {
               this.props.onTracksAdded([newTrack], newTrack.position, null);
-
               this.handleCloseContextMenu();
             }}
-            onChangeTrackType={this.handleChangeTrackType.bind(this)}
             onChangeTrackData={this.handleChangeTrackData.bind(this)}
-            onAddDivisor={this.handleAddDivisor.bind(this)}
+            onChangeTrackType={this.handleChangeTrackType.bind(this)}
             onCloseTrack={this.handleCloseTrack.bind(this)}
             onConfigureTrack={this.handleConfigureTrack.bind(this)}
             onExportData={this.handleExportTrackData.bind(this)}
@@ -1488,7 +1487,7 @@ class TiledPlot extends React.Component {
             onReplaceTrack={this.handleReplaceTrack.bind(this)}
             onTrackOptionsChanged={this.handleTrackOptionsChanged.bind(this)}
             onUnlockValueScale={this.handleUnlockValueScale.bind(this)}
-            orientation={'right'}
+            orientation="right"
             position={this.state.contextMenuPosition}
             tracks={relevantTracks}
             trackSourceServers={this.props.trackSourceServers}
@@ -1988,8 +1987,8 @@ class TiledPlot extends React.Component {
           topHeight={this.topHeight}
           topHeightNoGallery={this.topHeightNoGallery}
           uid={this.props.uid}
-          width={this.state.width}
           viewOptions={this.props.viewOptions}
+          width={this.state.width}
           xDomainLimits={this.props.xDomainLimits}
           yDomainLimits={this.props.yDomainLimits}
           zoomable={this.props.zoomable}
@@ -2014,6 +2013,7 @@ class TiledPlot extends React.Component {
           onMenuClosed={this.closeMenus.bind(this)}
         >
           <ConfigTrackMenu
+            ref={(c) => { this.configTrackMenu = c; }}
             closeMenu={this.closeMenus.bind(this)}
             onAddSeries={this.handleAddSeries.bind(this)}
             onAddTrack={this.handleAddTrack.bind(this)}
@@ -2025,11 +2025,10 @@ class TiledPlot extends React.Component {
             onReplaceTrack={this.handleReplaceTrack.bind(this)}
             onTrackOptionsChanged={this.handleTrackOptionsChanged.bind(this)}
             onUnlockValueScale={this.handleUnlockValueScale.bind(this)}
-            ref={(c) => { this.configTrackMenu = c; }}
             position={this.state.configTrackMenuLocation}
-            tracks={[getTrackByUid(this.props.tracks, this.state.configTrackMenuId)]}
             trackOrientation={
               getTrackPositionByUid(this.props.tracks, this.state.configTrackMenuId)}
+            tracks={[getTrackByUid(this.props.tracks, this.state.configTrackMenuId)]}
           />
         </PopupMenu>
       );
@@ -2136,11 +2135,11 @@ class TiledPlot extends React.Component {
     if (this.state.addTrackPosition || this.props.addTrackPosition) {
       addTrackModal = (
         <AddTrackModal
+          ref={(c) => { this.addTrackModal = c; }}
           host={this.state.addTrackHost}
           onCancel={this.handleNoTrackAdded.bind(this)}
           onTracksChosen={this.handleTracksAdded.bind(this)}
           position={position}
-          ref={(c) => { this.addTrackModal = c; }}
           show={this.state.addTrackPosition !== null || this.props.addTrackPosition !== null}
           trackSourceServers={this.props.trackSourceServers}
         />

--- a/app/scripts/mixwith.js
+++ b/app/scripts/mixwith.js
@@ -59,9 +59,9 @@ export const apply = (superclass, mixin) => {
  * @return {boolean} whether `proto` is a prototype created by the application of
  * `mixin` to a superclass
  */
-export const isApplicationOf = (proto, mixin) =>
-  proto.hasOwnProperty(_appliedMixin) && proto[_appliedMixin] === unwrap(mixin);
-
+export const isApplicationOf = (proto, mixin) => (
+  proto.hasOwnProperty(_appliedMixin) && proto[_appliedMixin] === unwrap(mixin)
+);
 /**
  * Returns `true` iff `o` has an application of `mixin` on its prototype
  * chain.

--- a/travis_build_test.sh
+++ b/travis_build_test.sh
@@ -12,7 +12,7 @@ start eslint
 # while we work to get individual files up to something higher.
 ./node_modules/eslint/bin/eslint.js \
   --ignore-path .eslintignore-minimal \
-  --config .eslintrc-minimal . || die 'Low-bar horizontal linting failed'
+  --config .eslintrc-minimal app test || die 'Low-bar horizontal linting failed'
 ./node_modules/eslint/bin/eslint.js \
   karma.conf.js \
   app/scripts/configs \


### PR DESCRIPTION
## Description

What was changed in this pull request?
- Running eslint on `.` seems to have suddenly gotten a lot slower, so limit to `app` and `tests`.
- `implicit-arrow-linebreak` enforced
- `react/jsx-sort-props` changed from warning to error: It was adding a lot of noise to the logs, and there weren't actually that many lines that needed to be reordered.

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example added or updated
- [ ] Screenshot for visual changes (e.g. new tracks)
- [ ] Updated CHANGELOG.md
