### PR TITLE
Convert to number before checking for NaN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add a new option to BarTrack for drawing a demarcation line at the bottom of the track, i.e., at the zero value. See [`/apis/svg.html?/viewconfs/bar-zero-line.json`](/apis/svg.html?/viewconfs/bar-zero-line.json) for an example.
 - Fixed an issue with small offsets when exporting bar tracks to SVG
 - Fixed an issue where bars in a `BarTrack` related to values higher than `valueScaleMax` were not drawn.
+- Fixed an issue with `hgApi.setTrackValueScaleLimits`
 - Fix #291: allow web page scrolling when zoomFixed is set to true
 - Fix #578: BarTrack SVG export overplotting error.
 

--- a/app/scripts/TiledPixiTrack.js
+++ b/app/scripts/TiledPixiTrack.js
@@ -185,12 +185,12 @@ class TiledPixiTrack extends PixiTrack {
   }
 
   setFixedValueScaleMin(value) {
-    if (!Number.isNaN(value)) this.fixedValueScaleMin = +value;
+    if (!Number.isNaN(+value)) this.fixedValueScaleMin = +value;
     else this.fixedValueScaleMin = null;
   }
 
   setFixedValueScaleMax(value) {
-    if (!Number.isNaN(value)) this.fixedValueScaleMax = +value;
+    if (!Number.isNaN(+value)) this.fixedValueScaleMax = +value;
     else this.fixedValueScaleMax = null;
   }
 


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Fix an issue checking if the value limit is a valid number

> Why is it necessary?

Avoid setting `NaN` as the value limits. `Number.isNaN('cool stuff yo!')` would be `false` because `cool stuff yo!` is not `NaN`. One needs to explicitly convert the variable to a number first.

## Checklist

- ~[ ] Unit tests added or updated~
- ~[ ] Documentation added or updated~
- ~[ ] Example added or updated~
- ~[ ] Screenshot for visual changes (e.g. new tracks)~
- [x] Updated CHANGELOG.md
