### PR TITLE
Fix eslint-plugin-react version to fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
-    "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react": "7.11.1",
     "fast-css-loader": "^1.0.2",
     "fast-sass-loader": "^1.4.6",
     "font-awesome": "^4.7.0",


### PR DESCRIPTION
## Description

Fixed the version of `eslint-plugin-react` to fix the broken build.

Why is it necessary?

The latest version of `eslint-plugin-react` causes an error: https://github.com/yannickcr/eslint-plugin-react/issues/2095


Fixes #___

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example added or updated
- [ ] Screenshot for visual changes (e.g. new tracks)
- [ ] Updated CHANGELOG.md
