### PR TITLE
Destroy texture-containing elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.5.5
+
+- Destroy heatmap sprites and axis texts to mitigate memory leak
+
 ## v1.5.4
 
 - Fix the multiple component passive event issue by replacing the dom-event.js handlers with a class so that each component maintains its own context

--- a/app/scripts/AxisPixi.js
+++ b/app/scripts/AxisPixi.js
@@ -73,6 +73,7 @@ class AxisPixi {
     while (this.axisTexts.length > this.tickValues.length) {
       const lastText = this.axisTexts.pop();
       this.pAxis.removeChild(lastText);
+      lastText.destroy(true);
     }
   }
 

--- a/app/scripts/HeatmapTiledPixiTrack.js
+++ b/app/scripts/HeatmapTiledPixiTrack.js
@@ -1015,6 +1015,20 @@ class HeatmapTiledPixiTrack extends TiledPixiTrack {
     }
   }
 
+  destroyTile(tile) {
+    // sprite have to be explicitly destroyed in order to
+    // free the texture cache
+    tile.sprite.destroy(true);
+
+    tile.canvas = null;
+    tile.sprite = null;
+    tile.texture = null;
+
+    // this is a handy method for checking what's in the texture
+    // cache
+    // console.log('destroy', PIXI.utils.BaseTextureCache);
+  }
+
   /**
    * Render / draw a tile.
    *
@@ -1052,15 +1066,21 @@ class HeatmapTiledPixiTrack extends TiledPixiTrack {
           const { graphics } = tile;
           const canvas = this.tileDataToCanvas(pixData.pixData);
 
+          if (tile.sprite) {
+            // if this tile has already been rendered with a sprite, we
+            // have to destroy it before creating a new one
+            tile.sprite.destroy(true);
+          }
 
           let sprite = null;
+          const texture = PIXI.Texture.fromCanvas(canvas, PIXI.SCALE_MODES.NEAREST);
 
           sprite = new PIXI.Sprite(
-            PIXI.Texture.fromCanvas(canvas, PIXI.SCALE_MODES.NEAREST)
+            texture
           );
 
           tile.sprite = sprite;
-
+          tile.texture = texture;
           // store the pixData so that we can export it
           tile.canvas = canvas;
           this.setSpriteProperties(


### PR DESCRIPTION
## Description

What was changed in this pull request?

Destroy sprites when necessary so that they're not maintained in PIXI's texture cache.

Why is it necessary?

Slows down memory leaks.

Fixes #___

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example added or updated
- [ ] Screenshot for visual changes (e.g. new tracks)
- [x] Updated CHANGELOG.md
