### PR TITLE
Added doc about `APP_BASEPATH`

### DIFF
--- a/docs/higlass_server.rst
+++ b/docs/higlass_server.rst
@@ -16,6 +16,8 @@ server is started:
 
     export OPTION=value; python manage.py runserver
 
+``APP_BASEPATH`` - Allow access to the admin interface at ``http://server.com/$APP_BASEPATH/admin``. 
+
 ``BASE_DIR`` - Set the Django base directory. This is where Django will 
 look for the database and the media directories.
 


### PR DESCRIPTION
## Description

> What was changed in this pull request?

The `APP_BASEPATH` setting can be used to specify where the higlass server should look for the admin interface.

## Checklist

- ~[ ] Unit tests added or updated~
- [x] Documentation added or updated
- ~[ ] Example added or updated~
- ~[ ] Screenshot for visual changes (e.g. new tracks)~
- ~[ ] Updated CHANGELOG.md~
