### PR TITLE
enforce import/prefer-default-export

### DIFF
--- a/.eslintrc-minimal
+++ b/.eslintrc-minimal
@@ -34,7 +34,6 @@
     // and eventually delete this file and just have one .exlintrc. 
     "import/no-extraneous-dependencies": 0,
     "import/no-named-as-default": 0,
-    "import/prefer-default-export": 0,
     "jsx-a11y/anchor-is-valid": 0,
     "jsx-a11y/click-events-have-key-events": 0,
     "jsx-a11y/no-noninteractive-element-interactions": 0,

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -17,7 +17,7 @@ import ExportLinkModal from './ExportLinkModal';
 import ViewHeader from './ViewHeader';
 import ChromosomeInfo from './ChromosomeInfo';
 
-import { createSymbolIcon } from './symbol';
+import createSymbolIcon from './symbol';
 import { all as icons } from './icons';
 import createApi from './api';
 

--- a/app/scripts/symbol.js
+++ b/app/scripts/symbol.js
@@ -10,7 +10,7 @@
  * @param   {Array}   paths    Array of path strings.
  * @param   {String}  viewBox  View box string.
  */
-export function createSymbolIcon(el, id, paths, viewBox) {
+export default function createSymbolIcon(el, id, paths, viewBox) {
   const symbol = el.append('symbol')
     .attr('id', id)
     .attr('viewBox', viewBox);


### PR DESCRIPTION
## Description

What was changed in this pull request?

- give `symbol.js` a default export.
- enforce `import/prefer-default-export`

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example added or updated
- [ ] Screenshot for visual changes (e.g. new tracks)
- [ ] Updated CHANGELOG.md
