### PR TITLE
closing slashes

### DIFF
--- a/docs/javascript_api.rst
+++ b/docs/javascript_api.rst
@@ -127,7 +127,7 @@ Creating a HiGlass component in your React app
   <HiGlassComponent
     options={options}
     viewConfig={viewConfig}
-  >
+  />
 
 Use the ``HiGlassComponent`` to create a HiGlass instance in react. The
 ``options`` prop is the same as explained above.
@@ -142,7 +142,7 @@ Use the ``HiGlassComponent`` to create a HiGlass instance in react. The
     ref={props.onRef}
     options={props.options}
     viewConfig={props.viewConfig}
-  >
+  />
 
   export default HiGlass;
 


### PR DESCRIPTION
## Description

What was changed in this pull request?

`>` -> `/>`

Why is it necessary?

At least for me, React requires the `/` on self-closing tags... maybe there is some version which does not have that requirement?