### PR TITLE
Mccalluc/prefer npm clean install

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ Kerpedjiev, P., Abdennur, N., Lekschas, F., McCallum, C., Dinkla, K., Strobelt, 
 To run higlass from its source code simply run the following:
 
 ```
-npm install
+npm clean-install
 npm run start
 ```
 
-This starts a server in development mode at http://localhost:8080/. 
+This starts a server in development mode at http://localhost:8080/.
 
 Once started, a list of the examples can be found at [http://localhost:8080/examples.html](http://localhost:8080/examples.html).
 Template viewconfs located at `/docs/examples/viewconfs` can viewed directly at urls such as  [http://localhost:8080/apis/svg.html?/viewconfs/overlay-tracks.json](http://localhost:8080/apis/svg.html?/viewconfs/overlay-tracks.json).
@@ -55,7 +55,7 @@ npm run test-watch
 - If the installation fails due to `sharp` > `node-gyp` try installing the node packages using `python2`:
 
   ```
-  npm i --python=/usr/bin/python2 && rm -rf node_modules/node-sass && npm i
+  npm ci --python=/usr/bin/python2 && rm -rf node_modules/node-sass && npm ci
   ```
 
 ### API

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -2684,7 +2684,7 @@ class HiGlassComponent extends React.Component {
         if ('description' in track) { delete track.description; }
         if ('created' in track) { delete track.created; }
         if ('project' in track) { delete track.project; }
-        if ('project_name' in track) { delete.track.project_name; }
+        if ('project_name' in track) { delete track.project_name; }
         if ('serverUidKey' in track) { delete track.serverUidKey; }
         if ('uuid' in track) { delete track.uuid; }
         if ('private' in track) { delete track.private; }


### PR DESCRIPTION
## Description

What was changed in this pull request?
- in README, `install` -> `clean-install`

Why is it necessary?
- `clean-install` takes package-lock.json as gospel, instead of trying to update it. We want new developers to have a predictable environment, just like we want travis to have a predictable environment.
- In older versions of the npm cli, there are some differences in behavior, and unwanted changes would be introduced into the package-lock.json.

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example added or updated
- [ ] Screenshot for visual changes (e.g. new tracks)
- [ ] Updated CHANGELOG.md
