### PR TITLE
Elevate react-in-jsx-scope; ignore sort-comp

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -97,9 +97,9 @@
     "react/no-unused-state": 0,
     "react/prefer-es6-class": 2,
     "react/prop-types": 1,
-    "react/react-in-jsx-scope": 1,
+    "react/react-in-jsx-scope": 2,
     "react/self-closing-comp": 2,
-    "react/sort-comp": 1
+    "react/sort-comp": 0
   },
   "overrides": [
     {

--- a/app/scripts/utils/test-helpers.js
+++ b/app/scripts/utils/test-helpers.js
@@ -1,10 +1,12 @@
 // In this project, these methods are only used in tests,
 // but plugin tracks also make use of them... so not really extraneous.
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+
 import { // eslint-disable-line import/no-extraneous-dependencies
   mount
 } from 'enzyme';
-
-import ReactDOM from 'react-dom';
 
 import { requestsInFlight } from '../services';
 


### PR DESCRIPTION
## Description

What was changed in this pull request?
- Change the status of two eslint rules

Why is it necessary?
- Warnings we'll just ignore aren't that useful. `react-in-jsx-scope` was easy, so why not. On the other hand, `sort-comp` looks like a small number of errors:
```
higlass/app/scripts/Autocomplete.js
  134:3   error    maybeScrollItemIntoView should be placed after setIgnoreBlur  react/sort-comp
higlass/app/scripts/HiGlassComponent.js
   373:3   error    zoomStartHandler should be placed after setChromInfo  react/sort-comp
higlass/app/scripts/TiledPlot.js
   163:3   error    waitForDOMAttachment should be placed after getIdealizedTrackPositionsOverlay  react/sort-comp
higlass/app/scripts/TrackArea.js
  19:3  error  handleMouseEnter should be placed after getControls  react/sort-comp
higlass/app/scripts/TrackRenderer.js
   402:3   error    dispatchEvent should be placed after setCenter       react/sort-comp
higlass/app/scripts/utils/test-helpers.js
  186:21  error  'React' must be in scope when using JSX  react/react-in-jsx-scope
```
... but that's just the first method out of order in each of these classes.

I think the on-going burden of needing to correctly order your methods isn't worth the small gain that comes from a predictable order... but if you'd prefer that we start enforcing this rule, I could do that instead. No strong feelings either way.

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example added or updated
- [ ] Screenshot for visual changes (e.g. new tracks)
- [ ] Updated CHANGELOG.md
