### PR TITLE
@example is sufficient by itself

### DIFF
--- a/app/scripts/TiledPixiTrack.js
+++ b/app/scripts/TiledPixiTrack.js
@@ -222,8 +222,6 @@ class TiledPixiTrack extends PixiTrack {
    *
    * @example
    *
-   * ..code-block::
-   *
    *  trackObj.on('dataChanged', (newData) => {
    *   console.log('newData:', newData)
    *  });


### PR DESCRIPTION
## Description

What was changed in this pull request?

Remove `..code-block::`

Why is it necessary?

At http://docs.higlass.io/javascript_api.html#TiledPixiTrack.on, `..code-block::` shows up in the output.
