### PR TITLE
Mccalluc/remove unneeded dones

### DIFF
--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -2684,7 +2684,7 @@ class HiGlassComponent extends React.Component {
         if ('description' in track) { delete track.description; }
         if ('created' in track) { delete track.created; }
         if ('project' in track) { delete track.project; }
-        if ('project_name' in track) { delete.track.project_name; }
+        if ('project_name' in track) { delete track.project_name; }
         if ('serverUidKey' in track) { delete track.serverUidKey; }
         if ('uuid' in track) { delete track.uuid; }
         if ('private' in track) { delete track.private; }

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -17,7 +17,7 @@ Boilerplate
 -----------
 
 Use the following template and replace individual ``it`` blocks
-to set up new tests. Add this code to the `tests` directory and 
+to set up new tests. Add this code to the `tests` directory and
 add a line to `karma.conf.js` to include it in the tests.
 
 .. code-block:: javascript
@@ -56,19 +56,15 @@ add a line to `karma.conf.js` to include it in the tests.
         );
       });
 
-      it('should respect zoom limits', (done) => {
+      it('should respect zoom limits', () => {
         // add your tests here
 
         const trackObj = getTrackObjectFromHGC(hgc.instance(), 'vv', 'tt');
         expect(trackObj.calculateZoomLevel()).to.eql(1);
-
-        done();
       });
 
-      afterAll((done) => {
+      afterAll(() => {
         removeHGComponent(div);
-
-        done();
       });
     });
 
@@ -107,11 +103,10 @@ Contributor Guidelines
 =======================
 
 Contributions are in the form of issues, code, documentation are always very welcome. The
-following are a set of guidelines to help ensure that contributions can be smoothly 
+following are a set of guidelines to help ensure that contributions can be smoothly
 merged into the existing code base:
 
 1. All code contributions should be accompanied by a test. Tests can be placed into the `test`
    folder.
-2. All added functions should include a jsdoc string for javascript code or a numpy style 
+2. All added functions should include a jsdoc string for javascript code or a numpy style
    docstring for python code.
-

--- a/test/2DRectangleDomainsTests.js
+++ b/test/2DRectangleDomainsTests.js
@@ -31,19 +31,13 @@ describe('Horizontal heatmaps', () => {
     );
   });
 
-  it('export rectangles in the same color that they are in the view', (done) => {
-    // add your tests here
-
+  it('export rectangles in the same color that they are in the view', () => {
     const svgString = hgc.instance().createSVGString();
     expect(svgString.indexOf('cyan')).to.be.above(-1);
-
-    done();
   });
 
-  afterAll((done) => {
+  afterAll(() => {
     removeHGComponent(div);
-
-    done();
   });
 });
 

--- a/test/APITests.js
+++ b/test/APITests.js
@@ -255,15 +255,13 @@ describe('API Tests', () => {
       });
     });
 
-    it('has version', (done) => {
+    it('has version', () => {
       [div, api] = createElementAndApi(emptyConf, { editable: false });
 
       expect(api.version).toEqual(VERSION);
-
-      done();
     });
 
-    it('adjust view spacing', (done) => {
+    it('adjust view spacing', () => {
       const options = {
         pixelPreciseMarginPadding: true,
         containingPaddingX: 0,
@@ -314,8 +312,6 @@ describe('API Tests', () => {
         + options.viewMarginLeft
         + options.viewMarginRight
       );
-
-      done();
     });
 
     it('mousemove and zoom events work for 1D and 2D tracks', (done) => {
@@ -414,12 +410,11 @@ describe('API Tests', () => {
       });
     });
 
-    it('APIs are independent', (done) => {
+    it('APIs are independent', () => {
       [div, api] = createElementAndApi(
         simpleCenterViewConfig, { editable: false, bounded: true }
       );
 
-      done();
       /* Turning this test off because it periodically
        * and inexplicablye fails
        */

--- a/test/AddAndRemoveViewconfTests.js
+++ b/test/AddAndRemoveViewconfTests.js
@@ -28,13 +28,12 @@ describe('Simple HiGlassComponent', () => {
   let api = null;
 
   describe('API tests', () => {
-    beforeAll((done) => {
+    beforeAll(() => {
       div = global.document.createElement('div');
       global.document.body.appendChild(div);
 
       api = viewer(div, simpleCenterViewConfig, {});
       api.setViewConfig(simpleCenterViewConfig);
-      done();
 
       // p.then(() => {
       //   console.log('done');
@@ -44,7 +43,7 @@ describe('Simple HiGlassComponent', () => {
       // ([div, hgc] = mountHGComponent(div, hgc, 'http://higlass.io/api/v1/viewconfs/?d=default', done));
     });
 
-    it('Ensures that setting a new viewconf changes the trackSourceServers', (done) => {
+    it('Ensures that setting a new viewconf changes the trackSourceServers', () => {
       const viewConf = JSON.parse(api.exportAsViewConfString());
       viewConf.trackSourceServers = ['http://blah'];
 
@@ -53,14 +52,10 @@ describe('Simple HiGlassComponent', () => {
       const newViewConf = JSON.parse(newApi.exportAsViewConfString());
 
       expect(newViewConf.trackSourceServers[0]).to.eql('http://blah');
-
-      done();
     });
 
-    afterAll((done) => {
+    afterAll(() => {
       removeHGComponent(div);
-
-      done();
     });
   });
 });

--- a/test/AddTrackTests.js
+++ b/test/AddTrackTests.js
@@ -98,7 +98,7 @@ describe('Add Track', () => {
       waitForJsonComplete(done);
     });
 
-    it('should select a few different tracks and check for the plot type selection', (done) => {
+    it('should select a few different tracks and check for the plot type selection', () => {
       const { tilesetFinder } = hgc.instance().modalRef;
 
       tilesetFinder.handleSelectedOptions([
@@ -124,25 +124,19 @@ describe('Add Track', () => {
       // console.warn('ptc.AVAILABLE_TRACK_TYPES', ptc.AVAILABLE_TRACK_TYPES);
       // should just have the horizontal-heatmap track type
       expect(ptc.AVAILABLE_TRACK_TYPES.length).to.eql(3);
-
-      done();
     });
 
-    it('should add the selected tracks', (done) => {
+    it('should add the selected tracks', () => {
       hgc.instance().modalRef.handleSubmit();
       const viewConf = JSON.parse(hgc.instance().getViewsAsString());
 
       expect(viewConf.views[0].tracks.top.length).to.eql(6);
 
       hgc.update();
-
-      done();
     });
 
-    afterAll((done) => {
+    afterAll(() => {
       removeHGComponent(div);
-
-      done();
     });
   });
 });

--- a/test/AxisTests.js
+++ b/test/AxisTests.js
@@ -71,10 +71,8 @@ describe('Simple HiGlassComponent', () => {
         .to.equal(track1.axis.pAxis.position.x);
     });
 
-    afterAll((done) => {
+    afterAll(() => {
       removeHGComponent(div);
-
-      done();
     });
   });
 });

--- a/test/BarTrackTests.js
+++ b/test/BarTrackTests.js
@@ -51,13 +51,11 @@ describe('BarTrack tests', () => {
       expect(
         Object.values(trackObj.fetchedTiles).every(tile => tile.svgData)
       ).to.eql(true);
+      done();
     });
-
-    done();
   });
 
-  afterAll((done) => {
+  afterAll(() => {
     removeHGComponent(div);
-    done();
   });
 });

--- a/test/BedLikeTests.js
+++ b/test/BedLikeTests.js
@@ -27,19 +27,17 @@ describe('Simple HiGlassComponent', () => {
       ([div, hgc] = mountHGComponent(div, hgc, viewConf, done));
     });
 
-    it('Ensures that the track was rendered', (done) => {
+    it('Ensures that the track was rendered', () => {
       expect(hgc.instance().state.viewConfig.editable).to.eql(true);
       const trackObj = getTrackObjectFromHGC(hgc.instance(),
         viewConf.views[0].uid,
         viewConf.views[0].tracks.top[0].uid);
 
       expect(Object.keys(trackObj.drawnRects).length).to.be.above(0);
-      done();
     });
 
-    afterAll((done) => {
+    afterAll(() => {
       removeHGComponent(div);
-      done();
     });
   });
 

--- a/test/ChromSizesTests.js
+++ b/test/ChromSizesTests.js
@@ -181,19 +181,16 @@ describe('Simple HiGlassComponent', () => {
       );
     });
 
-    it("Ensure that the viewport projection's borders are grey", (done) => {
+    it("Ensure that the viewport projection's borders are grey", () => {
       const trackObject = getTrackObjectFromHGC(
         hgc.instance(), 'Mw2aWH9TTcu38t5OZlCYyA'
       );
 
       expect(trackObject.options.lineStrokeColor).to.eql('grey');
-      done();
     });
 
-    afterAll((done) => {
+    afterAll(() => {
       removeHGComponent(div);
-
-      done();
     });
   });
 });

--- a/test/GenomePositionSearchBoxTest.js
+++ b/test/GenomePositionSearchBoxTest.js
@@ -115,11 +115,9 @@ describe('Genome position search box tests', () => {
       waitForJsonComplete(done);
     });
 
-    it('Makes sure that the search box points to mm9', (done) => {
+    it('Makes sure that the search box points to mm9', () => {
       hgc.update();
       expect(hgc.instance().genomePositionSearchBoxes.aa.state.selectedAssembly).toEqual('mm9');
-
-      done();
     });
 
     it('Switch the selected genome to dm3', (done) => {
@@ -136,10 +134,8 @@ describe('Genome position search box tests', () => {
       waitForJsonComplete(done);
     });
 
-    it('Makes sure that no genes are loaded', (done) => {
+    it('Makes sure that no genes are loaded', () => {
       expect(hgc.instance().genomePositionSearchBoxes.aa.state.genes.length).toEqual(0);
-
-      done();
     });
 
     it('Switch the selected genome to mm9', (done) => {
@@ -166,13 +162,11 @@ describe('Genome position search box tests', () => {
       });
     });
 
-    it('Expects the view to have changed location (1)', (done) => {
+    it('Expects the view to have changed location (1)', () => {
       const { zoomTransform } = hgc.instance().tiledPlots.aa.trackRenderer;
 
       expect(zoomTransform.k - 47).toBeLessThan(1);
       expect(zoomTransform.x - 2224932).toBeLessThan(1);
-
-      done();
     });
 
     it('Checks that autocomplete fetches some genes', (done) => {
@@ -217,13 +211,11 @@ describe('Genome position search box tests', () => {
       });
     });
 
-    it('Expects the view to have changed location (2)', (done) => {
+    it('Expects the view to have changed location (2)', () => {
       const { zoomTransform } = hgc.instance().tiledPlots.aa.trackRenderer;
 
       expect(zoomTransform.k - 234).toBeLessThan(1);
       expect(zoomTransform.x + 7656469).toBeLessThan(1);
-
-      done();
     });
 
     it('Ensures that the autocomplete has changed', (done) => {
@@ -234,11 +226,9 @@ describe('Genome position search box tests', () => {
       waitForJsonComplete(done);
     });
 
-    it('Ensure that newly loaded genes are from hg19', (done) => {
+    it('Ensure that newly loaded genes are from hg19', () => {
       expect(hgc.instance().genomePositionSearchBoxes.aa.state.genes[0].geneName)
         .toEqual('TP53');
-
-      done();
     });
 
     it('Switches back to mm9', (done) => {
@@ -254,11 +244,9 @@ describe('Genome position search box tests', () => {
       waitForJsonComplete(done);
     });
 
-    it('Make sure it has mouse genes', (done) => {
+    it('Make sure it has mouse genes', () => {
       expect(hgc.instance().genomePositionSearchBoxes.aa.state.genes[0].geneName)
         .toEqual('Gt(ROSA)26Sor');
-
-      done();
     });
 
     it('Switches back to hg19', (done) => {
@@ -287,17 +275,13 @@ describe('Genome position search box tests', () => {
       waitForJsonComplete(done);
     });
 
-    it('Ensures that selected assembly is hg19', (done) => {
+    it('Ensures that selected assembly is hg19', () => {
       expect(hgc.instance().genomePositionSearchBoxes.aa.state.selectedAssembly)
         .toEqual('hg19');
-
-      done();
     });
 
-    it("checks that the div hasn't grown too much", (done) => {
+    it("checks that the div hasn't grown too much", () => {
       expect(div.clientHeight).toBeLessThan(500);
-
-      done();
     });
   });
 });

--- a/test/HeatmapTests.js
+++ b/test/HeatmapTests.js
@@ -37,7 +37,7 @@ describe('Testing', () => {
       );
     });
 
-    it('once', (done) => {
+    it('once', () => {
       const tp = getTrackObjectFromHGC(hgc.instance(), 'NagBzk-AQZuoY0bqG-Yy0Q', 'PdEzdgsxRymGelD5xfKlNA');
       let data = tp.getVisibleRectangleData(262, 298, 1, 1);
 
@@ -47,14 +47,10 @@ describe('Testing', () => {
       expect(data.shape[1]).to.eql(234);
 
       // tp.exportData();
-
-      done();
     });
 
-    afterAll((done) => {
+    afterAll(() => {
       removeHGComponent(div);
-
-      done();
     });
   });
 
@@ -73,7 +69,7 @@ describe('Testing', () => {
       );
     });
 
-    it('should respect zoom limits', (done) => {
+    it('should respect zoom limits', () => {
       // add your tests here
 
       const trackObj = getTrackObjectFromHGC(hgc.instance(), 'vv', 'tt');
@@ -81,14 +77,10 @@ describe('Testing', () => {
 
       expect(rectData.shape[0]).to.eql(0);
       expect(rectData.shape[1]).to.eql(0);
-
-      done();
     });
 
-    afterAll((done) => {
+    afterAll(() => {
       removeHGComponent(div);
-
-      done();
     });
   });
 });

--- a/test/HiGlassComponentCreationTests.js
+++ b/test/HiGlassComponentCreationTests.js
@@ -26,16 +26,12 @@ describe('Simple HiGlassComponent', () => {
       ([div, hgc] = mountHGComponent(div, hgc, 'http://higlass.io/api/v1/viewconfs/?d=default', done));
     });
 
-    it('Ensures that the viewconf state is editable', (done) => {
+    it('Ensures that the viewconf state is editable', () => {
       expect(hgc.instance().state.viewConfig.editable).to.eql(true);
-
-      done();
     });
 
-    afterAll((done) => {
+    afterAll(() => {
       removeHGComponent(div);
-
-      done();
     });
   });
 });

--- a/test/HiGlassComponentTest.js
+++ b/test/HiGlassComponentTest.js
@@ -94,7 +94,7 @@ describe('Simple HiGlassComponent', () => {
       // done();
     });
 
-    it('Switches to the osm tles track', (done) => {
+    it('Switches to the osm tles track', () => {
       const { views } = hgc.instance().state;
       // console.log('views:', views);
 
@@ -106,7 +106,6 @@ describe('Simple HiGlassComponent', () => {
       hgc.setState({
         views,
       });
-      done();
     });
   });
 
@@ -280,10 +279,8 @@ describe('Simple HiGlassComponent', () => {
       waitForTilesLoaded(hgc.instance(), done);
     });
 
-    it('Exports to SVG', (done) => {
+    it('Exports to SVG', () => {
       hgc.instance().createSVG();
-
-      done();
     });
   });
 
@@ -313,15 +310,12 @@ describe('Simple HiGlassComponent', () => {
       waitForTilesLoaded(hgc.instance(), done);
     });
 
-    it('Exports to SVG', (done) => {
+    it('Exports to SVG', () => {
       const svg = hgc.instance().createSVG();
       const svgText = new XMLSerializer().serializeToString(svg);
 
       expect(svgText.indexOf('rect')).toBeGreaterThan(0);
       // hgc.instance().handleExportSVG();
-      //
-
-      done();
     });
 
 
@@ -350,17 +344,17 @@ describe('Simple HiGlassComponent', () => {
       waitForTilesLoaded(hgc.instance(), done);
     });
 
-    it('Exports to SVG', (done) => {
-      // const svg = hgc.instance().createSVG();
-      // const svgText = new XMLSerializer().serializeToString(svg);
+    // it('Exports to SVG', (done) => {
+    //   // const svg = hgc.instance().createSVG();
+    //   // const svgText = new XMLSerializer().serializeToString(svg);
+    //
+    //   // expect(svgText.indexOf('dy="-17"')).toBeGreaterThan(0);
+    //   // hgc.instance().handleExportSVG();
+    //
+    //   done();
+    // });
 
-      // expect(svgText.indexOf('dy="-17"')).toBeGreaterThan(0);
-      // hgc.instance().handleExportSVG();
-
-      done();
-    });
-
-    it('Replaces one of the views and tries to export again', (done) => {
+    it('Replaces one of the views and tries to export again', () => {
       let { views } = hgc.instance().state;
 
       const newView = JSON.parse(JSON.stringify(views.aa));
@@ -379,8 +373,6 @@ describe('Simple HiGlassComponent', () => {
       // would maintain a reference to the closed view and we would try
       // to export it as SVG
       hgc.instance().createSVG();
-
-      done();
 
       // hgc.instance().createSVG();
     });
@@ -411,7 +403,7 @@ describe('Simple HiGlassComponent', () => {
       waitForTilesLoaded(hgc.instance(), done);
     });
 
-    it('Exports to SVG', (done) => {
+    it('Exports to SVG', () => {
       const svg = hgc.instance().createSVG();
       const svgText = new XMLSerializer().serializeToString(svg);
 
@@ -427,8 +419,6 @@ describe('Simple HiGlassComponent', () => {
       expect(svgText.indexOf('#777777')).toBeGreaterThan(0);
 
       // hgc.instance().handleExportSVG();
-
-      done();
     });
   });
 
@@ -461,7 +451,7 @@ describe('Simple HiGlassComponent', () => {
       // to the left
     });
 
-    it('Opens the track type menu', (done) => {
+    it('Opens the track type menu', () => {
       const clickPosition = {
         bottom: 85,
         height: 28,
@@ -514,19 +504,15 @@ describe('Simple HiGlassComponent', () => {
 
       expect(trackTypeItems.props.menuItems['horizontal-line']).toBeDefined();
       expect(trackTypeItems.props.menuItems['horizontal-point']).toBeDefined();
-
-      done();
     });
 
-    it('Changes the track type', (done) => {
+    it('Changes the track type', () => {
       // make sure that this doesn't error
       hgc.instance().tiledPlots.aa.handleChangeTrackType('line1', 'horizontal-bar');
 
       // make sure that the uid of the top track has been changed
       expect(hgc.instance().state.views.aa.tracks.top[0].uid).not.toEqual('line1');
       expect(hgc.instance().state.views.aa.tracks.top[0].type).toEqual('horizontal-bar');
-
-      done();
     });
   });
 
@@ -776,7 +762,7 @@ describe('Simple HiGlassComponent', () => {
       // to the left
     });
 
-    it('Ensures that only the gene-annotations and 1d-tiles tracks are listed', (done) => {
+    it('Ensures that only the gene-annotations and 1d-tiles tracks are listed', () => {
       const clickPosition = {
         bottom: 85,
         height: 28,
@@ -827,8 +813,6 @@ describe('Simple HiGlassComponent', () => {
       expect(trackTypeItems.props.menuItems['horizontal-gene-annotations']).toBeDefined();
       expect(trackTypeItems.props.menuItems['horizontal-1d-tiles']).toBeDefined();
       expect(trackTypeItems.props.menuItems['horizontal-line']).toBeUndefined();
-
-      done();
     });
   });
 
@@ -870,12 +854,10 @@ describe('Simple HiGlassComponent', () => {
       waitForTilesLoaded(hgc.instance(), done);
     });
 
-    it('exports as JSON and makes sure that the scales are locked', (done) => {
+    it('exports as JSON and makes sure that the scales are locked', () => {
       const data = hgc.instance().getViewsAsString();
 
       expect(data.indexOf('valueScaleLocks')).toBeGreaterThanOrEqual(0);
-
-      done();
     });
 
     it('Moves the brush on one view and makes sure it moves on the other', (done) => {
@@ -906,7 +888,7 @@ describe('Simple HiGlassComponent', () => {
       waitForTilesLoaded(hgc.instance(), done);
     });
 
-    it('ensures that the new track domains are equal', (done) => {
+    it('ensures that the new track domains are equal', () => {
       const track1 = getTrackObjectFromHGC(hgc.instance(), 'aa', 'heatmap1');
       const track2 = getTrackObjectFromHGC(hgc.instance(), 'view2', 'heatmap2');
 
@@ -924,10 +906,7 @@ describe('Simple HiGlassComponent', () => {
       // than the other
       // expect(zl1).toEqual(zl2);
 
-
       expect(domain1[1]).toEqual(domain2[1]);
-
-      done();
     });
 
     it('unlocks the scales', (done) => {
@@ -1006,7 +985,7 @@ describe('Simple HiGlassComponent', () => {
       waitForTilesLoaded(hgc.instance(), done);
     });
 
-    it('ensures that the new track domains are not equal', (done) => {
+    it('ensures that the new track domains are not equal', () => {
       const track1 = hgc.instance().tiledPlots.aa.trackRenderer.getTrackObject('heatmap1');
       const track2 = hgc.instance().tiledPlots.view2.trackRenderer.getTrackObject('heatmap2');
 
@@ -1020,26 +999,20 @@ describe('Simple HiGlassComponent', () => {
       // unlock the scales and zoom out
       // hgc.instance().tiledPlots['aa'].trackRenderer
       // .setCenter(1799432348.8692136, 1802017603.5768778, 2887.21283197403);
-
-      done();
     });
 
-    it('Lock view scales ', (done) => {
+    it('Lock view scales ', () => {
       hgc.instance().handleZoomLockChosen('aa', 'view2');
       hgc.instance().handleLocationLockChosen('aa', 'view2');
-
-      done();
     });
 
-    it('locks the value scales ', (done) => {
+    it('locks the value scales ', () => {
       // lock the value scales to ensure that removing the track doesn't
       // lead to an error
       hgc.instance().handleValueScaleLocked('aa', 'c1', 'view2', 'heatmap2');
-
-      done();
     });
 
-    it('Replaces and displays a new track', (done) => {
+    it('Replaces and displays a new track', () => {
       hgc.instance().handleCloseTrack('view2', 'c2');
       hgc.instance().handleTrackAdded('view2', heatmapTrack, 'center');
 
@@ -1051,8 +1024,6 @@ describe('Simple HiGlassComponent', () => {
         .trackRenderer.syncTrackObjects(
           hgc.instance().tiledPlots.view2.positionedTracks()
         );
-
-      done();
     });
 
     it('Replaces and displays a new track', (done) => {
@@ -1067,10 +1038,8 @@ describe('Simple HiGlassComponent', () => {
       waitForTilesLoaded(hgc.instance(), done);
     });
 
-    it('Locks the scales again (after waiting for the previous tiles to load)', (done) => {
+    it('Locks the scales again (after waiting for the previous tiles to load)', () => {
       hgc.instance().handleValueScaleLocked('aa', 'c1', 'view2', 'heatmap3');
-
-      done();
     });
   });
 
@@ -1103,7 +1072,7 @@ describe('Simple HiGlassComponent', () => {
       // to the left
     });
 
-    it('Opens the track type menu', (done) => {
+    it('Opens the track type menu', () => {
       const clickPosition = {
         bottom: 85,
         height: 28,
@@ -1152,11 +1121,9 @@ describe('Simple HiGlassComponent', () => {
 
       expect(trackTypeItems.props.menuItems['horizontal-line']).toBeUndefined();
       expect(trackTypeItems.props.menuItems['horizontal-point']).toBeUndefined();
-
-      done();
     });
 
-    it('Opens the close track menu', (done) => {
+    it('Opens the close track menu', () => {
       const clickPosition = {
         bottom: 85,
         height: 28,
@@ -1170,8 +1137,6 @@ describe('Simple HiGlassComponent', () => {
       const uid = 'line1';
 
       hgc.instance().tiledPlots.aa.handleCloseTrackMenuOpened(uid, clickPosition);
-
-      done();
     });
   });
   //
@@ -1244,9 +1209,9 @@ describe('Simple HiGlassComponent', () => {
       waitForTilesLoaded(hgc.instance(), done);
     });
 
-    it('renders with no errors', (done) => {
-      done();
-    });
+    // it('renders with no errors', (done) => {
+    //   done();
+    // });
   });
 
   describe('Track Resizing', () => {
@@ -1319,14 +1284,12 @@ describe('Simple HiGlassComponent', () => {
       waitForTilesLoaded(hgc.instance(), done);
     });
 
-    it('should load the initial config', (done) => {
+    it('should load the initial config', () => {
       // this was to test an example from the higlass-website demo page
       // where the issue was that the genome position search box was being
       // styled with a margin-bottom of 10px, fixed by setting the style of
       // genome-position-search to specify margin-bottom app/styles/GenomePositionSearchBox.css
       expect(hgc.instance().state.views.aa.layout.h).toEqual(6);
-
-      done();
     });
 
     it('should change the opacity of the first text label to 20%', (done) => {
@@ -1539,17 +1502,15 @@ describe('Simple HiGlassComponent', () => {
       waitForTilesLoaded(hgc.instance(), done);
     });
 
-    it('Changes the position of the brush to the top right', (done) => {
+    it('Changes the position of the brush to the top right', () => {
       const { views } = hgc.instance().state;
       views.aa.tracks.center[0].contents[0].options.colorbarPosition = 'topRight';
 
       hgc.instance().setState({ views });
-
-      done();
     });
 
 
-    it('Moves the brush on one of the views', (done) => {
+    it('Moves the brush on one of the views', () => {
       const track = getTrackObjectFromHGC(hgc.instance(), 'aa', 'heatmap1');
 
       const domain1 = track.limitedValueScale.domain();
@@ -1565,8 +1526,6 @@ describe('Simple HiGlassComponent', () => {
 
       // console.log('domain1:', domain1);
       // console.log('domain2:', domain2);
-
-      done();
     });
 
     it('locks the scales and recenters the page', (done) => {
@@ -1582,7 +1541,7 @@ describe('Simple HiGlassComponent', () => {
       waitForTilesLoaded(hgc.instance(), done);
     });
 
-    it('Moves the brush on one view and makes sure it moves on the other', (done) => {
+    it('Moves the brush on one view and makes sure it moves on the other', () => {
       const track = getTrackObjectFromHGC(hgc.instance(), 'aa', 'heatmap1');
 
       // console.log('lvs1', heatmapTrack.limitedValueScale.domain());
@@ -1599,8 +1558,6 @@ describe('Simple HiGlassComponent', () => {
         .toEqual(heatmap2Track.options.scaleStartPercent);
       expect(track.options.scaleEndPercent)
         .toEqual(heatmap2Track.options.scaleEndPercent);
-
-      done();
     });
   });
 
@@ -1668,11 +1625,11 @@ describe('Simple HiGlassComponent', () => {
       waitForTilesLoaded(hgc.instance(), done);
     });
 
-    it('Exports the views as SVG', (done) => {
-      // hgc.instance().handleExportSVG();
-
-      done();
-    });
+    // it('Exports the views as SVG', (done) => {
+    //   // hgc.instance().handleExportSVG();
+    //
+    //   done();
+    // });
   });
 
 
@@ -1714,15 +1671,13 @@ describe('Simple HiGlassComponent', () => {
       // to the left
     });
 
-    it('Gets and sets the viewconfig', (done) => {
+    it('Gets and sets the viewconfig', () => {
       const viewConf = hgc.instance().getViewsAsString();
 
       const newViews = hgc.instance().processViewConfig(JSON.parse(viewConf));
       hgc.setState({
         viewsByUid: newViews,
       });
-
-      done();
     });
   });
 
@@ -1764,17 +1719,14 @@ describe('Simple HiGlassComponent', () => {
       });
     });
 
-    it('Zooms one of the views to the center', (done) => {
+    it('Zooms one of the views to the center', () => {
       hgc.instance().api.zoomToDataExtent('view2');
-
-      done();
     });
 
-    it('Zooms a nonexistant view to the center', (done) => {
+    it('Zooms a nonexistant view to the center', () => {
       const badFn = () => hgc.instance().api.zoomToDataExtent('xxx');
 
       expect(badFn).toThrow();
-      done();
     });
   });
 
@@ -1893,7 +1845,7 @@ describe('Simple HiGlassComponent', () => {
       waitForTilesLoaded(hgc.instance(), done);
     });
 
-    it('Checks to make sure that the two views have moved to the same place', (done) => {
+    it('Checks to make sure that the two views have moved to the same place', () => {
       const aaXScale = hgc.instance().xScales.aa;
       const aaYScale = hgc.instance().yScales.aa;
 
@@ -1905,8 +1857,6 @@ describe('Simple HiGlassComponent', () => {
 
       expect(aaCenterX - bbCenterX).toBeLessThan(0.001);
       expect(aaCenterY - bbCenterY).toBeLessThan(0.001);
-
-      done();
     });
 
     it('Links the third view', (done) => {
@@ -2188,7 +2138,7 @@ describe('Simple HiGlassComponent', () => {
       waitForJsonComplete(done);
     });
 
-    it('Searches for strings with spaces at the beginning', (done) => {
+    it('Searches for strings with spaces at the beginning', () => {
       const gpsb = hgc.instance().genomePositionSearchBoxes.aa;
 
       let [range1, range2] = gpsb.searchField.searchPosition('  chr1:1-1000 & chr1:2001-3000');
@@ -2203,18 +2153,15 @@ describe('Simple HiGlassComponent', () => {
 
       expect(range1[0]).toEqual(1);
       expect(range1[1]).toEqual(1000);
-
-      done();
     });
 
-    it('Ensures that hg38 is in the list of available assemblies', (done) => {
+    it('Ensures that hg38 is in the list of available assemblies', () => {
       expect(
         hgc
           .instance()
           .genomePositionSearchBoxes.aa.state.availableAssemblies
           .indexOf('hg38')
       ).toBeGreaterThanOrEqual(0);
-      done();
     });
 
     it('Selects mm9', (done) => {
@@ -2348,7 +2295,7 @@ describe('Simple HiGlassComponent', () => {
       waitForTilesLoaded(hgc.instance(), done);
     });
 
-    it('Should flip the vertical heatmap', (done) => {
+    it('Should flip the vertical heatmap', () => {
       const { views } = hgc.instance().state;
       const track = getTrackByUid(views.aa.tracks, 'vh1');
 
@@ -2361,8 +2308,6 @@ describe('Simple HiGlassComponent', () => {
 
       // make sure the heatmap was flipped
       expect(trackObj.pMain.scale.y).toBeLessThan(0);
-
-      done();
     });
 
     it('Should remove the vertical heatmap', (done) => {
@@ -2387,18 +2332,16 @@ describe('Simple HiGlassComponent', () => {
       waitForTilesLoaded(hgc.instance(), done);
     });
 
-    it('should change the opacity of the label', (done) => {
+    it('should change the opacity of the label', () => {
       hgc.instance().state.views.aa.tracks.top[0].options.labelBackgroundOpacity = 0.5;
 
       hgc.setState(hgc.instance().state);
       const horizontalHeatmap = getTrackObjectFromHGC(hgc.instance(), 'aa', 'hh1');
 
       expect(horizontalHeatmap.options.labelBackgroundOpacity).toEqual(0.5);
-
-      done();
     });
 
-    it('should have a horizontal heatmap scale', (done) => {
+    it('should have a horizontal heatmap scale', () => {
       const horizontalHeatmap = getTrackObjectFromHGC(hgc.instance(), 'aa', 'hh1');
 
       const svg = horizontalHeatmap.exportColorBarSVG();
@@ -2406,8 +2349,6 @@ describe('Simple HiGlassComponent', () => {
       expect(rects.length).toBeGreaterThan(0);
 
       // let svgText = new XMLSerializer().serializeToString(svg);
-
-      done();
     });
 
     it('should add a large horizontal heatmap', (done) => {
@@ -2474,7 +2415,7 @@ describe('Simple HiGlassComponent', () => {
       waitForTilesLoaded(hgc.instance(), done);
     });
 
-    it('Checks to make sure the newly added heatmap was large enough and deletes a track', (done) => {
+    it('Checks to make sure the newly added heatmap was large enough and deletes a track', () => {
       const prevTotalHeight = hgc.instance().calculateViewDimensions(
         hgc.instance().state.views.aa
       ).totalHeight;
@@ -2491,7 +2432,6 @@ describe('Simple HiGlassComponent', () => {
       expect(nextTotalHeight).toBeLessThan(prevTotalHeight);
 
       // setTimeout(done, shortLoadTime);
-      done();
     });
 
     it('Should resize the center track', (done) => {
@@ -2505,7 +2445,7 @@ describe('Simple HiGlassComponent', () => {
       waitForTilesLoaded(hgc.instance(), done);
     });
 
-    it('Should add a bottom track and have the new height', (done) => {
+    it('Should add a bottom track and have the new height', () => {
       // const prevHeight = getTrackObjectFromHGC(hgc.instance(), 'aa', 'heatmap3').dimensions[1];
 
       const newTrack = JSON.parse(JSON.stringify(horizontalHeatmapTrack));
@@ -2515,7 +2455,7 @@ describe('Simple HiGlassComponent', () => {
       hgc.setState(hgc.instance().state);
       hgc.instance().tiledPlots.aa.measureSize();
       // skip this test for now
-      done();
+
       /*
 
       // adding a new track should not make the previous one smaller
@@ -2617,15 +2557,13 @@ describe('Simple HiGlassComponent', () => {
       // to the left
     });
 
-    it('clones itself', (done) => {
+    it('clones itself', () => {
       hgc.instance().handleAddView(hgc.instance().state.views.aa);
-
-      done();
     });
   });
 
   describe('Cleanup', () => {
-    it('Cleans up previously created instances and mounts a new component', (done) => {
+    it('Cleans up previously created instances and mounts a new component', () => {
       if (hgc) {
         hgc.unmount();
         hgc.detach();
@@ -2634,8 +2572,6 @@ describe('Simple HiGlassComponent', () => {
       if (div) {
         global.document.body.removeChild(div);
       }
-
-      done();
     });
   });
 });

--- a/test/HorizontalHeatmapTests.js
+++ b/test/HorizontalHeatmapTests.js
@@ -32,20 +32,16 @@ describe('Horizontal heatmaps', () => {
     );
   });
 
-  it('should respect zoom limits', (done) => {
+  it('should respect zoom limits', () => {
     // make sure that the correct zoom level is returned when a zoom
     // limit is set
 
     const trackObj = getTrackObjectFromHGC(hgc.instance(), 'vv', 'tt');
     expect(trackObj.calculateZoomLevel()).to.eql(1);
-
-    done();
   });
 
-  afterAll((done) => {
+  afterAll(() => {
     removeHGComponent(div);
-
-    done();
   });
 });
 

--- a/test/HorizontalMultivecTests.js
+++ b/test/HorizontalMultivecTests.js
@@ -29,14 +29,12 @@ describe('Horizontal heatmaps', () => {
     );
   });
 
-  it('not have errors in the loaded viewconf', (done) => {
-    done();
-  });
+  // it('not have errors in the loaded viewconf', (done) => {
+  //   done();
+  // });
 
-  afterAll((done) => {
+  afterAll(() => {
     removeHGComponent(div);
-
-    done();
   });
 });
 

--- a/test/LabelTests.js
+++ b/test/LabelTests.js
@@ -88,10 +88,8 @@ describe('Simple HiGlassComponent', () => {
       );
     });
 
-    afterAll((done) => {
+    afterAll(() => {
       removeHGComponent(div);
-
-      done();
     });
   });
 });

--- a/test/LeftTrackModifierTests.js
+++ b/test/LeftTrackModifierTests.js
@@ -32,7 +32,7 @@ describe('Horizontal heatmaps', () => {
     );
   });
 
-  it('should respect zoom limits', (done) => {
+  it('should respect zoom limits', () => {
     // add your tests here
 
     const trackObj = getTrackObjectFromHGC(hgc.instance(), 'vv', 'tt');
@@ -40,14 +40,10 @@ describe('Horizontal heatmaps', () => {
     // trackObj is a LeftTrackModifier that contains the
     // original track
     expect(trackObj.originalTrack.id).to.eql('tt');
-
-    done();
   });
 
-  afterAll((done) => {
+  afterAll(() => {
     removeHGComponent(div);
-
-    done();
   });
 });
 

--- a/test/OverlayTrackTests.js
+++ b/test/OverlayTrackTests.js
@@ -19,7 +19,7 @@ describe('Overlay Track:', () => {
   let viewConf;
 
   describe('Annotation overlays:', () => {
-    it('Should render', (done) => {
+    it('Should render', () => {
       viewConf = overlayAnnotations1d2dViewConf;
 
       [div, api] = createElementAndApi(viewConf, { bound: true });
@@ -55,8 +55,6 @@ describe('Overlay Track:', () => {
 
       expect(overlayTrackDef.width).toEqual(overlayTrackObj.dimensions[0]);
       expect(overlayTrackDef.height).toEqual(overlayTrackObj.dimensions[1]);
-
-      done();
     });
 
     afterEach(() => {

--- a/test/PluginTrackTests.js
+++ b/test/PluginTrackTests.js
@@ -15,7 +15,7 @@ describe('Overlay Track:', () => {
   let viewConf;
 
   describe('Annotation overlays:', () => {
-    it('Should render', (done) => {
+    it('Should render', () => {
       viewConf = dummyTrackViewConf;
 
       [div, api] = createElementAndApi(viewConf, { bound: true });
@@ -33,8 +33,6 @@ describe('Overlay Track:', () => {
       expect(dummyTrack.constructor.name).toEqual('DummyTrackClass');
 
       expect(dummyTrack.hgc).toEqual(trackRenderer.availableForPlugins);
-
-      done();
     });
 
     afterEach(() => {

--- a/test/TiledPixiTrackTests.js
+++ b/test/TiledPixiTrackTests.js
@@ -63,10 +63,8 @@ describe('Simple HiGlassComponent', () => {
       });
     });
 
-    afterAll((done) => {
+    afterAll(() => {
       removeHGComponent(div);
-
-      done();
     });
   });
 });

--- a/test/ViewConfigEditorTests.js
+++ b/test/ViewConfigEditorTests.js
@@ -128,8 +128,7 @@ describe('View Config Editor', () => {
       .toEqual(30);
   });
 
-  afterAll((done) => {
+  afterAll(() => {
     removeHGComponent(div);
-    done();
   });
 });

--- a/test/ViewManipulationTests.js
+++ b/test/ViewManipulationTests.js
@@ -37,22 +37,18 @@ describe('Simple HiGlassComponent', () => {
       );
     });
 
-    it('ensures that valueScaleLocks are removed when the viewconf changes', (done) => {
+    it('ensures that valueScaleLocks are removed when the viewconf changes', () => {
       const newViews = hgc.instance().processViewConfig(emptyConf);
       hgc.setState({
         views: newViews,
       });
 
       expect(Object.keys(hgc.instance().valueScaleLocks).length).to.eql(0);
-
-      done();
     });
 
-    afterAll((done) => {
-      // removeHGComponent(div);
-
-      done();
-    });
+    // afterAll(() => {
+    //   // removeHGComponent(div);
+    // });
   });
 
   describe('Viewport projection tests', () => {
@@ -83,10 +79,8 @@ describe('Simple HiGlassComponent', () => {
       });
     });
 
-    afterAll((done) => {
+    afterAll(() => {
       removeHGComponent(div);
-
-      done();
     });
   });
 });


### PR DESCRIPTION
## Description

What was changed in this pull request?
- remove unneeded `done()` calls.
- Comment out some no-op tests.

Why is it necessary?
- Cleaning up cruft is good.
- `done()` shouldn't just be boilerplate. Consider BarTrackTests.js:
```diff
    waitForTilesLoaded(hgc.instance(), () => {
      expect(trackObj.zeroLine.fill.color)
        .to.eql(colorToHex(trackConf.options.zeroLineColor));
      expect(trackObj.zeroLine.fill.alpha)
        .to.eql(trackConf.options.zeroLineOpacity);
      expect(
        Object.values(trackObj.fetchedTiles).every(tile => tile.svgData)
      ).to.eql(true);
+     done();
    });

-   done();
```
The `done()` had been outside, so none of the assertions inside the wait even mattered. If we only add a `done` parameter where we have a callback, and explicitly put the done inside, we can be more sure that we're testing what we meant to test.

Fixes #374 

## Checklist

- [x] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example added or updated
- [ ] Screenshot for visual changes (e.g. new tracks)
- [ ] Updated CHANGELOG.md
