### PR TITLE
Enforce no-children-prop

### DIFF
--- a/.eslintrc-minimal
+++ b/.eslintrc-minimal
@@ -43,7 +43,6 @@
     "no-undef": 0,
     "no-unused-vars": 0,
     "react/no-array-index-key": 0,
-    "react/no-children-prop": 0,
     "react/no-find-dom-node": 0,
     "react/no-unused-prop-types": 0,
     "react/no-unused-state": 0,

--- a/app/scripts/Autocomplete.js
+++ b/app/scripts/Autocomplete.js
@@ -376,9 +376,10 @@ Autocomplete.defaultProps = {
     return (
       /* eslint-disable react/no-this-in-sfc */
       <div
-        children={items}
         style={{ ...style, ...this.menuStyle }}
-      />
+      >
+        {items}
+      </div>
       /* eslint-enable react/no-this-in-sfc */
     );
   },

--- a/app/scripts/GenomePositionSearchBox.js
+++ b/app/scripts/GenomePositionSearchBox.js
@@ -644,18 +644,16 @@ class GenomePositionSearchBox extends React.Component {
 
   handleRenderMenu(items) {
     return (
-      <PopupMenu
-        children={items}
-      >
+      <PopupMenu>
         <div
-          children={items}
           style={{
             left: this.menuPosition.left,
             top: this.menuPosition.top,
           }}
           styleName="styles.genome-position-search-bar-suggestions"
-        />
-
+        >
+          {items}
+        </div>
       </PopupMenu>
     );
   }


### PR DESCRIPTION
Locally, searching for a gene seems to work the same as before.

## Description

What was changed in this pull request?

- Enforce no-children-prop
- My guess is the `children` attribute on PopupMenu was being ignored, since a child element was already supplied?

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example added or updated
- [ ] Screenshot for visual changes (e.g. new tracks)
- [ ] Updated CHANGELOG.md
