### PR TITLE
Pkerpedjiev/sync value scale bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.5.8
+
+- Fix a value scale syncing bug
+
 ## v1.5.7
 
 - Fix #637 - SVG export fill color doesn't match what is selected

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -955,6 +955,12 @@ class HiGlassComponent extends React.Component {
 
         lockedTrack.valueScale.domain([allMin, allMax]);
 
+        // In TiledPixiTrack, we check if valueScale has changed before
+        // calling onValueScaleChanged. If we don't update prevValueScale
+        // here, that function won't get called and the value scales won't
+        // stay synced
+        lockedTrack.prevValueScale = lockedTrack.valueScale.copy();
+
         if (
           sourceTrack.options
           && typeof sourceTrack.options.scaleStartPercent !== 'undefined'


### PR DESCRIPTION
## Description

What was changed in this pull request?

Update `track.prevValueScale` in `syncValueScales` to fix a value scale syncing bug.

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example added or updated
- [ ] Screenshot for visual changes (e.g. new tracks)
- [x] Updated CHANGELOG.md
