### PR TITLE
Remove extra export which confused the default

### DIFF
--- a/.eslintrc-minimal
+++ b/.eslintrc-minimal
@@ -33,7 +33,6 @@
     // Turn a lot of rules off: We plan to fix one kind of error at a time, so we can remove these exceptions,
     // and eventually delete this file and just have one .exlintrc. 
     "import/no-extraneous-dependencies": 0,
-    "import/no-named-as-default": 0,
     "import/prefer-default-export": 0,
     "jsx-a11y/anchor-is-valid": 0,
     "jsx-a11y/click-events-have-key-events": 0,

--- a/app/scripts/OverlayTrack.js
+++ b/app/scripts/OverlayTrack.js
@@ -3,7 +3,7 @@ import PixiTrack from './PixiTrack';
 // Utils
 import { colorToHex } from './utils';
 
-export class OverlayTrack extends PixiTrack {
+class OverlayTrack extends PixiTrack {
   constructor(context, options) {
     super(context, options);
 


### PR DESCRIPTION
## Description

What was changed in this pull request?

- enforce `import/no-named-as-default`

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example added or updated
- [ ] Screenshot for visual changes (e.g. new tracks)
- [ ] Updated CHANGELOG.md
