### PR TITLE
Flekschas/fix value limit rendering issue with bar charts

### DIFF
--- a/app/scripts/BarTrack.js
+++ b/app/scripts/BarTrack.js
@@ -91,7 +91,7 @@ class BarTrack extends HorizontalLine1DPixiTrack {
     );
 
     // Important when when using `options.valueScaleMin` or
-    // `options.valueScaleMax` such that the y position later on doesn't get
+    // `options.valueScaleMax` such that the y position later on doesn't become
     // negative
     valueScale.clamp(true);
 

--- a/app/scripts/BarTrack.js
+++ b/app/scripts/BarTrack.js
@@ -210,11 +210,10 @@ class BarTrack extends HorizontalLine1DPixiTrack {
     super.draw();
 
     Object.values(this.fetchedTiles).forEach((tile) => {
+      const tDomain = tile.drawnAtScale.domain();
+      const xDomain = this._xScale.domain();
       // scaling between tiles
-      const tileK = (
-        (tile.drawnAtScale.domain()[1] - tile.drawnAtScale.domain()[0])
-        / (this._xScale.domain()[1] - this._xScale.domain()[0])
-      );
+      const tileK = (tDomain[1] - tDomain[0]) / (xDomain[1] - xDomain[0]);
 
       const newRange = this._xScale.domain().map(tile.drawnAtScale);
 

--- a/app/scripts/BarTrack.js
+++ b/app/scripts/BarTrack.js
@@ -90,6 +90,11 @@ class BarTrack extends HorizontalLine1DPixiTrack {
       0
     );
 
+    // Important when when using `options.valueScaleMin` or
+    // `options.valueScaleMax` such that the y position later on doesn't get
+    // negative
+    valueScale.clamp(true);
+
     this.valueScale = valueScale;
 
     const colorScale = valueScale.copy();

--- a/app/scripts/TiledPixiTrack.js
+++ b/app/scripts/TiledPixiTrack.js
@@ -185,11 +185,13 @@ class TiledPixiTrack extends PixiTrack {
   }
 
   setFixedValueScaleMin(value) {
-    this.fixedValueScaleMin = +value || null;
+    if (!Number.isNaN(value)) this.fixedValueScaleMin = +value;
+    else this.fixedValueScaleMin = null;
   }
 
   setFixedValueScaleMax(value) {
-    this.fixedValueScaleMax = +value || null;
+    if (!Number.isNaN(value)) this.fixedValueScaleMax = +value;
+    else this.fixedValueScaleMax = null;
   }
 
   checkValueScaleLimits() {


### PR DESCRIPTION
## Description

> What was changed in this pull request?

1. Fixed an issue preventing `hgApi.setTrackValueScaleLimits` from setting `0` as a limit.
2. Clamp `valueScale` of `BarTrack` as y positions can otherwise be negative which seems to result in bars not being plotted

> Why is it necessary?

Avoid missing bars that are larger than `valueScaleMax` as seen below:

![screen shot 2019-02-24 at 9 54 29 pm](https://user-images.githubusercontent.com/932103/53703346-060c9500-3ddf-11e9-8e37-01c49e6350d5.png)

Source: https://higlass.slack.com/archives/GD79YCB8C/p1551063296032800

## Checklist

- ~[ ] Unit tests added or updated~
- ~[ ] Documentation added or updated~
- ~[ ] Example added or updated~
- [x] Screenshot for visual changes (e.g. new tracks)
- [x] Updated CHANGELOG.md
