### PR TITLE
Use bins_per_dimension or tile_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.5.3
+
+- Let HorizontalLineTracks look up tileset_info.tile_size
+  and tileset_info.bins_per_dimension
+
 ## v1.5.1
 
 - Fixed UI hanging on mouseover of zoomed out matrix bug

--- a/app/scripts/HorizontalLine1DPixiTrack.js
+++ b/app/scripts/HorizontalLine1DPixiTrack.js
@@ -127,7 +127,15 @@ class HorizontalLine1DPixiTrack extends HorizontalTiled1DPixiTrack {
     const stroke = colorToHex(this.options.lineStrokeColor ? this.options.lineStrokeColor : 'blue');
     // this scale should go from an index in the data array to
     // a position in the genome coordinates
-    const tileXScale = scaleLinear().domain([0, this.tilesetInfo.tile_size])
+    if (!this.tilesetInfo.tile_size && !this.tilesetInfo.bins_per_dimension) {
+      console.warn('No tileset_info.tile_size or tileset_info.bins_per_dimension',
+        this.tilesetInfo);
+    }
+
+    const tileSize = this.tilesetInfo.tile_size
+      || this.tilesetInfo.bins_per_dimension;
+
+    const tileXScale = scaleLinear().domain([0, tileSize])
       .range([tileX, tileX + tileWidth]);
 
     const strokeWidth = this.options.lineStrokeWidth ? this.options.lineStrokeWidth : 1;


### PR DESCRIPTION
## Description

What was changed in this pull request?

This pull request allows line tracks to use either `tileset_info.tile_size` or `tileset_info.bins_per_dimension` to determine the number of data points in each tile.

Why is it necessary?

At some point we began using both terms for specifying the size of a tile. As long as we use both we should check for both.

Fixes #___

## Checklist

- [ ] Unit tests added or updated
- [o] Documentation added or updated
- [o] Example added or updated
- [o] Screenshot for visual changes (e.g. new tracks)
- [x] Updated CHANGELOG.md
