### PR TITLE
Flekschas/osm hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Updated `pub-sub-es` to version `1.2.1` to fix a bug in the shorthand event unsubscription
 - Added an example of a map overlay
 - Improve performance of the `mousemove`-related event handling
-- Fix OSM track
+- Fix OSM track to avoid CORS issues in Chrome and allow setting `minPos` to `0`
 - Fix #648: Auto select and copy URL when exporting a view by link
 - Fix #647: Shows correct URL when specifying an absolute URL as `exportViewUrl` in the viewconf
 - Fix #651: set correct namespace for SVG exports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Updated `pub-sub-es` to version `1.2.1` to fix a bug in the shorthand event unsubscription
 - Added an example of a map overlay
 - Improve performance of the `mousemove`-related event handling
+- Fix OSM track
 - Fix #648: Auto select and copy URL when exporting a view by link
 - Fix #647: Shows correct URL when specifying an absolute URL as `exportViewUrl` in the viewconf
 - Fix #651: set correct namespace for SVG exports

--- a/app/scripts/OSMTilesTrack.js
+++ b/app/scripts/OSMTilesTrack.js
@@ -434,7 +434,7 @@ class OSMTilesTrack extends PixiTrack {
   getTileUrl(tileZxy) {
     const serverPrefixes = ['a', 'b', 'c'];
     const serverPrefixIndex = Math.floor(Math.random() * serverPrefixes.length);
-    const src = `http://${serverPrefixes[serverPrefixIndex]}.tile.openstreetmap.org/${tileZxy[0]}/${tileZxy[1]}/${tileZxy[2]}.png`;
+    const src = `https://${serverPrefixes[serverPrefixIndex]}.tile.openstreetmap.org/${tileZxy[0]}/${tileZxy[1]}/${tileZxy[2]}.png`;
 
     return src;
   }

--- a/app/scripts/OSMTilesTrack.js
+++ b/app/scripts/OSMTilesTrack.js
@@ -42,8 +42,21 @@ class OSMTilesTrack extends PixiTrack {
     // the graphics that have already been drawn for this track
     this.tileGraphics = {};
 
-    this.minX = +this.options.minPos || -180;
+    this.minX = (
+      typeof this.options.minPos !== 'undefined'
+      && !Number.isNaN(+this.options.minPos)
+    )
+      ? +this.options.minPos
+      : -180;
     this.maxX = +this.options.maxPos || 180;
+
+    this.maxX = (
+      typeof this.options.maxPos !== 'undefined'
+      && !Number.isNaN(+this.options.maxPos)
+    )
+      ? +this.options.maxPos
+      : 180;
+
     // HiGlass currently only supports squared tile sets but maybe in the
     // future...
     this.minY = this.options.minY || this.minX;


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Use `options.minPos` unless it's `undefined` or an invalid number

> Why is it necessary?

To allow `minPos` to be `0`

## Checklist

- [x] Updated CHANGELOG.md
