### PR TITLE
Extra period caused syntax error

### DIFF
--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -2684,7 +2684,7 @@ class HiGlassComponent extends React.Component {
         if ('description' in track) { delete track.description; }
         if ('created' in track) { delete track.created; }
         if ('project' in track) { delete track.project; }
-        if ('project_name' in track) { delete.track.project_name; }
+        if ('project_name' in track) { delete track.project_name; }
         if ('serverUidKey' in track) { delete track.serverUidKey; }
         if ('uuid' in track) { delete track.uuid; }
         if ('private' in track) { delete track.private; }


### PR DESCRIPTION
## Description

What was changed in this pull request?
- remove period introduced in previous commit.
```
ad812a67d app/scripts/HiGlassComponent.js    (Peter Kerpedjiev 2019-06-03 22:47:20 -0700 2687)         if ('project_name' in track) { delete.track.project_name; }
```

Why is it necessary?
- build fails

We do have tests, but this commit went straight to develop, and wasn't caught. :(
```
$ git log  --graph  --all

* commit 3e82ba052facfe703d6a3925829e99871d1fa5c2 (HEAD -> mccalluc/extra-period, origin/mccalluc/extra-period)
| Author: Chuck McCallum <chuck_mccallum@hms.harvard.edu>
| Date:   Tue Jun 4 11:40:13 2019 -0400
| 
|     Extra period caused syntax error
| 
* commit 050ff5f06fb7775d4dd33981d42b2eadc16ca98e (origin/develop, origin/HEAD, develop)
| Author: Peter Kerpedjiev <pkerpedjiev@gmail.com>
| Date:   Mon Jun 3 22:48:36 2019 -0700
| 
|     Delete description from output viewconf
| 
* commit ad812a67d8ab7b385d38ff6d2117651e6a31f248
| Author: Peter Kerpedjiev <pkerpedjiev@gmail.com>
| Date:   Mon Jun 3 22:47:20 2019 -0700
| 
|     Remove exported json fields
```

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example added or updated
- [ ] Screenshot for visual changes (e.g. new tracks)
- [ ] Updated CHANGELOG.md
