### PR TITLE
Check schema when we export json, and also test re-exporting fixtures

### DIFF
--- a/app/scripts/api.js
+++ b/app/scripts/api.js
@@ -235,7 +235,17 @@ const createApi = function api(context, pubSub) {
        * @returns (Object) A JSON object describing the visible views
        */
       getViewConfig() {
-        return self.getViewsAsJson();
+        const newViewConfig = self.getViewsAsJson();
+        const validate = new Ajv().compile(schema);
+        const valid = validate(newViewConfig);
+        if (validate.errors) {
+          console.warn(JSON.stringify(validate.errors, null, 2));
+        }
+        if (!valid) {
+          console.warn('Invalid viewconf');
+          // throw new Error('Invalid viewconf');
+        }
+        return newViewConfig;
       },
       /**
        * Get the minimum and maximum visible values for a given track.

--- a/test/SchemaTests.js
+++ b/test/SchemaTests.js
@@ -1,6 +1,7 @@
 /* eslint-env node, jasmine, mocha */
 import Ajv from 'ajv';
 import schema from '../app/schema.json';
+import createElementAndApi from './utils/create-element-and-api';
 
 
 describe('Viewconf JSON schema', () => {
@@ -26,7 +27,8 @@ describe('Viewconf JSON schema', () => {
     'overlay-track.json',
     'overlay-tracks.json'
   ].forEach((viewconfName) => {
-    it(`validates ${viewconfName}`, (done) => {
+    it(`validates original  of ${viewconfName}`, (done) => {
+      // (Extra space in message is to align the output of this test with the next.)
       const viewconfPath = `/base/docs/examples/viewconfs/${viewconfName}`;
 
       // Just dynamically requiring the JSON would be simpler, but I get this error:
@@ -48,6 +50,28 @@ describe('Viewconf JSON schema', () => {
           done();
           // If there are errors, the log can be noisy:
           // We could put in special code to handle that, if it's worth it.
+        });
+      });
+    });
+
+    it(`validates re-export of ${viewconfName}`, (done) => {
+      const viewconfPath = `/base/docs/examples/viewconfs/${viewconfName}`;
+
+      fetch(viewconfPath).then((viewconfResponse) => {
+        viewconfResponse.json().then((originalViewconf) => {
+          const [div, api] = createElementAndApi( // eslint-disable-line no-unused-vars
+            originalViewconf, { editable: false }
+          );
+
+          const viewconf = api.getViewConfig();
+          const valid = validate(viewconf);
+          if (validate.errors) {
+            console.warn(JSON.stringify(validate.errors, null, 2));
+          }
+          expect(validate.errors).toEqual(null);
+          expect(valid).toEqual(true);
+
+          done();
         });
       });
     });


### PR DESCRIPTION
## Description

What was changed in this pull request?
- Check schema when we export json
- and also test re-exporting fixtures

Why is it necessary?
- I think you suggested this?

(It's possible that this PR when combined with the ones to tighten the schema will produce errors that neither produced independently: I think this kind of scenario is exactly why travis starts two builds, so don't worry about it until we actually see a problem.)

## Checklist

- [x] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example added or updated
- [ ] Screenshot for visual changes (e.g. new tracks)
- [ ] Updated CHANGELOG.md
