### PR TITLE
Summary option for bigwig tracks

### DIFF
--- a/app/scripts/ExportLinkModal.js
+++ b/app/scripts/ExportLinkModal.js
@@ -20,13 +20,14 @@ class ExportLinkModal extends React.Component {
         />
       )
 
-      : (<div>
-        <span
-          aria-hidden="true"
-          className="glyphicon glyphicon-refresh glyphicon-refresh-animate"
-        />
-        <span>&nbsp;&nbsp;We are generating your link...</span>
-         </div>
+      : (
+        <div>
+          <span
+            aria-hidden="true"
+            className="glyphicon glyphicon-refresh glyphicon-refresh-animate"
+          />
+          <span>&nbsp;&nbsp;We are generating your link...</span>
+        </div>
       );
 
     return (
@@ -57,7 +58,8 @@ class ExportLinkModal extends React.Component {
             <Button onClick={this.props.onDone}>Done</Button>
           </Modal.Footer>
         </Modal>
-      </div>);
+      </div>
+    );
   }
 }
 

--- a/app/scripts/HeatmapOptions.js
+++ b/app/scripts/HeatmapOptions.js
@@ -84,34 +84,35 @@ class HeatmapOptions extends React.Component {
     const colorFields = this.state.colors.map((x, i) => {
       // only let colors be removed if there's more than two present
       const closeButton = (this.state.colors.length > 2 && i === this.state.colors.length - 1)
-        ? (<div
-          style={{
-            background: 'white',
-            position: 'absolute',
-            top: 0,
-            right: 0,
-            opacity: 1,
-            width: 14,
-            height: 14,
-            borderRadius: 2,
-
-          }}
-        >
-          <svg
-            height="10px"
-            onClick={() => this.handleRemoveColor(i)}
+        ? (
+          <div
             style={{
+              background: 'white',
               position: 'absolute',
-              top: 2,
-              right: 2,
-              opacity: 0.5,
-              width: 10,
-              height: 10,
+              top: 0,
+              right: 0,
+              opacity: 1,
+              width: 14,
+              height: 14,
+              borderRadius: 2,
+
             }}
           >
-            <use xlinkHref="#cross" />
-          </svg>
-           </div>
+            <svg
+              height="10px"
+              onClick={() => this.handleRemoveColor(i)}
+              style={{
+                position: 'absolute',
+                top: 2,
+                right: 2,
+                opacity: 0.5,
+                width: 10,
+                height: 10,
+              }}
+            >
+              <use xlinkHref="#cross" />
+            </svg>
+          </div>
         )
         : null; // closebutton
 

--- a/app/scripts/HorizontalLine1DPixiTrack.js
+++ b/app/scripts/HorizontalLine1DPixiTrack.js
@@ -287,6 +287,22 @@ class HorizontalLine1DPixiTrack extends HorizontalTiled1DPixiTrack {
 
     return [base, track];
   }
+
+  tileToLocalId(tile) {
+    // tile
+    if (this.options.summary && this.options.summary !== 'mean') {
+      return `${tile.join('.')}.${this.options.summary}`;
+    }
+    return `${tile.join('.')}`;
+  }
+
+  tileToRemoteId(tile) {
+    // tile
+    if (this.options.summary && this.options.summary !== 'mean') {
+      return `${tile.join('.')}.${this.options.summary}`;
+    }
+    return `${tile.join('.')}`;
+  }
 }
 
 export default HorizontalLine1DPixiTrack;


### PR DESCRIPTION
## Description

For bigwig files, this allows users to see max, min, and mean (old behavior, default) summary statistics for tiles. Although it changes the request patterns for other non-bigwig file types, the changed tileids have no impact unless clodius is changed to support the summary pattern in the tileids.

Why is it necessary?

The goal of this change is to support users seeing the maximum and minimum values inside a tile as they zoom out. A track could be set up to see min, max, and mean simlutaneously.

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example added or updated
- [ ] Screenshot for visual changes (e.g. new tracks)
- [ ] Updated CHANGELOG.md
