### PR TITLE
Update docs build commands

### DIFF
--- a/COMMANDS
+++ b/COMMANDS
@@ -1,4 +1,21 @@
-./node_modules/karma/bin/karma start karma.conf.js
+sphinx-autobuild -b html . _build/html -p 8062 --ignore "*.swp" -B
 
-git subtree pull --prefix docs hg-docs master
-git subtree push --prefix docs hg-docs develop
+git pull upstream develop
+git add _build/html/*.html
+
+sed -i.bak 's/\.\.\/app/\.\.\/higlass\/app/g' conf.py;rm -rf _build; sphinx-build -b html . _build/html; touch _build/html/.nojekyll; cp CNAME _build/html;
+# cat _build/html/index.rst | grep -v "development docs" > _build/html/index.rst
+cat index.rst | grep -v "develoment" > index.rst
+cat _build/html/index.html | grep -v "^$" > _build/html/index.html
+
+find _build/html/ -name "*.html" | xargs git add
+find _build/html/ -name "*.png" | xargs git add
+find _build/html/ -name "*.mp4" | xargs git add
+find _build/html/ -name "*.js" | xargs git add
+find _build/html/ -name "*.css" | xargs git add
+find _build/html/ -name ".nojekyll" | xargs git add
+find _build/html/ -name "CNAME" | xargs git add
+find _build/html/ -name "*.gif" | xargs git add
+
+#git subtree push --prefix _build/html/ origin gh-pages
+git push origin `git subtree split --prefix _build/html master`:gh-pages --force

--- a/docs/COMMANDS
+++ b/docs/COMMANDS
@@ -1,5 +1,17 @@
 sphinx-autobuild -b html . _build/html -p 8062 --ignore "*.swp" -B
 
 git pull upstream develop
-rm -rf _build; sphinx-build -b html . _build/html; touch _build/html/.nojekyll; cp CNAME _build/html;
-git subtree push --prefix _build/html/ origin gh-pages
+git add _build/html/*.html
+
+find _build/html/ -name "*.html" | xargs git add
+find _build/html/ -name "*.png" | xargs git add
+find _build/html/ -name "*.mp4" | xargs git add
+find _build/html/ -name "*.js" | xargs git add
+find _build/html/ -name "*.css" | xargs git add
+find _build/html/ -name ".nojekyll" | xargs git add
+find _build/html/ -name "CNAME" | xargs git add
+find _build/html/ -name "*.gif" | xargs git add
+
+sed -i.bak 's/\.\.\/app/\.\.\/higlass\/app/g' conf.py;rm -rf _build; sphinx-build -b html . _build/html; touch _build/html/.nojekyll; cp CNAME _build/html;
+#git subtree push --prefix _build/html/ origin gh-pages
+git push origin `git subtree split --prefix _build/html master`:gh-pages --force


### PR DESCRIPTION
## Description

Small PR to update the docs build reference commands.

Why is it necessary?

I look at these commands whenever I rebuild the docs in the `higlass-docs-dev` and `higlass-docs` repos. Because the current procedure is to push the `docs` subtree to each of those repositories, the reference commands need to be up-to-date here.

This is like meta-documentation. Documentation about how to build the documentation.

## Checklist

- [ ] Unit tests added or updated
- [x] Documentation added or updated
- [ ] Example added or updated
- [ ] Screenshot for visual changes (e.g. new tracks)
- [ ] Updated CHANGELOG.md
