### PR TITLE
Flekschas/expose mix library to plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add a fudge factor to ensure that the entire view is shown in the grid layout
 - Fix minified build
 - Fix a minor visual glitch in the gene annotation track
+- Expose `mix()` from `mixwith` to plugin tracks
 
 ## v1.2.8
 

--- a/app/scripts/configs/available-for-plugins.js
+++ b/app/scripts/configs/available-for-plugins.js
@@ -4,6 +4,7 @@
 
 // Libraries
 import * as PIXI from 'pixi.js';
+import { mix } from '../mixwith';
 
 // Tracks
 import Annotations2dTrack from '../Annotations2dTrack';
@@ -57,6 +58,7 @@ import * as configs from '.';
 
 const libraries = {
   PIXI,
+  mix,
 };
 
 const tracks = {


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Exposes `mix()` from `mixwith` to plugin tracks.

> Why is it necessary?

To avoid code duplication

## Checklist

- ~[ ] Unit tests added or updated~
- ~[ ] Documentation added or updated~
- ~[ ] Example added or updated~
- ~[ ] Screenshot for visual changes (e.g. new tracks)~
- [x] Updated CHANGELOG.md
