### PR TITLE
Mccalluc/test hi glass track component

### DIFF
--- a/app/scripts/TiledPlot.js
+++ b/app/scripts/TiledPlot.js
@@ -161,15 +161,17 @@ class TiledPlot extends React.Component {
   }
 
   waitForDOMAttachment(callback) {
-    if (!this.mounted) return;
-
-    const thisElement = ReactDOM.findDOMNode(this);
-
-    if (document.body.contains(thisElement)) {
-      callback();
-    } else {
-      requestAnimationFrame(() => this.waitForDOMAttachment(callback));
+    // console.log('wait...');
+    if (this.mounted) {
+      // console.log('mounted...');
+      if (document.body.contains(this.element)) {
+        // console.log('wait...')
+        callback();
+        return;
+      }
     }
+
+    requestAnimationFrame(() => this.waitForDOMAttachment(callback));
   }
 
   componentDidMount() {

--- a/app/scripts/hglib.js
+++ b/app/scripts/hglib.js
@@ -4,7 +4,7 @@ import HiGlassComponent from './HiGlassComponent';
 
 export { default as ChromosomeInfo } from './ChromosomeInfo';
 export { default as HiGlassComponent } from './HiGlassComponent';
-export { default as HiGlassTrackComponent, trackViewer } from './HiGlassTrackComponent';
+export { default as HiGlassTrackComponent } from './HiGlassTrackComponent';
 
 export { default as schema } from '../schema.json';
 

--- a/test/HiGlassTrackComponentTests.js
+++ b/test/HiGlassTrackComponentTests.js
@@ -1,0 +1,53 @@
+/* eslint-env node, jasmine */
+import {
+  configure,
+  mount,
+} from 'enzyme';
+
+import Adapter from 'enzyme-adapter-react-16';
+
+import React from 'react';
+
+import HiGlassTrackComponent from '../app/scripts/HiGlassTrackComponent';
+
+configure({ adapter: new Adapter() });
+
+describe('Simple HiGlassTrackComponent', () => {
+  let div;
+  let hgc;
+
+  it('mounts', (done) => {
+    div = global.document.createElement('div');
+
+    const trackConfig = {
+      server: '//higlass.io/api/v1',
+      tilesetUid: 'CQMd6V_cRw6iCI_-Unl3PQ',
+      type: 'heatmap',
+      options: {
+        colorRange: ['white', '#000'],
+        heatmapValueScaling: 'log',
+        scaleStartPercent: 0,
+        scaleEndPercent: 1,
+      }
+    };
+
+    hgc = mount(<HiGlassTrackComponent
+        height={100}
+        trackConfig={trackConfig}
+        width={100}
+        x={0}
+        y={0}
+    />, { attachTo: div });
+  });
+
+  afterEach(() => {
+    if (hgc) {
+      hgc.unmount();
+      hgc.detach();
+    }
+
+    if (div) {
+      global.document.body.removeChild(div);
+    }
+  });
+});


### PR DESCRIPTION
## Description

What was changed in this pull request?
- #693 didn't actually do what I needed it to do: The API was still not available when I needed it, and think because the render method on the inner component was not being called.
- This PR handles the composition of components in a more idiomatic way.
- To help with the test, I've tweaked `TiledPlot.waitForDomAttachment`... The live demo works, but `document.body.contains` does not work in the test... It's not really mounted in the DOM?

Why is it necessary?
- Still trying to get a react component that can show a 2d track and serve as a background for other tools.

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks)
- [ ] Updated CHANGELOG.md
