### PR TITLE
animateTime=0 stutters, at least for me, and =1 works well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## in progress
+
+- Improve zoomTo performance by specifying non-zero animationTime.
+
 ## v1.5.4
 
 - Fix the multiple component passive event issue by replacing the dom-event.js handlers with a class so that each component maintains its own context

--- a/app/scripts/api.js
+++ b/app/scripts/api.js
@@ -395,7 +395,7 @@ const createApi = function api(context, pubSub) {
         end1Abs,
         start2Abs,
         end2Abs,
-        animateTime = 0,
+        animateTime = 1,
       ) {
         self.zoomTo(viewUid, start1Abs, end1Abs, start2Abs, end2Abs, animateTime);
       },


### PR DESCRIPTION
## Description

What was changed in this pull request?

Give a default 1ms animation time
Follow-up to https://github.com/higlass/higlass/pull/613#issuecomment-483063637

Why is it necessary?

With `animationTime=0`, it seems to be redrawing from scratch each time, and couldn't keep up with refreshes faster than once per second, or so.

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example added or updated
- [ ] Screenshot for visual changes (e.g. new tracks)
- [x] Updated CHANGELOG.md
