### PR TITLE
Update pub-sub-es

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.5.8
+
+- Updated `pub-sub-es` to version `1.2.1` to fix a bug in the shorthand event unsubscription
+
 ## v1.5.7
 
 - Fix #637 - SVG export fill color doesn't match what is selected

--- a/package-lock.json
+++ b/package-lock.json
@@ -2558,7 +2558,7 @@
         },
         "yargs": {
           "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
           "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
           "dev": true,
           "requires": {
@@ -5498,7 +5498,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -6141,7 +6141,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
@@ -6196,7 +6196,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
@@ -7097,7 +7097,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -11050,7 +11050,7 @@
         },
         "yargs": {
           "version": "6.6.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "dev": true,
           "requires": {
@@ -12003,7 +12003,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -12328,7 +12328,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -12396,7 +12396,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -15917,9 +15917,9 @@
       "dev": true
     },
     "pub-sub-es": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pub-sub-es/-/pub-sub-es-1.2.0.tgz",
-      "integrity": "sha512-qcUBG9xa2y73Nt518157GfIxFNi/6PMCEv6XAMmUFECS58mzc2Wfj6UU8q9pabMWJRfL7AtmSczXVDJ7pFII3A==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/pub-sub-es/-/pub-sub-es-1.2.1.tgz",
+      "integrity": "sha512-QohEHVGVMa1u3qCO/dSZ0KbLrel5R1ARW8BuXGuUWP6Z0n7SmKbRfKuZgEDu7YIedkVp9AZmdpWy92QGJrQ39Q==",
       "requires": {
         "broadcast-channel": "^2.1.8"
       }
@@ -18132,7 +18132,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "path": "^0.12.7",
     "pixi.js": "^4.6.2",
     "prop-types": "^15.6.0",
-    "pub-sub-es": "^1.2.0",
+    "pub-sub-es": "^1.2.1",
     "react": "^16.6.3",
     "react-autocomplete": "github:tiemevanveen/react-autocomplete#fix-176",
     "react-bootstrap": "0.32.1",


### PR DESCRIPTION
## Description

> What was changed in this pull request?

`pub-sub-es` is updated from version `1.2.0` to `1.2.1`

> Why is it necessary?

There was a bug in the shorthand unsubscription which led to memory leaks

## Checklist

- ~[ ] Unit tests added or updated~
- ~[ ] Documentation added or updated~
- ~[ ] Example added or updated~
- ~[ ] Screenshot for visual changes (e.g. new tracks)~
- [x] Updated CHANGELOG.md
