### PR TITLE
Allow any horizontal track to be vertical

### DIFF
--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -2214,6 +2214,7 @@ class HiGlassComponent extends React.Component {
       return null;
     }
 
+    newTrack.position = position;
     newTrack.width = this.getTrackInfo(newTrack.type).defaultWidth
       || this.getTrackInfo(newTrack.type).minWidth
       || this.minVerticalWidth;

--- a/app/scripts/TiledPlot.js
+++ b/app/scripts/TiledPlot.js
@@ -1522,7 +1522,7 @@ class TiledPlot extends React.Component {
     }
 
     const orientationToPositions = {
-      '1d-horizontal': ['top', 'bottom'],
+      '1d-horizontal': ['top', 'bottom', 'left', 'right'],
       '2d': ['center'],
       '1d-vertical': ['left', 'right']
     };

--- a/app/scripts/TrackRenderer.js
+++ b/app/scripts/TrackRenderer.js
@@ -75,7 +75,8 @@ import { getDarkTheme } from './services';
 
 // Configs
 import {
-  AVAILABLE_FOR_PLUGINS
+  AVAILABLE_FOR_PLUGINS,
+  TRACKS_INFO_BY_TYPE,
 } from './configs';
 
 // Styles
@@ -188,6 +189,16 @@ class TrackRenderer extends React.Component {
     this.metaTracks = {};
 
     this.pubSubs = [];
+
+    // if there's plugin tracks, they'll define new track
+    // types and we'll want to use their information when
+    // we look up the orientation of a track
+    if (window.higlassTracksByType) {
+      // Extend `TRACKS_INFO_BY_TYPE` with the configs of plugin tracks.
+      Object.keys(window.higlassTracksByType).forEach((pluginTrackType) => {
+        TRACKS_INFO_BY_TYPE[pluginTrackType] = window.higlassTracksByType[pluginTrackType].config;
+      });
+    }
 
     this.boundForwardEvent = this.forwardEvent.bind(this);
     this.boundScrollEvent = this.scrollEvent.bind(this);
@@ -1206,6 +1217,17 @@ class TrackRenderer extends React.Component {
   }
 
   createTrackObject(track) {
+    const trackObject = this.createLocationAgnosticTrackObject(track);
+
+    if (track.position === 'left' || track.position === 'right') {
+      if (TRACKS_INFO_BY_TYPE[track.type].orientation === '1d-horizontal') {
+        return new LeftTrackModifier(trackObject);
+      }
+    }
+    return trackObject;
+  }
+
+  createLocationAgnosticTrackObject(track) {
     const handleTilesetInfoReceived = (x) => {
       this.currentProps.onTilesetInfoReceived(track.uid, x);
     };

--- a/app/scripts/TrackRenderer.js
+++ b/app/scripts/TrackRenderer.js
@@ -1218,7 +1218,6 @@ class TrackRenderer extends React.Component {
 
   createTrackObject(track) {
     const trackObject = this.createLocationAgnosticTrackObject(track);
-
     if (track.position === 'left' || track.position === 'right') {
       if (TRACKS_INFO_BY_TYPE[track.type].orientation === '1d-horizontal') {
         return new LeftTrackModifier(trackObject);

--- a/docs/examples/others/test_drag.html
+++ b/docs/examples/others/test_drag.html
@@ -63,10 +63,11 @@ function lineDragStart(ev) {
 
    var lineTrack = 
     {
-        "server": "http://localhost:8000/api/v1",
-        "tilesetUid": "KMj8e06yQtWg6Y7yhkt2lg",
-        "datatype": "arcs",
-      }
+        "server": "http://higlass.io/api/v1",
+        "tilesetUid": "WEAuzo5DQy6lEYw4kmgnDA",
+        "datatype": "vector",
+        "defaultTracks": ['horizontal-bar']
+    }
 
     window.hgApi.showAvailableTrackPositions(lineTrack);
 }
@@ -77,11 +78,8 @@ function multivecDragStart(ev) {
         "server": "http://higlass.io/api/v1",
         "tilesetUid": "WtBJUYawQzS9M2WVIIHnlA",
         "datatype": "multivec",
-        "defaultTracks": {
-            top: "horizontal-stacked-bar",
-            bottom: "horizontal-multivec"
-        },
-      }
+        "defaultTracks": [ "horizontal-stacked-bar"]
+    }
 
     ev.dataTransfer.setData("text/json", JSON.stringify(lineTrack));
     window.hgApi.showAvailableTrackPositions(lineTrack);
@@ -102,9 +100,10 @@ function linearLabelsDragStart(ev) {
 function heatmapDragStart(ev) {
    var heatmapTrack = 
     {
-        "server": "http://test1.resgen.io/api/v1",
-        "tilesetUid": "N4h3G6FjSOKs5GOIPANVEA",
+        "server": "http://higlass.io/api/v1",
+        "tilesetUid": "CQMd6V_cRw6iCI_-Unl3PQ",
         "datatype": "matrix",
+        "defaultTracks": [ "heatmap"]
     } 
 
     console.log('heatmapDragStart(ev)');
@@ -128,17 +127,68 @@ function heatmapDragStart(ev) {
         1511074199.6112716
       ],
       "initialYDomain": [
-        1505212490.8607008,
-        1510254940.471237
+        1504683396.5786693,
+        1510784034.7532685
       ],
       "tracks": {
         "top": [],
         "left": [],
         "center": [
-
+          {
+            "uid": "KD3HH8QCTnWD96Xq7Y1Rrg",
+            "type": "combined",
+            "contents": [
+              {
+                "type": "heatmap",
+                "uid": "GW6HZwSmR5y-8Cbz22iK_A",
+                "tilesetUid": "CQMd6V_cRw6iCI_-Unl3PQ",
+                "server": "http://higlass.io/api/v1",
+                "options": {
+                  "backgroundColor": "#eeeeee",
+                  "labelPosition": "bottomRight",
+                  "labelLeftMargin": 0,
+                  "labelRightMargin": 0,
+                  "labelTopMargin": 0,
+                  "labelBottomMargin": 0,
+                  "colorRange": [
+                    "white",
+                    "rgba(245,166,35,1.0)",
+                    "rgba(208,2,27,1.0)",
+                    "black"
+                  ],
+                  "maxZoom": null,
+                  "colorbarPosition": "topRight",
+                  "trackBorderWidth": 0,
+                  "trackBorderColor": "black",
+                  "heatmapValueScaling": "log",
+                  "showMousePosition": false,
+                  "mousePositionColor": "#999999",
+                  "showTooltip": false,
+                  "name": "Rao et al. (2014) GM12878 MboI (allreps) 1kb",
+                  "scaleStartPercent": "0.00000",
+                  "scaleEndPercent": "1.00000"
+                },
+                "width": 747,
+                "height": 522,
+                "name": "Rao et al. (2014) GM12878 MboI (allreps) 1kb",
+                "transforms": [
+                  {
+                    "name": "ICE",
+                    "value": "weight"
+                  }
+                ],
+                "position": "center"
+              }
+            ],
+            "position": "center",
+            "width": 747,
+            "height": 522
+          }
         ],
         "bottom": [],
-        "right": []
+        "right": [],
+        "whole": [],
+        "gallery": []
       },
       "layout": {
         "w": 12,

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -22,6 +22,7 @@ module.exports = (config) => {
       'node_modules/font-awesome/css/font-awesome.css',
       'build/hglib.css',
       'test/**/*.+(js|jsx)',
+      // 'test/LeftTrackModifierTests.js',
       // 'test/OverlayTrackTests.js',
       // 'test/HorizontalMultivecTests.js',
       // 'test/HeatmapTests.js',

--- a/test/APITests.js
+++ b/test/APITests.js
@@ -81,7 +81,7 @@ describe('API Tests', () => {
       );
 
       selection = select(div).selectAll('.DragListeningDiv');
-      expect(selection.size()).toEqual(3);
+      expect(selection.size()).toEqual(5);
     });
 
     it('creates a track with default options', () => {

--- a/test/LeftTrackModifierTests.js
+++ b/test/LeftTrackModifierTests.js
@@ -1,0 +1,147 @@
+/* eslint-env node, jasmine */
+import {
+  configure,
+  // render,
+} from 'enzyme';
+
+import Adapter from 'enzyme-adapter-react-16';
+
+import { expect } from 'chai';
+
+// Utils
+import {
+  mountHGComponent,
+  removeHGComponent,
+  getTrackObjectFromHGC
+} from '../app/scripts/utils';
+
+configure({ adapter: new Adapter() });
+
+describe('Horizontal heatmaps', () => {
+  let hgc = null;
+  let div = null;
+
+  beforeAll((done) => {
+    ([div, hgc] = mountHGComponent(div, hgc,
+      zoomLimitViewConf,
+      done,
+      {
+        style: 'width:800px; height:400px; background-color: lightgreen',
+        bounded: true,
+      })
+    );
+  });
+
+  it('should respect zoom limits', (done) => {
+    // add your tests here
+
+    const trackObj = getTrackObjectFromHGC(hgc.instance(), 'vv', 'tt');
+
+    // trackObj is a LeftTrackModifier that contains the
+    // original track
+    expect(trackObj.originalTrack.id).to.eql('tt');
+
+    done();
+  });
+
+  afterAll((done) => {
+    removeHGComponent(div);
+
+    done();
+  });
+});
+
+// enter either a viewconf link or a viewconf object
+const zoomLimitViewConf = {
+  editable: true,
+  zoomFixed: false,
+  trackSourceServers: [
+    '//higlass.io/api/v1'
+  ],
+  exportViewUrl: '/api/v1/viewconfs',
+  views: [
+    {
+      uid: 'vv',
+      initialXDomain: [
+        2.9802322387695312e-8,
+        3099999999.9999995
+      ],
+      autocompleteSource: '/api/v1/suggest/?d=OHJakQICQD6gTD7skx4EWA&',
+      genomePositionSearchBox: {
+        autocompleteServer: '//higlass.io/api/v1',
+        autocompleteId: 'OHJakQICQD6gTD7skx4EWA',
+        chromInfoServer: '//higlass.io/api/v1',
+        chromInfoId: 'hg19',
+        visible: true
+      },
+      chromInfoPath: '//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv',
+      tracks: {
+        top: [],
+        left: [
+          {
+            name: 'Bonev et al. 2017 - GSE96107_CN_H3K27ac',
+            created: '2017-12-12T16:58:42.670164Z',
+            project: "b'FZKFLh4bQ42x53NJokWJEg'",
+            project_name: 'Bonev et al. 2017',
+            description: '',
+            server: '//higlass.io/api/v1',
+            tilesetUid: 'aVKtyKdXRS-pexA2DVdQ1Q',
+            uid: 'tt',
+            type: 'horizontal-bar',
+            options: {
+              align: 'bottom',
+              labelColor: 'black',
+              labelPosition: 'topLeft',
+              labelLeftMargin: 0,
+              labelRightMargin: 0,
+              labelTopMargin: 0,
+              labelBottomMargin: 0,
+              axisLabelFormatting: 'scientific',
+              axisPositionHorizontal: 'right',
+              barFillColor: 'darkgreen',
+              valueScaling: 'linear',
+              trackBorderWidth: 0,
+              trackBorderColor: 'black',
+              labelTextOpacity: 0.4,
+              barOpacity: 1,
+              name: 'Bonev et al. 2017 - GSE96107_CN_H3K27ac'
+            },
+            width: 20,
+            height: 20,
+            position: 'left'
+          }
+        ],
+        center: [],
+        right: [],
+        bottom: [],
+        whole: [],
+        gallery: []
+      },
+      layout: {
+        w: 12,
+        h: 12,
+        x: 0,
+        y: 0,
+        i: 'aa',
+        moved: false,
+        static: false
+      },
+      initialYDomain: [
+        996853415.1957023,
+        2103146584.804298
+      ]
+    }
+  ],
+  zoomLocks: {
+    locksByViewUid: {},
+    locksDict: {}
+  },
+  locationLocks: {
+    locksByViewUid: {},
+    locksDict: {}
+  },
+  valueScaleLocks: {
+    locksByViewUid: {},
+    locksDict: {}
+  }
+};


### PR DESCRIPTION
## Description

There's really no reason why we need separate horizontal and vertical tracks. After this PR, any horizontal track that is added to a vertical position will be decorated with a `LeftTrackModifier` and work as if it were a vertical track.

## Checklist

- [x] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example added or updated
- [o] Screenshot for visual changes (e.g. new tracks)
- [x] Updated CHANGELOG.md
