### PR TITLE
Fix broken link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ npm run test-watch
 
 ### API
 
-HiGlass provides an API for controlling the component from within a Javascript script. Complete documentation is availabe at [docs.higlass.io](http://docs.higlass.io/higlass_developer.html#public-api). Example:
+HiGlass provides an API for controlling the component from within a Javascript script. Complete documentation is availabe at [docs.higlass.io](http://docs.higlass.io/javascript_api.html). Example:
 
 ```
 <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" type="text/css">


### PR DESCRIPTION
The developer docs are now more about how to develop higlass than how to use the API, so this seems right.

## Description

What was changed in this pull request?

Fix bad link.