### PR TITLE
enforce no-prototype-builtins

### DIFF
--- a/.eslintrc-minimal
+++ b/.eslintrc-minimal
@@ -48,7 +48,6 @@
     "no-dupe-class-members": 0,
     "no-nested-ternary": 0,
     "no-param-reassign": 0,
-    "no-prototype-builtins": 0,
     "no-restricted-globals": 0,
     "no-return-assign": 0,
     "no-shadow": 0,

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -881,7 +881,7 @@ class HiGlassComponent extends React.Component {
    *    Event handler is called with parameters (xScale, yScale)
    */
   addDraggingChangedListener(viewUid, listenerUid, eventHandler) {
-    if (!this.draggingChangedListeners.hasOwnProperty(viewUid)) {
+    if (!Object.prototype.hasOwnProperty.call(this.draggingChangedListeners, viewUid)) {
       this.draggingChangedListeners[viewUid] = {};
     }
 
@@ -898,11 +898,11 @@ class HiGlassComponent extends React.Component {
    * @param listenerUid: The uid of the listener itself.
    */
   removeDraggingChangedListener(viewUid, listenerUid) {
-    if (this.draggingChangedListeners.hasOwnProperty(viewUid)) {
+    if (Object.prototype.hasOwnProperty.call(this.draggingChangedListeners, viewUid)) {
       const listeners = this.draggingChangedListeners[viewUid];
 
 
-      if (listeners.hasOwnProperty(listenerUid)) {
+      if (Object.prototype.hasOwnProperty.call(listeners, listenerUid)) {
         // make sure the listener doesn't think we're still
         // dragging
         listeners[listenerUid](false);
@@ -1090,7 +1090,7 @@ class HiGlassComponent extends React.Component {
 
         // notify the listeners of all locked views that the scales of
         // this view have changed
-        if (this.scalesChangedListeners.hasOwnProperty(key)) {
+        if (Object.prototype.hasOwnProperty.call(this.scalesChangedListeners, key)) {
           dictValues(this.scalesChangedListeners[key]).forEach((x) => {
             x(newXScale, newYScale);
           });
@@ -1139,7 +1139,7 @@ class HiGlassComponent extends React.Component {
 
         // notify the listeners of all locked views that the scales of
         // this view have changed
-        if (this.scalesChangedListeners.hasOwnProperty(key)) {
+        if (Object.prototype.hasOwnProperty.call(this.scalesChangedListeners, key)) {
           dictValues(this.scalesChangedListeners[key]).forEach((x) => {
             x(newXScale, newYScale);
           });
@@ -2925,7 +2925,7 @@ class HiGlassComponent extends React.Component {
 
     for (const v of dictValues(viewsByUid)) {
       for (const trackOrientation of ['left', 'top', 'center', 'right', 'bottom']) {
-        if (v.tracks && v.tracks.hasOwnProperty(trackOrientation)) {
+        if (v.tracks && Object.prototype.hasOwnProperty.call(v.tracks, trackOrientation)) {
           // filter out invalid tracks
           v.tracks[trackOrientation] = v.tracks[trackOrientation]
             .filter(t => this.isTrackValid(t, viewUidsSet));

--- a/app/scripts/TrackRenderer.js
+++ b/app/scripts/TrackRenderer.js
@@ -329,7 +329,7 @@ class TrackRenderer extends React.Component {
       const trackObject = this.trackDefObjects[track.track.uid].trackObject;
       trackObject.rerender(options);
 
-      if (track.track.hasOwnProperty('contents')) {
+      if (Object.prototype.hasOwnProperty.call(track.track, 'contents')) {
         const ctDefs = {};
         for (const ct of track.track.contents) {
           ctDefs[ct.uid] = ct;

--- a/app/scripts/mixwith.js
+++ b/app/scripts/mixwith.js
@@ -60,7 +60,8 @@ export const apply = (superclass, mixin) => {
  * `mixin` to a superclass
  */
 export const isApplicationOf = (proto, mixin) => (
-  proto.hasOwnProperty(_appliedMixin) && proto[_appliedMixin] === unwrap(mixin)
+  Object.prototype.hasOwnProperty.call(proto, _appliedMixin)
+    && proto[_appliedMixin] === unwrap(mixin)
 );
 /**
  * Returns `true` iff `o` has an application of `mixin` on its prototype


### PR DESCRIPTION
but if we would never shadow Object.prototype methods, this is excessive, and it would be better just to ignore the rule.

Thoughts? I'd be happy just to disable the rule, too.