### PR TITLE
Flekschas/fix mousemove performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Replace ReactBootstrap modal with custom modal to not rely on Bootstrap and support Jupyter
 - Updated `pub-sub-es` to version `1.2.1` to fix a bug in the shorthand event unsubscription
 - Added an example of a map overlay
+- Improve performance of the `mousemove`-related event handling
 - Fix #651: set correct namespace for SVG exports
 
 ## v1.5.7

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -4028,7 +4028,6 @@ class HiGlassComponent extends React.Component {
         className="higlass"
         onMouseLeave={this.onMouseLeaveHandlerBound}
         onMouseMove={this.mouseMoveHandlerBound}
-        onWheel={this.onWheelHandlerBound}
         styleName={styleNames}
       >
         <PubSubProvider value={this.pubSub}>

--- a/app/scripts/TrackRenderer.js
+++ b/app/scripts/TrackRenderer.js
@@ -1630,20 +1630,17 @@ class TrackRenderer extends React.Component {
     this.eventTracker.addEventListener('mouseover', this.boundForwardEvent);
     this.eventTracker.addEventListener('mouseenter', this.boundForwardEvent);
     this.eventTracker.addEventListener('mousedown', this.boundForwardEvent);
-    this.eventTracker.addEventListener('mousemove', this.boundForwardEvent);
     this.eventTracker.addEventListener('mouseup', this.boundForwardEvent);
     this.eventTracker.addEventListener('mouseout', this.boundForwardEvent);
     this.eventTracker.addEventListener('mouseleave', this.boundForwardEvent);
 
     this.eventTracker.addEventListener('touchstart', this.boundForwardEvent);
-    this.eventTracker.addEventListener('touchmove', this.boundForwardEvent);
     this.eventTracker.addEventListener('touchend', this.boundForwardEvent);
     this.eventTracker.addEventListener('touchcancel', this.boundForwardEvent);
 
     this.eventTracker.addEventListener('pointerover', this.boundForwardEvent);
     this.eventTracker.addEventListener('pointerenter', this.boundForwardEvent);
     this.eventTracker.addEventListener('pointerdown', this.boundForwardEvent);
-    this.eventTracker.addEventListener('pointermove', this.boundForwardEvent);
     this.eventTracker.addEventListener('pointerup', this.boundForwardEvent);
     this.eventTracker.addEventListener('pointercancel', this.boundForwardEvent);
     this.eventTracker.addEventListener('pointerout', this.boundForwardEvent);
@@ -1665,20 +1662,17 @@ class TrackRenderer extends React.Component {
     this.eventTracker.removeEventListener('mouseover', this.boundForwardEvent);
     this.eventTracker.removeEventListener('mouseenter', this.boundForwardEvent);
     this.eventTracker.removeEventListener('mousedown', this.boundForwardEvent);
-    this.eventTracker.removeEventListener('mousemove', this.boundForwardEvent);
     this.eventTracker.removeEventListener('mouseup', this.boundForwardEvent);
     this.eventTracker.removeEventListener('mouseout', this.boundForwardEvent);
     this.eventTracker.removeEventListener('mouseleave', this.boundForwardEvent);
 
     this.eventTracker.removeEventListener('touchstart', this.boundForwardEvent);
-    this.eventTracker.removeEventListener('touchmove', this.boundForwardEvent);
     this.eventTracker.removeEventListener('touchend', this.boundForwardEvent);
     this.eventTracker.removeEventListener('touchcancel', this.boundForwardEvent);
 
     this.eventTracker.removeEventListener('pointerover', this.boundForwardEvent);
     this.eventTracker.removeEventListener('pointerenter', this.boundForwardEvent);
     this.eventTracker.removeEventListener('pointerdown', this.boundForwardEvent);
-    this.eventTracker.removeEventListener('pointermove', this.boundForwardEvent);
     this.eventTracker.removeEventListener('pointerup', this.boundForwardEvent);
     this.eventTracker.removeEventListener('pointercancel', this.boundForwardEvent);
     this.eventTracker.removeEventListener('pointerout', this.boundForwardEvent);


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Avoid duplicated event handling.

**Before:**
![Screen Shot 2019-06-03 at 10 21 59 AM](https://user-images.githubusercontent.com/932103/58824006-0fd5ac80-8609-11e9-8e46-b92e29fe490b.png)

**After:**
![Screen Shot 2019-06-03 at 2 10 00 PM](https://user-images.githubusercontent.com/932103/58824095-4c090d00-8609-11e9-8dae-93aa328c2792.png)

> Why is it necessary?

Reduces the JS execution time of the `mousemove` callback from 11 to 7.5ms. This is important given that the `mousemove` event fires most frequently, i.e., on every pixel-move.

## Checklist

- ~[ ] Unit tests added or updated~
- ~[ ] Documentation added or updated~
- ~[ ] Example added or updated~
- ~[ ] Screenshot for visual changes (e.g. new tracks)~
- [x] Updated CHANGELOG.md
