### PR TITLE
Fix protocol to avoid CORS errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Updated `pub-sub-es` to version `1.2.1` to fix a bug in the shorthand event unsubscription
 - Added an example of a map overlay
 - Improve performance of the `mousemove`-related event handling
+- Fix OSM track
 - Fix #648: Auto select and copy URL when exporting a view by link
 - Fix #647: Shows correct URL when specifying an absolute URL as `exportViewUrl` in the viewconf
 - Fix #651: set correct namespace for SVG exports

--- a/app/scripts/OSMTilesTrack.js
+++ b/app/scripts/OSMTilesTrack.js
@@ -434,7 +434,7 @@ class OSMTilesTrack extends PixiTrack {
   getTileUrl(tileZxy) {
     const serverPrefixes = ['a', 'b', 'c'];
     const serverPrefixIndex = Math.floor(Math.random() * serverPrefixes.length);
-    const src = `http://${serverPrefixes[serverPrefixIndex]}.tile.openstreetmap.org/${tileZxy[0]}/${tileZxy[1]}/${tileZxy[2]}.png`;
+    const src = `https://${serverPrefixes[serverPrefixIndex]}.tile.openstreetmap.org/${tileZxy[0]}/${tileZxy[1]}/${tileZxy[2]}.png`;
 
     return src;
   }


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Update the protocol from `http` to `https` for fetching OSM tiles.

> Why is it necessary?

With the `http` protocol Chrome is throwing CORS errors

## Checklist

- ~[ ] Unit tests added or updated~
- ~[ ] Documentation added or updated~
- ~[ ] Example added or updated~
- ~[ ] Screenshot for visual changes (e.g. new tracks)~
- [x] Updated CHANGELOG.md
