### PR TITLE
Switch to nearest neighbor interpolation for horizontal heatmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.5.7
+
+- Switch to nearest neighbor interpolation for horizontal heatmaps
+
 ## v1.5.6
 
 - Allow any horizontal track to also be placed on the left or right

--- a/app/scripts/HorizontalHeatmapTrack.js
+++ b/app/scripts/HorizontalHeatmapTrack.js
@@ -294,12 +294,7 @@ class HorizontalHeatmapTrack extends HeatmapTiledPixiTrack {
           const canvas = this.tileDataToCanvas(pixData.pixData);
 
           let sprite = null;
-
-          if (tile.tileData.zoomLevel === this.maxZoom) {
-            sprite = new PIXI.Sprite(PIXI.Texture.fromCanvas(canvas, PIXI.SCALE_MODES.NEAREST));
-          } else {
-            sprite = new PIXI.Sprite(PIXI.Texture.fromCanvas(canvas));
-          }
+          sprite = new PIXI.Sprite(PIXI.Texture.fromCanvas(canvas, PIXI.SCALE_MODES.NEAREST));
 
           tile.sprite = sprite;
           tile.canvas = canvas;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "higlass",
-  "version": "1.5.4",
+  "version": "1.5.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "higlass",
-  "version": "1.5.4",
+  "version": "1.5.6",
   "description": "HiGlass Hi-C / genomic / large data viewer",
   "author": "Peter Kerpedjiev <pkerpedjiev@gmail.com>",
   "main": "dist/hglib.js",


### PR DESCRIPTION
## Description

What was changed in this pull request?

Use nearest neighbor interpolation for horizontal heatmaps. This matches the behavior in the 2D heatmaps and makes much more sense when zooming in.

Why is it necessary?

Any other type of interpolation leads to blurry heatmaps when zooming in.

![image](https://user-images.githubusercontent.com/2143629/57004800-d253ae80-6b86-11e9-86fa-891e91a96595.png)
vs
![image](https://user-images.githubusercontent.com/2143629/57004797-c10aa200-6b86-11e9-9c76-eca0bf1ee8cb.png)


## Checklist

- [o] Unit tests added or updated
- [o] Documentation added or updated
- [o] Example added or updated
- [x] Screenshot for visual changes (e.g. new tracks)
- [x] Updated CHANGELOG.md
