### PR TITLE
Removed the periodically broken test for API independence

### DIFF
--- a/test/APITests.js
+++ b/test/APITests.js
@@ -226,6 +226,10 @@ describe('API Tests', () => {
     });
 
     it('APIs are independent', (done) => {
+      [div, api] = createElementAndApi(
+        simpleCenterViewConfig, { editable: false, bounded: true }
+      );
+
       done();
       /* Turning this test off because it periodically
        * and inexplicablye fails


### PR DESCRIPTION
## Description

What was changed in this pull request?

Turned of the independent API tests.

Why is it necessary?

These tests would fail intermittently and our only solution was to restart. Better to turn them off until we figure out how to fix them.

## Checklist

- [x] Unit tests added or updated
- [o] Documentation added or updated
- [o] Example added or updated
- [o] Screenshot for visual changes (e.g. new tracks)
- [o] Updated CHANGELOG.md
