### PR TITLE
Added the default-track-options.html example

### DIFF
--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -573,7 +573,7 @@ class HiGlassComponent extends React.Component {
    *
    * @param {array} track The track to add default options to
    */
-  addDefaultOptions(track) {
+  addDefaultTrackOptions(track) {
     const trackInfo = this.getTrackInfo(track.type);
     if (!trackInfo) return;
 
@@ -583,12 +583,13 @@ class HiGlassComponent extends React.Component {
 
     const trackOptions = track.options ? track.options : {};
 
-    if (this.props.options.defaultOptions) {
-      if (this.props.options.defaultOptions.trackSpecific
-        && this.props.options.defaultOptions.trackSpecific[track.type]) {
+    console.log('options', this.props.options)
+    if (this.props.options.defaultTrackOptions) {
+      if (this.props.options.defaultTrackOptions.trackSpecific
+        && this.props.options.defaultTrackOptions.trackSpecific[track.type]) {
         // track specific options take precedence over all options
 
-        const options = this.props.options.defaultOptions.trackSpecific[track.type];
+        const options = this.props.options.defaultTrackOptions.trackSpecific[track.type];
 
         for (const optionName in options) {
           track.options[optionName] = typeof (track.options[optionName]) !== 'undefined'
@@ -597,8 +598,8 @@ class HiGlassComponent extends React.Component {
         }
       }
 
-      if (this.props.options.defaultOptions.all) {
-        const options = this.props.options.defaultOptions.all;
+      if (this.props.options.defaultTrackOptions.all) {
+        const options = this.props.options.defaultTrackOptions.all;
 
         for (const optionName in options) {
           track.options[optionName] = typeof (track.options[optionName]) !== 'undefined'
@@ -608,14 +609,14 @@ class HiGlassComponent extends React.Component {
       }
     }
 
-    if (trackInfo.defaultOptions) {
+    if (trackInfo.defaultTrackOptions) {
       if (!track.options) {
-        track.options = JSON.parse(JSON.stringify(trackInfo.defaultOptions));
+        track.options = JSON.parse(JSON.stringify(trackInfo.defaultTrackOptions));
       } else {
-        for (const optionName in trackInfo.defaultOptions) {
+        for (const optionName in trackInfo.defaultTrackOptions) {
           track.options[optionName] = typeof (track.options[optionName]) !== 'undefined'
             ? track.options[optionName]
-            : JSON.parse(JSON.stringify(trackInfo.defaultOptions[optionName]));
+            : JSON.parse(JSON.stringify(trackInfo.defaultTrackOptions[optionName]));
         }
       }
     } else { track.options = trackOptions; }
@@ -2062,14 +2063,14 @@ class HiGlassComponent extends React.Component {
    *  describing this track
    */
   handleTrackAdded(viewId, newTrack, position, host = null) {
-    this.addDefaultOptions(newTrack);
+    this.addDefaultTrackOptions(newTrack);
 
     // make sure the new track has a uid
     if (!newTrack.uid) newTrack.uid = slugid.nice();
 
     if (newTrack.contents) {
       // add default options to combined tracks
-      for (const ct of newTrack.contents) { this.addDefaultOptions(ct); }
+      for (const ct of newTrack.contents) { this.addDefaultTrackOptions(ct); }
     }
 
     this.addNameToTrack(newTrack);
@@ -3015,11 +3016,11 @@ class HiGlassComponent extends React.Component {
       // add default options (as specified in config.js
       // (e.g. line color, heatmap color scales, etc...)
       looseTracks.forEach((t) => {
-        this.addDefaultOptions(t);
+        this.addDefaultTrackOptions(t);
 
         if (t.contents) {
           // add default options to combined tracks
-          for (const ct of t.contents) { this.addDefaultOptions(ct); }
+          for (const ct of t.contents) { this.addDefaultTrackOptions(ct); }
         }
       });
 
@@ -3431,7 +3432,7 @@ class HiGlassComponent extends React.Component {
     return (
       this.props.zoomFixed
       || this.props.options.zoomFixed
-      || this.props.viewConfig.zoomFixed
+      || this.state.viewConfig.zoomFixed
       || (view && view.zoomFixed)
     );
   }
@@ -3443,7 +3444,7 @@ class HiGlassComponent extends React.Component {
     const isZoomFixed = (
       this.props.zoomFixed
       || this.props.options.zoomFixed
-      || this.props.viewConfig.zoomFixed
+      || this.state.viewConfig.zoomFixed
     );
 
     const isTargetCanvas = evt.target === this.canvasElement;
@@ -3592,7 +3593,7 @@ class HiGlassComponent extends React.Component {
             }
             setCentersFunction={(c) => { this.setCenters[view.uid] = c; }}
             svgElement={this.state.svgElement}
-            trackSourceServers={this.props.viewConfig.trackSourceServers}
+            trackSourceServers={this.state.viewConfig.trackSourceServers}
             overlays={view.overlays}
             tracks={view.tracks}
             viewOptions={view.options}

--- a/app/scripts/hglib.js
+++ b/app/scripts/hglib.js
@@ -58,7 +58,7 @@ const launch = (element, config, options) => {
  * * **editable** *(bool)* - Can the layout be changed? If false, the view headers will
   be hidden. This can also be specified in the viewconfig using the ``editable`` option.
   The value passed here overrides the value in the viewconf. [default=true]
- * * **defaultOptions** *(dict)* - Specify a set of default options that will be used for
+ * * **defaultTrackOptions** *(dict)* - Specify a set of default options that will be used for
  *  newly added tracks. These can be broken down into two types: `all` - affecting all
  *  all track types and `trackSpecific` which will affect only some track types. See the
  *  example below for a concrete demonstration.
@@ -75,7 +75,7 @@ const launch = (element, config, options) => {
  *  document.getElementById('development-demo'),
  *  testViewConfig,
  *  { bounded: true,
- *   defaultOptions: {
+ *   defaultTrackOptions: {
  *     all: {
  *       showTooltip: true,
  *     },

--- a/docs/examples/apis/default-track-options.html
+++ b/docs/examples/apis/default-track-options.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>setTrackValueScaleLimits() &middot; HiGlass</title>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+  <link rel="stylesheet" href="/hglib.css">
+  <script crossorigin src="https://unpkg.com/react@16.5/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@16.5/umd/react-dom.production.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/4.8.2/pixi.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react-bootstrap/0.32.1/react-bootstrap.min.js"></script>
+</head>
+<body >
+  <div
+      id="demo"
+      style="position: absolute; left: 1rem; top: 1rem; bottom: 1rem; right: 1rem">
+  </div>
+</body>
+<script src='/hglib.js'>
+</script>
+<script>
+
+
+// start with an empty viewconf
+const hgApi = hglib.viewer(
+  document.getElementById('demo'),
+  'http://higlass.io/api/v1/viewconfs/?d=MOaW2COEQpeAq548Qb69KA',
+  {
+    bounded: true,
+    defaultTrackOptions: {
+      all: {
+        showTooltip: true
+      }
+    }
+  },
+);
+
+</script>
+</html>

--- a/docs/examples/apis/set-track-value-scale-limits.html
+++ b/docs/examples/apis/set-track-value-scale-limits.html
@@ -4,7 +4,6 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>setTrackValueScaleLimits() &middot; HiGlass</title>
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-  <link rel="stylesheet" href="/styles/page.css">
   <link rel="stylesheet" href="/hglib.css">
   <script crossorigin src="https://unpkg.com/react@16.5/umd/react.production.min.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@16.5/umd/react-dom.production.min.js"></script>


### PR DESCRIPTION
## Description

I added an example showing the use of the `defaultTrackOptions` option in `hglib.viewer`. I also renamed `defaultOptions` to `defaultTrackOptions`.

Why is it necessary?

To show how to use this option.

## Checklist

- [ ] Unit tests added or updated
- [x] Documentation added or updated
- [x] Example added or updated
- [NA] Screenshot for visual changes (e.g. new tracks)
- [NA] Updated CHANGELOG.md
