### PR TITLE
Add an example of a tile response

### DIFF
--- a/docs/higlass_server.rst
+++ b/docs/higlass_server.rst
@@ -174,6 +174,21 @@ To modify a tileset name, specify the tileset `uuid` in the URL, use the `PATCH`
 
     curl --user ${username}:${password} --request PATCH --header "Content-Type: application/json" --data '{"name":"new_name_of_tileset"}' http://localhost:8000/api/v1/tilesets/${uuid}/ 
       
+Tile JSON Response Format
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Tiles returned by the server vary according to the data type but
+all are indexed by their tile id:
+
+.. code-block:: bash
+
+  {
+    "OHJakQICQD6gTD7skx4EWA.3.2": [
+      { "uid": "US2sjy_8SlGuy-0iSshcDQ", "importance": 457.0, "fields": [...] }
+    ]
+  }
+
+
 Management commands 
 ^^^^^^^^^^^^^^^^^^^ 
 

--- a/docs/higlass_server.rst
+++ b/docs/higlass_server.rst
@@ -178,7 +178,8 @@ Tile JSON Response Format
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Tiles returned by the server vary according to the data type but
-all are indexed by their tile id:
+all are indexed by their tile id. The example below is a tile response
+from a bedlike track.
 
 .. code-block:: bash
 
@@ -188,6 +189,12 @@ all are indexed by their tile id:
     ]
   }
 
+The `uid` is used to unique identify annotations. This is necessary
+because annotations that span multiple tiles are returned in every tile
+they intersect. The `importance` determines the priority with which
+annotations are hidden. Annotations with a lower `importance` are hidden
+before annotations with a higher importance. The `fields` field
+contains the actual columns from the bed file.
 
 Management commands 
 ^^^^^^^^^^^^^^^^^^^ 


### PR DESCRIPTION
## Description

Update the docs to include a sample tile response.

Why is it necessary?

So one doesn't have to open the developer console to see what tile responses look like.

## Checklist

- [ ] Unit tests added or updated
- [x] Documentation added or updated
- [ ] Example added or updated
- [ ] Screenshot for visual changes (e.g. new tracks)
- [ ] Updated CHANGELOG.md
