### PR TITLE
Flekschas/min height bar track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v1.5.0
 
 - Add a new option to tracks that support axis: `axisMargin` to add some margin to an axis. See [docs/examples/viewconfs/axis-margin.json](docs/examples/viewconfs/axis-margin.json) for an example
+- Add a new option to BarTrack for drawing bars with a min. height at positions where the value is zero. See [`/apis/svg.html?/viewconfs/bar-min-height-at-zero.json`](/apis/svg.html?/viewconfs/bar-min-height-at-zero.json) for an example.
 
 ## v1.4.2
 

--- a/app/scripts/BarTrack.js
+++ b/app/scripts/BarTrack.js
@@ -260,6 +260,7 @@ class BarTrack extends HorizontalLine1DPixiTrack {
     super.draw();
 
     if (this.options.demarcationLine) this.drawDemarcationLine();
+    else this.demarcationLine.clear();
 
     Object.values(this.fetchedTiles).forEach((tile) => {
       const domainScale = tile.drawnAtScale.domain();

--- a/app/scripts/BarTrack.js
+++ b/app/scripts/BarTrack.js
@@ -159,9 +159,26 @@ class BarTrack extends HorizontalLine1DPixiTrack {
       barSprite.width = this._xScale(tileX + tileWidth) - barSprite.x;
     }
 
+    const maxYPos = (
+      this.dimensions[1] - +this.options.barMinHeightAtZero || Infinity
+    );
+    const barMinHeightOpacity = (
+      this.options.barMinHeightAtZeroOpacity || opacity
+    );
+
     for (let i = 0; i < tileValues.length; i++) {
+      const value = tileValues[i] + pseudocount;
+
       xPos = this._xScale(tileXScale(i));
-      yPos = this.valueScale(tileValues[i] + pseudocount);
+      yPos = this.valueScale(value);
+
+      if (value === 0 && maxYPos !== null && yPos > maxYPos) {
+        yPos = maxYPos;
+        graphics.beginFill(colorHex, barMinHeightOpacity);
+      } else {
+        graphics.beginFill(colorHex, opacity);
+      }
+
       width = this._xScale(tileXScale(i + 1)) - xPos;
       height = this.dimensions[1] - yPos;
 

--- a/app/scripts/configs/options-info.js
+++ b/app/scripts/configs/options-info.js
@@ -210,12 +210,16 @@ export const OPTIONS_INFO = {
     name: 'Bar opacity',
     inlineOptions: OPACITY_OPTIONS,
   },
-  barMinHeightAtZero: {
-    name: 'Min. bar height at 0 vals',
-    inlineOptions: AVAILABLE_WIDTHS,
+  demarcationLine: {
+    name: 'Demarcation line',
+    inlineOptions: YES_NO,
   },
-  barMinHeightAtZeroOpacity: {
-    name: 'Opacity of min. bars at 0 vals',
+  demarcationLineColor: {
+    name: 'Demarcation color',
+    inlineOptions: AVAILABLE_COLORS,
+  },
+  demarcationLineOpacity: {
+    name: 'Demarcation opacity',
     inlineOptions: OPACITY_OPTIONS,
   },
   fillOpacity: {

--- a/app/scripts/configs/options-info.js
+++ b/app/scripts/configs/options-info.js
@@ -210,6 +210,14 @@ export const OPTIONS_INFO = {
     name: 'Bar opacity',
     inlineOptions: OPACITY_OPTIONS,
   },
+  barMinHeightAtZero: {
+    name: 'Min. bar height at 0 vals',
+    inlineOptions: AVAILABLE_WIDTHS,
+  },
+  barMinHeightAtZeroOpacity: {
+    name: 'Opacity of min. bars at 0 vals',
+    inlineOptions: OPACITY_OPTIONS,
+  },
   fillOpacity: {
     name: 'Fill Opacity',
     inlineOptions: OPACITY_OPTIONS,

--- a/app/scripts/configs/tracks-info.js
+++ b/app/scripts/configs/tracks-info.js
@@ -550,8 +550,9 @@ export const TRACKS_INFO = [
       'showMousePosition',
       'showTooltip',
       'aggregationMode',
-      'barMinHeightAtZero',
-      'barMinHeightAtZeroOpacity'
+      'demarcationLine',
+      'demarcationLineColor',
+      'demarcationLineOpacity',
     ],
     defaultOptions: {
       align: 'bottom',

--- a/app/scripts/configs/tracks-info.js
+++ b/app/scripts/configs/tracks-info.js
@@ -549,7 +549,9 @@ export const TRACKS_INFO = [
       'barOpacity',
       'showMousePosition',
       'showTooltip',
-      'aggregationMode'
+      'aggregationMode',
+      'barMinHeightAtZero',
+      'barMinHeightAtZeroOpacity'
     ],
     defaultOptions: {
       align: 'bottom',
@@ -590,7 +592,9 @@ export const TRACKS_INFO = [
       'barOpacity',
       'showMousePosition',
       'showTooltip',
-      'aggregationMode'
+      'aggregationMode',
+      'barMinHeightAtZero',
+      'barMinHeightAtZeroOpacity'
     ],
     defaultOptions: {
       align: 'bottom',

--- a/docs/examples/apis/svg.html
+++ b/docs/examples/apis/svg.html
@@ -41,49 +41,48 @@
 </body>
 <script src='/hglib.js'></script>
 <script>
-if (!location.search.slice(1)) {
-  location.search = '?/viewconfs/default.json';
+if (!window.location.search.slice(1)) {
+  window.location.search = '?/viewconfs/default.json';
 } else {
   const urlInput = document.getElementById('url');
-  urlInput.value = location.search.slice(1);
+  urlInput.value = window.location.search.slice(1);
   urlInput.onchange = (event) => {
     const url = event.target.value;
-    location.search = '?' + url;
-  }
+    window.location.search = '?' + url;
+  };
 
   fetch(
-    location.search.slice(1).replace(
+    window.location.search.slice(1).replace(
       'http://higlass.io/app/?config=',
       'http://higlass.io/api/v1/viewconfs/?d='
-    ))
-    .then((response) => {
-      return response.json();
-    })
+    )
+  )
+    .then(response => response.json())
     .then((viewconf) => {
-      const hgApi = hglib.viewer(
+      const hgApi = window.hglib.viewer(
         document.getElementById('demo'),
         viewconf,
         { bounded: true },
       );
 
+      let isRendering = false;
+
       function renderPreview() {
-        setTimeout(() => {
+        if (isRendering) return;
+
+        isRendering = true;
+
+        window.requestIdleCallback(() => {
           document.getElementById('preview').innerHTML = hgApi.exportAsSvg();
-        }, 1000);
-        // Issue #386 is for adding an "onLoad" event, which would be better than this.
+          isRendering = false;
+        });
       }
+
+      hgApi.on('location', renderPreview);
+      hgApi.on('viewConfig', renderPreview);
+
       renderPreview();
-
-      hgApi.on('location', (event) => {
-        console.log('location event', event);
-        renderPreview();
-      });
-
-      hgApi.on('viewConfig', (event) => {
-        console.log('viewConfig event', JSON.parse(event));
-        renderPreview();
-      });
     });
-  }
+}
 </script>
 </html>

--- a/docs/examples/examples.html
+++ b/docs/examples/examples.html
@@ -43,7 +43,7 @@
   <br />
   <a href="apis/svg.html?/viewconfs/axis-margin.json">axis-margin.json</a>
   <br />
-  <a href="apis/svg.html?/viewconfs/bar-min-height-at-zero.json">bar-min-height-at-zero.json</a>
+  <a href="apis/svg.html?/viewconfs/bar-demarcation.json">bar-demarcation.json</a>
   <br />
 
   <h2>Viewconf examples</h2>

--- a/docs/examples/examples.html
+++ b/docs/examples/examples.html
@@ -43,6 +43,8 @@
   <br />
   <a href="apis/svg.html?/viewconfs/axis-margin.json">axis-margin.json</a>
   <br />
+  <a href="apis/svg.html?/viewconfs/bar-min-height-at-zero.json">bar-min-height-at-zero.json</a>
+  <br />
 
   <h2>Viewconf examples</h2>
   <table>

--- a/docs/examples/viewconfs/bar-demarcation.json
+++ b/docs/examples/viewconfs/bar-demarcation.json
@@ -121,8 +121,8 @@
               "axisPositionHorizontal": "right",
               "labelColor": "black",
               "labelTextOpacity": 1,
-              "barMinHeightAtZero": 1,
-              "barMinHeightAtZeroOpacity": 0.5
+              "demarcationLine": true,
+              "demarcationLineColor": "red"
             }
           },
           {
@@ -137,8 +137,7 @@
               "axisPositionHorizontal": "right",
               "labelColor": "black",
               "labelTextOpacity": 1,
-              "barMinHeightAtZero": 1,
-              "barMinHeightAtZeroOpacity": 0.5
+              "demarcationLine": true
             }
           },
           {
@@ -153,8 +152,9 @@
               "axisPositionHorizontal": "right",
               "labelColor": "black",
               "labelTextOpacity": 1,
-              "barMinHeightAtZero": 1,
-              "barMinHeightAtZeroOpacity": 0.5
+              "demarcationLine": true,
+              "demarcationLineColor": "#000",
+              "demarcationLineOpacity": 0.1
             }
           },
           {
@@ -167,11 +167,11 @@
             "options": {
               "name": "GM12878-E116-H3K4me3.fc.signal",
               "barFillColor": "orange",
+              "barOpacity": 0.25,
               "axisPositionHorizontal": "right",
               "labelColor": "black",
               "labelTextOpacity": 1,
-              "barMinHeightAtZero": 1,
-              "barMinHeightAtZeroOpacity": 0.5
+              "demarcationLine": true
             }
           }
         ]

--- a/docs/examples/viewconfs/bar-min-height-at-zero.json
+++ b/docs/examples/viewconfs/bar-min-height-at-zero.json
@@ -1,0 +1,187 @@
+{
+  "zoomFixed": false,
+  "views": [
+    {
+      "layout": {
+        "w": 12,
+        "h": 6,
+        "x": 0,
+        "y": 0,
+        "i": "aa",
+        "moved": false,
+        "static": false
+      },
+      "uid": "aa",
+      "initialYDomain": [2541320068.253662, 2541325651.38588],
+      "initialXDomain": [2540172918.0011406, 2540208277.8385234],
+      "tracks": {
+        "left": [],
+        "top": [
+          {
+            "uid": "chrom-labels",
+            "height": 35,
+            "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
+            "type": "horizontal-chromosome-labels",
+            "options": {
+              "color": "#777777",
+              "stroke": "#FFFFFF",
+              "fontSize": 12
+            }
+          },
+          {
+            "uid": "gene-annotations",
+            "tilesetUid": "OHJakQICQD6gTD7skx4EWA",
+            "height": 60,
+            "server": "//higlass.io/api/v1",
+            "type": "horizontal-gene-annotations",
+            "options": {
+              "labelColor": "black",
+              "plusStrandColor": "black",
+              "labelPosition": "hidden",
+              "minusStrandColor": "black",
+              "fontSize": 11,
+              "showMousePosition": false,
+              "mousePositionColor": "#999999",
+              "geneAnnotationHeight": 10,
+              "geneLabelPosition": "outside",
+              "geneStrandSpacing": 4
+            }
+          },
+          {
+            "uid": "line1",
+            "tilesetUid": "PjIJKXGbSNCalUZO21e_HQ",
+            "height": 48,
+            "server": "//higlass.io/api/v1",
+            "type": "horizontal-line",
+            "options": {
+              "name": "GM12878-E116-H3K27ac.fc.signal",
+              "lineStrokeWidth": 2,
+              "lineStrokeColor": "blue",
+              "axisPositionHorizontal": "right",
+              "labelColor": "black",
+              "labelTextOpacity": 1
+            }
+          },
+          {
+            "uid": "line2",
+            "tilesetUid": "PdAaSdibTLK34hCw7ubqKA",
+            "height": 48,
+            "server": "//higlass.io/api/v1",
+            "type": "horizontal-line",
+            "options": {
+              "name": "GM12878-E116-H3K27me3.fc.signal",
+              "lineStrokeWidth": 2,
+              "lineStrokeColor": "turquoise",
+              "axisPositionHorizontal": "right",
+              "axisLabelFormatting": "scientific",
+              "labelColor": "black",
+              "labelTextOpacity": 1
+            }
+          },
+          {
+            "uid": "line3",
+            "tilesetUid": "e0DYtZBSTqiMLHoaimsSpg",
+            "height": 48,
+            "server": "//higlass.io/api/v1",
+            "type": "horizontal-line",
+            "options": {
+              "name": "GM12878-E116-H3K4me1.fc.signal",
+              "lineStrokeWidth": 2,
+              "lineStrokeColor": "red",
+              "axisPositionHorizontal": "right",
+              "labelColor": "black",
+              "labelTextOpacity": 1
+            }
+          },
+          {
+            "uid": "line4",
+            "tilesetUid": "cE0nGyd0Q_yVYSyBUe89Ww",
+            "height": 48,
+            "position": "top",
+            "server": "//higlass.io/api/v1",
+            "type": "horizontal-line",
+            "options": {
+              "name": "GM12878-E116-H3K4me3.fc.signal",
+              "lineStrokeWidth": 2,
+              "lineStrokeColor": "orange",
+              "axisPositionHorizontal": "right",
+              "labelColor": "black",
+              "labelTextOpacity": 1
+            }
+          },
+          {
+            "uid": "bar1",
+            "tilesetUid": "PjIJKXGbSNCalUZO21e_HQ",
+            "height": 48,
+            "server": "//higlass.io/api/v1",
+            "type": "horizontal-bar",
+            "options": {
+              "name": "GM12878-E116-H3K27ac.fc.signal",
+              "barFillColor": "blue",
+              "axisPositionHorizontal": "right",
+              "labelColor": "black",
+              "labelTextOpacity": 1,
+              "barMinHeightAtZero": 1,
+              "barMinHeightAtZeroOpacity": 0.5
+            }
+          },
+          {
+            "uid": "bar2",
+            "tilesetUid": "PdAaSdibTLK34hCw7ubqKA",
+            "height": 48,
+            "server": "//higlass.io/api/v1",
+            "type": "horizontal-bar",
+            "options": {
+              "name": "GM12878-E116-H3K27me3.fc.signal",
+              "barFillColor": "turquoise",
+              "axisPositionHorizontal": "right",
+              "labelColor": "black",
+              "labelTextOpacity": 1,
+              "barMinHeightAtZero": 1,
+              "barMinHeightAtZeroOpacity": 0.5
+            }
+          },
+          {
+            "uid": "bar3",
+            "tilesetUid": "e0DYtZBSTqiMLHoaimsSpg",
+            "height": 48,
+            "server": "//higlass.io/api/v1",
+            "type": "horizontal-bar",
+            "options": {
+              "name": "GM12878-E116-H3K4me1.fc.signal",
+              "barFillColor": "red",
+              "axisPositionHorizontal": "right",
+              "labelColor": "black",
+              "labelTextOpacity": 1,
+              "barMinHeightAtZero": 1,
+              "barMinHeightAtZeroOpacity": 0.5
+            }
+          },
+          {
+            "uid": "bar4",
+            "tilesetUid": "cE0nGyd0Q_yVYSyBUe89Ww",
+            "height": 48,
+            "position": "top",
+            "server": "//higlass.io/api/v1",
+            "type": "horizontal-bar",
+            "options": {
+              "name": "GM12878-E116-H3K4me3.fc.signal",
+              "barFillColor": "orange",
+              "axisPositionHorizontal": "right",
+              "labelColor": "black",
+              "labelTextOpacity": 1,
+              "barMinHeightAtZero": 1,
+              "barMinHeightAtZeroOpacity": 0.5
+            }
+          }
+        ]
+      },
+      "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv"
+    }
+  ],
+  "editable": true,
+  "exportViewUrl": "/api/v1/viewconfs",
+  "trackSourceServers": [
+    "//higlass.io/api/v1"
+  ]
+}

--- a/docs/track_types.rst
+++ b/docs/track_types.rst
@@ -207,8 +207,13 @@ Bar tracks display 1D vector data as bars.
 Options
 --------
 
-**axisLabelFormatting**: ['normal', 'scientific'] - Display the vertical axis labels as regular numbers or using scientific notation.
-**barFillColor**: - A valid color (e.g. ``black``) or to track the color of the bars use ``[glyph-color]``.
+- **axisLabelFormatting**: ['normal', 'scientific'] - Display the vertical axis labels as regular numbers or using scientific notation.
+
+- **barFillColor**: - A valid color (e.g. ``black``) or to track the color of the bars use ``[glyph-color]``.
+
+- **barMinHeightAtZero**: - Height in pixel of fake bars that are to be drawn at position where the value is zero if the height is greater than zero. Drawing something at positions with zero value can help to demarcate tracks. The resulting effect is similar to the plot produced by ``horizontal-line``, i.e., even if the value is zero a thin line is drawn.
+
+- **barMinHeightAtZeroOpacity**: - The opacity of bars drawn at positions where the value is zero. This option is useful to deemphasize the bars.
 
 **Demos:**
 

--- a/docs/track_types.rst
+++ b/docs/track_types.rst
@@ -209,11 +209,13 @@ Options
 
 - **axisLabelFormatting**: ['normal', 'scientific'] - Display the vertical axis labels as regular numbers or using scientific notation.
 
-- **barFillColor**: - A valid color (e.g. ``black``) or to track the color of the bars use ``[glyph-color]``.
+- **barFillColor**: A valid color (e.g. ``black``) or to track the color of the bars use ``[glyph-color]``.
 
-- **barMinHeightAtZero**: - Height in pixel of fake bars that are to be drawn at position where the value is zero if the height is greater than zero. Drawing something at positions with zero value can help to demarcate tracks. The resulting effect is similar to the plot produced by ``horizontal-line``, i.e., even if the value is zero a thin line is drawn.
+- **demarcationLine**: If ``true`` draw a demarcation line at the bottom of a bar track.
 
-- **barMinHeightAtZeroOpacity**: - The opacity of bars drawn at positions where the value is zero. This option is useful to deemphasize the bars.
+- **demarcationLineColor**: The color of the demarcation line. If ``undefined`` the bar fill color (``barFillColor``) will be used.
+
+- **demarcationLineOpacity**: The opacity of the demarcation line. If ``undefined`` the bar opacity (``barOpacity``) will be used.
 
 **Demos:**
 

--- a/test/BarTrackTests.js
+++ b/test/BarTrackTests.js
@@ -1,0 +1,63 @@
+/* eslint-env node, jasmine, mocha */
+import {
+  configure,
+  // render,
+} from 'enzyme';
+
+import Adapter from 'enzyme-adapter-react-16';
+
+import { expect } from 'chai';
+
+// Utils
+import {
+  colorToHex,
+  mountHGComponent,
+  removeHGComponent,
+  getTrackObjectFromHGC,
+  waitForTilesLoaded
+} from '../app/scripts/utils';
+
+import viewConf from './view-configs/bar';
+
+
+configure({ adapter: new Adapter() });
+
+describe('BarTrack tests', () => {
+  let hgc = null;
+  let div = null;
+
+  beforeAll((done) => {
+    ([div, hgc] = mountHGComponent(div, hgc, viewConf, done));
+  });
+
+  it('Ensures that the track was rendered', (done) => {
+    expect(hgc.instance().state.viewConfig.editable).to.eql(true);
+
+    const trackConf = viewConf.views[0].tracks.top[0];
+
+    const trackObj = getTrackObjectFromHGC(
+      hgc.instance(),
+      viewConf.views[0].uid,
+      trackConf.uid
+    );
+
+    waitForTilesLoaded(hgc.instance(), () => {
+      expect(trackObj.demarcationLine.fillColor)
+        .to.eql(colorToHex(trackConf.options.demarcationLineColor));
+
+      expect(trackObj.demarcationLine.fillAlpha)
+        .to.eql(trackConf.options.demarcationLineOpacity);
+
+      expect(
+        Object.values(trackObj.fetchedTiles).every(tile => tile.svgData)
+      ).to.eql(true);
+    });
+
+    done();
+  });
+
+  afterAll((done) => {
+    removeHGComponent(div);
+    done();
+  });
+});

--- a/test/view-configs/bar.js
+++ b/test/view-configs/bar.js
@@ -1,0 +1,48 @@
+const viewconfig = {
+  zoomFixed: false,
+  views: [
+    {
+      layout: {
+        w: 12,
+        h: 6,
+        x: 0,
+        y: 0,
+        i: 'aa',
+        moved: false,
+        static: false
+      },
+      uid: 'aa',
+      initialYDomain: [2541320068.253662, 2541325651.38588],
+      initialXDomain: [2540172918.0011406, 2540208277.8385234],
+      tracks: {
+        left: [],
+        top: [
+          {
+            uid: 'bar1',
+            tilesetUid: 'PjIJKXGbSNCalUZO21e_HQ',
+            height: 48,
+            server: '//higlass.io/api/v1',
+            type: 'horizontal-bar',
+            options: {
+              name: 'GM12878-E116-H3K27ac.fc.signal',
+              barFillColor: 'blue',
+              axisPositionHorizontal: 'right',
+              labelColor: 'black',
+              labelTextOpacity: 1,
+              demarcationLine: true,
+              demarcationLineColor: 'red',
+              demarcationLineOpacity: 0.5
+            }
+          }
+        ]
+      },
+      chromInfoPath: '//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv'
+    }
+  ],
+  editable: true,
+  exportViewUrl: '/api/v1/viewconfs',
+  trackSourceServers: [
+    '//higlass.io/api/v1'
+  ]
+};
+export default viewconfig;


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Adds two track options to BarTrack:

- **barMinHeightAtZero**: - Height in pixel of fake bars that are to be drawn at position where the value is zero if the height is greater than zero. Drawing something at positions with zero value can help to demarcate tracks. The resulting effect is similar to the plot produced by ``horizontal-line``, i.e., even if the value is zero a thin line is drawn.

- **barMinHeightAtZeroOpacity**: - The opacity of bars drawn at positions where the value is zero. This option is useful to deemphasize the bars.

> Why is it necessary?

Having multiple tacked sparse ChIP-seq tracks can be visually a bit confusing since peaks appear as unconnected spikes. Having a connecting line helps to differentiate tracks from one another

**Without**:

![screen shot 2019-03-05 at 10 59 22 am](https://user-images.githubusercontent.com/932103/53818350-ec319600-3f35-11e9-93f1-15f26c654e4a.png)

**With 2px (1px seems to work best)**:

![screen shot 2019-03-05 at 11 00 10 am](https://user-images.githubusercontent.com/932103/53818359-f05db380-3f35-11e9-802a-211a0bc30a74.png)


## Checklist

- [ ] Unit tests added or updated
- [x] Documentation added or updated
- [x] Example added or updated
- [x] Screenshot for visual changes (e.g. new tracks)
- [x] Updated CHANGELOG.md
