### PR TITLE
Mccalluc/fix some easy warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -56,7 +56,7 @@
     "react/jsx-key": 1,
     "react/jsx-max-props-per-line": 1,
     "react/jsx-no-bind": [0, {"ignoreRefs": true }],
-    "react/jsx-no-duplicate-props": 1,
+    "react/jsx-no-duplicate-props": 2,
     "react/jsx-no-literals": 0,
     "react/jsx-no-undef": 1,
     "react/jsx-pascal-case": 1,

--- a/.eslintrc
+++ b/.eslintrc
@@ -48,7 +48,7 @@
     "react/jsx-boolean-value": 0,
     "react/jsx-closing-bracket-location": 1,
     "react/jsx-curly-spacing": 1,
-    "react/jsx-equals-spacing": 1,
+    "react/jsx-equals-spacing": 2,
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "react/jsx-handler-names": 0,
     "react/jsx-indent": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -34,6 +34,7 @@
     "jsx-quotes": 1,
     "no-bitwise": 0,
     "no-console": ["error", { "allow": ["warn", "error"] }],
+    "no-constant-condition": 2,
     "no-continue": 0,
     "no-mixed-operators": 0,
     "no-multi-spaces": ["error", { "ignoreEOLComments": true }],

--- a/.eslintrc-minimal
+++ b/.eslintrc-minimal
@@ -82,7 +82,7 @@
     "react/jsx-key": 1,
     "react/jsx-max-props-per-line": 1,
     "react/jsx-no-bind": [0, {"ignoreRefs": true }],
-    "react/jsx-no-duplicate-props": 1,
+    "react/jsx-no-duplicate-props": 2,
     "react/jsx-no-literals": 0,
     "react/jsx-no-undef": 1,
     "react/jsx-pascal-case": 1,

--- a/.eslintrc-minimal
+++ b/.eslintrc-minimal
@@ -60,6 +60,7 @@
     "jsx-quotes": 1,
     "no-bitwise": 0,
     // "no-console": ["error", { "allow": ["warn", "error"] }],
+    "no-constant-condition": 2,
     "no-continue": 0,
     "no-mixed-operators": 0,
     // "no-multi-spaces": ["error", { "ignoreEOLComments": true }],

--- a/.eslintrc-minimal
+++ b/.eslintrc-minimal
@@ -31,7 +31,7 @@
   },
   "rules": {
     // Turn a lot of rules off: We plan to fix one kind of error at a time, so we can remove these exceptions,
-    // and eventually delete this file and just have one .exlintrc. 
+    // and eventually delete this file and just have one .exlintrc.
     "jsx-a11y/anchor-is-valid": 0,
     "jsx-a11y/click-events-have-key-events": 0,
     "jsx-a11y/no-noninteractive-element-interactions": 0,
@@ -74,7 +74,7 @@
     "react/jsx-boolean-value": 0,
     "react/jsx-closing-bracket-location": 1,
     "react/jsx-curly-spacing": 1,
-    "react/jsx-equals-spacing": 1,
+    "react/jsx-equals-spacing": 2,
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "react/jsx-handler-names": 0,
     "react/jsx-indent": 0,

--- a/app/scripts/TiledPlot.js
+++ b/app/scripts/TiledPlot.js
@@ -1609,7 +1609,6 @@ class TiledPlot extends React.Component {
       <DragListeningDiv
         draggingHappening={this.props.draggingHappening}
         enabled={centerAllowed}
-        enabled={centerAllowed}
         onTrackDropped={track => this.handleTracksAdded([track], 'center')}
         position="center"
 

--- a/app/scripts/ViewHeader.js
+++ b/app/scripts/ViewHeader.js
@@ -119,7 +119,7 @@ class ViewHeader extends React.Component {
           onMenuClosed={() => this.setState({ configMenuUid: null })}
         >
           <ConfigViewMenu
-            onClearView = {() => {
+            onClearView={() => {
               this.setState({ configMenuUid: null }); // hide the menu
               this.props.onClearView();
             }}

--- a/app/scripts/services/tile-proxy.js
+++ b/app/scripts/services/tile-proxy.js
@@ -506,42 +506,40 @@ export const tileDataToPixData = (
 
   // comment this and uncomment the code afterwards to enable threading
 
-  if (true) {
-    const pixData = workerSetPix(
-      tileData.dense.length,
-      tileData.dense,
-      valueScaleType,
-      valueScaleDomain,
-      pseudocount,
-      colorScale,
-      ignoreUpperRight
-    );
+  const pixData = workerSetPix(
+    tileData.dense.length,
+    tileData.dense,
+    valueScaleType,
+    valueScaleDomain,
+    pseudocount,
+    colorScale,
+    ignoreUpperRight
+  );
 
-    finished({ pixData });
-  } else {
-    const newTileData = new Float32Array(tileData.dense.length);
-    newTileData.set(tileData.dense);
-    /*
-    var params = {
-      size: newTileData.length,
-      data: newTileData,
-      valueScaleType: valueScaleType,
-      valueScaleDomain: valueScaleDomain,
-      pseudocount: pseudocount,
-      colorScale: colorScale
-    };
+  finished({ pixData });
 
-    setPixPool.send(params, [ newTileData.buffer ])
-      .promise()
-      .then(returned => {
-        finished(returned);
-      })
-      .catch(reason => {
-        finished(null);
-      });
-    ;
-    */
-  }
+  // const newTileData = new Float32Array(tileData.dense.length);
+  // newTileData.set(tileData.dense);
+  /*
+  var params = {
+    size: newTileData.length,
+    data: newTileData,
+    valueScaleType: valueScaleType,
+    valueScaleDomain: valueScaleDomain,
+    pseudocount: pseudocount,
+    colorScale: colorScale
+  };
+
+  setPixPool.send(params, [ newTileData.buffer ])
+    .promise()
+    .then(returned => {
+      finished(returned);
+    })
+    .catch(reason => {
+      finished(null);
+    });
+  ;
+  */
 };
 
 function fetchEither(url, callback, textOrJson, pubSub) {


### PR DESCRIPTION
## Description

What was changed in this pull request?

- Change some lint warnings to errors

Warnings about order and whitespace don't feel that important to me, but `jsx-no-duplicate-props` seems like a good thing to turn on: If the properties were separated, and a developer made an edit to the first one, without seeing it's duplicate, it could be confusing. The remaining warnings are:

```
   5 func-names
   1 no-alert
   1 no-console
   2 react/no-danger
   2 react/no-did-mount-set-state
   2 react/no-direct-mutation-state
   2 react/no-string-refs
  55 react/prop-types
   1 react/react-in-jsx-scope
   6 react/sort-comp
```

The `react/no-*` issues might be worth looking at?



## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example added or updated
- [ ] Screenshot for visual changes (e.g. new tracks)
- [ ] Updated CHANGELOG.md
