### PR TITLE
Flekschas/overlay tracks 1d and 2d

### DIFF
--- a/app/scripts/OverlayTrack.js
+++ b/app/scripts/OverlayTrack.js
@@ -25,7 +25,7 @@ class OverlayTrack extends PixiTrack {
       const orientation = this.options.orientationsAndPositions[i].orientation;
       const position = this.options.orientationsAndPositions[i].position;
 
-      if (orientation === '1d-horizontal') {
+      if (orientation === '1d-horizontal' || orientation === '2d') {
         const xPos = this.position[0]
           + position.left
           + this._xScale(this.options.extent[0][0]);
@@ -39,7 +39,7 @@ class OverlayTrack extends PixiTrack {
         graphics.drawRect(xPos, yPos, width, height);
       }
 
-      if (orientation === '1d-vertical') {
+      if (orientation === '1d-vertical' || orientation === '2d') {
         const xPos = this.position[0] + position.left;
         const yPos = this.position[1]
           + position.top

--- a/app/scripts/OverlayTrack.js
+++ b/app/scripts/OverlayTrack.js
@@ -19,17 +19,9 @@ class OverlayTrack extends PixiTrack {
     graphics.clear();
     graphics.beginFill(fill, 0.3);
 
-    // console.log('_xScale', this._xScale.range());
-    // console.log('this.dimensions:', this.dimensions);
-
     for (let i = 0; i < this.options.orientationsAndPositions.length; i++) {
       const orientation = this.options.orientationsAndPositions[i].orientation;
       const position = this.options.orientationsAndPositions[i].position;
-
-      /*
-      console.log('this.position:', this.position);
-      console.log('position.left:', position.left);
-      */
 
       if (orientation === '1d-horizontal') {
         const xPos = this.position[0] + position.left
@@ -39,22 +31,8 @@ class OverlayTrack extends PixiTrack {
         const width = this._xScale(this.options.extent[0][1])
           - xPos + position.left + this.position[0];
 
-        /*
-        console.log('top:', yPos);
-        console.log('height:', position.height);
-        console.log('yPos:', yPos);
-        console.log('width:', width);
-        console.log('height:', height);
-        */
-
         graphics.drawRect(xPos, yPos, width, height);
       }
-
-      /*
-      console.log('orientation:', orientation);
-      console.log('position:', position);
-      console.log('this.extent', this.extent);
-      */
     }
   }
 
@@ -79,6 +57,7 @@ class OverlayTrack extends PixiTrack {
 
   exportSVG() {
     // TODO: implement me
+    console.warn('Overlay tracks cannot be exported as SVG yet.');
   }
 }
 

--- a/app/scripts/OverlayTrack.js
+++ b/app/scripts/OverlayTrack.js
@@ -14,7 +14,9 @@ class OverlayTrack extends PixiTrack {
   draw() {
     super.draw();
     const graphics = this.pMain;
-    const fill = colorToHex(this.options.fillColor ? this.options.fillColor : 'blue');
+    const fill = colorToHex(
+      this.options.fillColor ? this.options.fillColor : 'blue'
+    );
 
     graphics.clear();
     graphics.beginFill(fill, 0.3);
@@ -24,12 +26,15 @@ class OverlayTrack extends PixiTrack {
       const position = this.options.orientationsAndPositions[i].position;
 
       if (orientation === '1d-horizontal') {
-        const xPos = this.position[0] + position.left
+        const xPos = this.position[0]
+          + position.left
           + this._xScale(this.options.extent[0][0]);
         const yPos = this.position[1] + position.top;
         const height = position.height;
         const width = this._xScale(this.options.extent[0][1])
-          - xPos + position.left + this.position[0];
+          - xPos
+          + position.left
+          + this.position[0];
 
         graphics.drawRect(xPos, yPos, width, height);
       }

--- a/app/scripts/OverlayTrack.js
+++ b/app/scripts/OverlayTrack.js
@@ -38,6 +38,20 @@ class OverlayTrack extends PixiTrack {
 
         graphics.drawRect(xPos, yPos, width, height);
       }
+
+      if (orientation === '1d-vertical') {
+        const xPos = this.position[0] + position.left;
+        const yPos = this.position[1]
+          + position.top
+          + this._yScale(this.options.extent[0][0]);
+        const width = position.width;
+        const height = this._yScale(this.options.extent[0][1])
+          - yPos
+          + position.top
+          + this.position[1];
+
+        graphics.drawRect(xPos, yPos, width, height);
+      }
     }
   }
 

--- a/app/scripts/OverlayTrack.js
+++ b/app/scripts/OverlayTrack.js
@@ -19,7 +19,7 @@ class OverlayTrack extends PixiTrack {
     );
 
     graphics.clear();
-    graphics.beginFill(fill, 0.3);
+    graphics.beginFill(fill, this.options.fillOpacity || 0.3);
 
     for (let i = 0; i < this.options.orientationsAndPositions.length; i++) {
       const orientation = this.options.orientationsAndPositions[i].orientation;

--- a/app/scripts/TiledPlot.js
+++ b/app/scripts/TiledPlot.js
@@ -974,11 +974,29 @@ class TiledPlot extends React.Component {
             orientationsAndPositions: overlayTrack.includes.map((trackUuid) => {
               // translate a trackUuid into that track's orientation
               const includedTrack = getTrackByUid(this.props.tracks, trackUuid);
+              const trackPos = includedTrack.position;
               if (!includedTrack) {
                 console.warn(`OverlayTrack included uid (${trackUuid}) not found in the track list`);
                 return null;
               }
-              const orientation = TRACKS_INFO_BY_TYPE[includedTrack.type].orientation;
+
+              let orientation;
+              if (trackPos === 'top' || trackPos === 'bottom') {
+                orientation = '1d-horizontal';
+              }
+
+              if (trackPos === 'left' || trackPos === 'right') {
+                orientation = '1d-vertical';
+              }
+
+              if (trackPos === 'center') {
+                orientation = '2d';
+              }
+
+              if (!orientation) {
+                console.warn('Only top, bottom, left, right, or center tracks can be overlaid at the moment');
+                return null;
+              }
 
               const positionedTrack = positionedTracks.filter(
                 track => track.track.uid === trackUuid
@@ -989,6 +1007,7 @@ class TiledPlot extends React.Component {
                 // an invalid uuid
                 return null;
               }
+
               const position = {
                 left: positionedTrack[0].left,
                 top: positionedTrack[0].top,

--- a/docs/examples/viewconfs/overlay-tracks.json
+++ b/docs/examples/viewconfs/overlay-tracks.json
@@ -1,0 +1,106 @@
+{
+  "editable": true,
+  "zoomFixed": false,
+  "trackSourceServers": ["http://higlass.io/api/v1"],
+  "exportViewUrl": "http://localhost:8000/api/v1/viewconfs/",
+  "views": [{
+    "uid": "aa",
+    "initialXDomain": [-128227010, 3227095876],
+    "initialYDomain": [-679063376, 3737688490],
+    "autocompleteSource": "http://higlass.io/api/v1/suggest/?d=OHJakQICQD6gTD7skx4EWA&",
+    "genomePositionSearchBoxVisible": false,
+    "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
+    "tracks": {
+      "top": [{
+        "server": "http://higlass.io/api/v1",
+        "tilesetUid": "OHJakQICQD6gTD7skx4EWA",
+        "uid": "genes-top",
+        "type": "horizontal-gene-annotations"
+      }, {
+        "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
+        "type": "horizontal-chromosome-labels",
+        "position": "top",
+        "uid": "chroms-top"
+      }],
+      "left": [{
+        "server": "http://higlass.io/api/v1",
+        "tilesetUid": "OHJakQICQD6gTD7skx4EWA",
+        "uid": "genes-left",
+        "type": "vertical-gene-annotations"
+      }, {
+        "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
+        "type": "vertical-chromosome-labels",
+        "position": "left",
+        "name": "Chromosome Labels (hg19)",
+        "uid": "chroms-left"
+      }],
+      "center": [{
+        "uid": "center",
+        "type": "combined",
+        "contents": [{
+          "data": {
+            "type": "divided",
+            "children": [{
+              "server": "http://higlass.io/api/v1",
+              "tilesetUid": "CQMd6V_cRw6iCI_-Unl3PQ"
+            }, {
+              "server": "http://higlass.io/api/v1",
+              "tilesetUid": "ZCvntCKST0KUvQPGcCbJGA"
+            }]
+          },
+          "type": "heatmap",
+          "position": "center",
+          "options": {
+            "colorRange": ["#FFFFFF", "#F8E71C", "#F5A623", "#D0021B"],
+            "colorbarPosition": "topRight",
+            "colorbarLabelsPosition": "outside",
+            "maxZoom": null,
+            "labelPosition": "bottomLeft",
+            "name": "Rao et al. (2014) GM12878 MboI (allreps) 1kb",
+            "trackBorderWidth": 0,
+            "trackBorderColor": "black",
+            "heatmapValueScaling": "log",
+            "scaleStartPercent": "0.00000",
+            "scaleEndPercent": "1.00000"
+          },
+          "uid": "heatmap",
+          "name": "Rao et al. (2014) GM12878 MboI (allreps) 1kb",
+          "transforms": [{
+            "name": "ICE",
+            "value": "weight"
+          }]
+        }, {
+          "type": "2d-chromosome-grid",
+          "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
+          "tilesetUid": "TIlwFtqxTX-ndtM7Y9k1bw",
+          "uid": "LUVqXXu2QYiO8XURIwyUyA",
+          "options": {
+            "lineStrokeWidth": 1,
+            "lineStrokeColor": "grey"
+          }
+        }]
+      }],
+      "right": [],
+      "bottom": []
+    },
+    "layout": {
+      "w": 12,
+      "h": 12,
+      "x": 0,
+      "y": 0,
+      "i": "aa",
+      "moved": false,
+      "static": false
+    },
+    "overlays": [{
+      "uid": "overlay",
+      "type": "",
+      "includes": ["chroms-top", "chroms-left", "genes-top", "genes-left", "center"],
+      "options": {
+        "extent": [
+          [1000000000, 1100000000]
+        ]
+      }
+    }]
+  }]
+}

--- a/test/OverlayTrackTests.js
+++ b/test/OverlayTrackTests.js
@@ -33,14 +33,27 @@ describe('Overlay Track:', () => {
 
       expect(numNormalTracks).toEqual(4);
 
-      const posTracks = hgc.tiledPlots[viewConf.views[0].uid]
-        .trackRenderer.props.positionedTracks;
+      const trackRenderer = hgc.tiledPlots[viewConf.views[0].uid]
+        .trackRenderer;
+
+      const posTracks = trackRenderer.props.positionedTracks;
 
       expect(posTracks.length).toEqual(5);
 
       const overlayTrack = posTracks[posTracks.length - 1];
 
+      console.log(trackRenderer.trackDefObjects[overlayTrack.track.uid]);
+
       expect(overlayTrack.track.type).toEqual('overlay-track');
+
+      const overlayTrackInfo = trackRenderer
+        .trackDefObjects[overlayTrack.track.uid];
+
+      const overlayTrackDef = overlayTrackInfo.trackDef;
+      const overlayTrackObj = overlayTrackInfo.trackObject;
+
+      expect(overlayTrackDef.width).toEqual(overlayTrackObj.dimensions[0]);
+      expect(overlayTrackDef.height).toEqual(overlayTrackObj.dimensions[1]);
 
       done();
     });

--- a/test/OverlayTrackTests.js
+++ b/test/OverlayTrackTests.js
@@ -1,0 +1,55 @@
+/* eslint-env node, jasmine */
+
+// Utils
+// import {
+//   getTrackObjectFromHGC,
+//   waitForTilesLoaded
+// } from '../app/scripts/utils';
+
+import createElementAndApi from './utils/create-element-and-api';
+import removeDiv from './utils/remove-div';
+
+import overlayAnnotations1d2dViewConf from './view-configs/overlay-annotations-1d-2d';
+
+describe('Overlay Track:', () => {
+  let hgc = null;
+  let api = null;
+  let div = null;
+  let viewConf;
+
+  describe('Annotation overlays:', () => {
+    it('Should render', (done) => {
+      viewConf = overlayAnnotations1d2dViewConf;
+
+      [div, api] = createElementAndApi(viewConf, { bound: true });
+
+      hgc = api.getComponent();
+
+      const numNormalTracks = viewConf.views[0].tracks.top.length
+        + viewConf.views[0].tracks.right.length
+        + viewConf.views[0].tracks.bottom.length
+        + viewConf.views[0].tracks.left.length
+        + viewConf.views[0].tracks.center.length;
+
+      expect(numNormalTracks).toEqual(4);
+
+      const posTracks = hgc.tiledPlots[viewConf.views[0].uid]
+        .trackRenderer.props.positionedTracks;
+
+      expect(posTracks.length).toEqual(5);
+
+      const overlayTrack = posTracks[posTracks.length - 1];
+
+      expect(overlayTrack.track.type).toEqual('overlay-track');
+
+      done();
+    });
+
+    afterEach(() => {
+      if (api && api.destroy) api.destroy();
+      if (div) removeDiv(div);
+      api = undefined;
+      div = undefined;
+    });
+  });
+});

--- a/test/OverlayTrackTests.js
+++ b/test/OverlayTrackTests.js
@@ -42,8 +42,6 @@ describe('Overlay Track:', () => {
 
       const overlayTrack = posTracks[posTracks.length - 1];
 
-      console.log(trackRenderer.trackDefObjects[overlayTrack.track.uid]);
-
       expect(overlayTrack.track.type).toEqual('overlay-track');
 
       const overlayTrackInfo = trackRenderer

--- a/test/view-configs/overlay-annotations-1d-2d.js
+++ b/test/view-configs/overlay-annotations-1d-2d.js
@@ -1,0 +1,63 @@
+const viewConf = {
+  editable: false,
+  zoomFixed: false,
+  views: [{
+    uid: 'aa',
+    initialXDomain: [-128227010, 3227095876],
+    tracks: {
+      top: [
+        {
+          server: 'http://higlass.io/api/v1',
+          tilesetUid: 'OHJakQICQD6gTD7skx4EWA',
+          uid: 'genes-top',
+          type: 'horizontal-gene-annotations'
+        },
+        {
+          chromInfoPath: '//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv',
+          type: 'horizontal-chromosome-labels',
+          position: 'top',
+          uid: 'chroms-top'
+        }
+      ],
+      left: [
+        {
+          server: 'http://higlass.io/api/v1',
+          tilesetUid: 'OHJakQICQD6gTD7skx4EWA',
+          uid: 'genes-left',
+          type: 'vertical-gene-annotations'
+        },
+        {
+          chromInfoPath: '//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv',
+          type: 'vertical-chromosome-labels',
+          position: 'left',
+          name: 'Chromosome Labels (hg19)',
+          uid: 'chroms-left'
+        }
+      ],
+      center: [],
+      right: [],
+      bottom: []
+    },
+    layout: {
+      w: 12,
+      h: 12,
+      x: 0,
+      y: 0,
+      i: 'aa',
+      moved: false,
+      static: false
+    },
+    overlays: [{
+      uid: 'overlay',
+      type: '',
+      includes: ['chroms-top', 'chroms-left', 'genes-top', 'genes-left'],
+      options: {
+        extent: [
+          [1000000000, 1100000000]
+        ]
+      }
+    }]
+  }]
+};
+
+export default viewConf;


### PR DESCRIPTION
## Description

> What was changed in this pull request?

This PR adds support for 1D vertical and 2D overlay tracks. Overlay tracks also support the option `fillOpacity` now.

> Why is it necessary?

Because previously overlay tracks were only visible for 1D horizontal tracks.

<img width="952" alt="screen shot 2019-01-11 at 5 04 36 pm" src="https://user-images.githubusercontent.com/932103/51065609-064c9900-15c3-11e9-9b85-b310cab78703.png">

## Checklist

- [x] Unit tests added or updated
- [ ] Documentation added or updated
- [x] Example added or updated
- [x] Screenshot for visual changes (e.g. new tracks)
- [ ] ~Updated CHANGELOG.md~
