### PR TITLE
Mccalluc/eslint no restricted globals

### DIFF
--- a/.eslintrc-minimal
+++ b/.eslintrc-minimal
@@ -31,7 +31,7 @@
   },
   "rules": {
     // Turn a lot of rules off: We plan to fix one kind of error at a time, so we can remove these exceptions,
-    // and eventually delete this file and just have one .exlintrc. 
+    // and eventually delete this file and just have one .exlintrc.
     "import/no-extraneous-dependencies": 0,
     "jsx-a11y/anchor-is-valid": 0,
     "jsx-a11y/click-events-have-key-events": 0,
@@ -40,7 +40,6 @@
     "jsx-a11y/role-has-required-aria-props": 0,
     "no-param-reassign": 0,
     "no-prototype-builtins": 0,
-    "no-restricted-globals": 0,
     "no-return-assign": 0,
     "no-undef": 0,
     "no-unused-vars": 0,
@@ -51,7 +50,7 @@
     "react/no-unused-prop-types": 0,
     "react/no-unused-state": 0,
     "react/require-default-props": 0,
-    
+
     // By default, this is a warning, but most properties were in order,
     // and the few exceptions added a lot of noise to the logs.
     "react/jsx-sort-props": ["error"],

--- a/app/scripts/GenomePositionSearchBox.js
+++ b/app/scripts/GenomePositionSearchBox.js
@@ -551,8 +551,8 @@ class GenomePositionSearchBox extends React.Component {
         }
 
         if (
-          (range1 && (isNaN(range1[0]) || isNaN(range1[1])))
-          || (range2 && (isNaN(range2[0]) || isNaN(range2[1])))) {
+          (range1 && (Number.isNaN(+range1[0]) || Number.isNaN(+range1[1])))
+          || (range2 && (Number.isNaN(+range2[0]) || Number.isNaN(+range2[1])))) {
           return;
         }
 

--- a/app/scripts/GenomePositionSearchBox.js
+++ b/app/scripts/GenomePositionSearchBox.js
@@ -504,7 +504,7 @@ class GenomePositionSearchBox extends React.Component {
 
       const [chr, pos, retPos] = this.searchField.parsePosition(valueParts[i]);
 
-      if (retPos === null || isNaN(retPos)) {
+      if (retPos === null || Number.isNaN(+retPos)) {
         // not a chromsome position, let's see if it's a gene name
         const url = `${this.state.autocompleteServer}/suggest/?d=${this.state.autocompleteId}&ac=${valueParts[i].toLowerCase()}`;
         requests.push(tileProxy.json(url, toVoid, this.props.pubSub));

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -3087,7 +3087,7 @@ class HiGlassComponent extends React.Component {
     }
 
     if (
-      isNaN(start1Abs) || isNaN(end1Abs)
+      Number.isNaN(+start1Abs) || Number.isNaN(+end1Abs)
     ) {
       const coords = [start1Abs, end1Abs].join(', ');
       console.warn([
@@ -3098,7 +3098,7 @@ class HiGlassComponent extends React.Component {
       return;
     }
 
-    if (isNaN(start2Abs) || isNaN(end2Abs)
+    if (Number.isNaN(+start2Abs) || Number.isNaN(+end2Abs)
       || start2Abs === null || end2Abs === null) {
       start2Abs = start1Abs;
       end2Abs = end1Abs;

--- a/app/scripts/SearchField.js
+++ b/app/scripts/SearchField.js
@@ -88,7 +88,7 @@ class SearchField {
 
     let retPos = null;
 
-    if (isNaN(pos)) { retPos = null; }
+    if (Number.isNaN(pos)) { retPos = null; }
 
     // queries like chr1:1000-2000
     if (chr === null) { chr = prevChr; }

--- a/app/scripts/ValueIntervalTrack.js
+++ b/app/scripts/ValueIntervalTrack.js
@@ -75,7 +75,7 @@ class ValueIntervalTrack extends HorizontalLine1DPixiTrack {
 
     const min = Math.min.apply(null, visibleAndFetchedIds.map(
       x => +Math.min(...(this.fetchedTiles[x].tileData
-        .filter(y => !isNaN(y.fields[3]))
+        .filter(y => !Number.isNaN(y.fields[3]))
         .map(y => +y.fields[3])))
     ));
 
@@ -92,7 +92,7 @@ class ValueIntervalTrack extends HorizontalLine1DPixiTrack {
 
     const max = Math.max.apply(null, visibleAndFetchedIds.map(
       x => +Math.max(...(this.fetchedTiles[x].tileData
-        .filter(y => !isNaN(y.fields[3]))
+        .filter(y => !Number.isNaN(y.fields[3]))
         .map(y => +y.fields[3])))
     ));
 

--- a/app/scripts/worker.js
+++ b/app/scripts/worker.js
@@ -108,7 +108,7 @@ export function workerSetPix(
       // and its mirror will fill in that space
       if (ignoreUpperRight && Math.floor(i / tileWidth) < i % tileWidth) {
         rgbIdx = 255;
-      } else if (isNaN(d)) {
+      } else if (Number.isNaN(+d)) {
         rgbIdx = 255;
       } else {
         // values less than espilon are considered NaNs and made transparent (rgbIdx 255)


### PR DESCRIPTION
## Description

What was changed in this pull request?

Enforce `no-restricted-globals`:
- No bare `isNaN` calls.
- See earlier discussion at https://github.com/higlass/higlass/pull/399#discussion_r235588487 
  - If we know that the the argument is numeric, `Number.isNaN` is sufficient.
  - If not, the argument should be cast first... but unary plus is less verbose than `Number()`, but still clear enough, I think?

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example added or updated
- [ ] Screenshot for visual changes (e.g. new tracks)
- [ ] Updated CHANGELOG.md
