### PR TITLE
Add an option to make 2D annotations non-interactive

### DIFF
--- a/app/scripts/configs/options-info.js
+++ b/app/scripts/configs/options-info.js
@@ -48,6 +48,10 @@ const OPACITY_OPTIONS_NO_ZERO = sizesInPx([0.2, 0.4, 0.6, 0.8, 1.0], '%', 100);
 // these values define the options that are visible in the track config
 // menu
 export const OPTIONS_INFO = {
+  interactive: {
+    name: 'Interactive',
+    inlineOptions: YES_NO,
+  },
   axisLabelFormatting: {
     name: 'Axis Label Formatting',
     inlineOptions: {

--- a/app/scripts/configs/tracks-info.js
+++ b/app/scripts/configs/tracks-info.js
@@ -1291,6 +1291,7 @@ export const TRACKS_INFO = [
     name: '2D Annotations',
     thumbnail: svgArrowheadDomainsIcon,
     availableOptions: [
+      'interactive',
       'labelPosition',
       'labelLeftMargin',
       'labelRightMargin',
@@ -1305,7 +1306,6 @@ export const TRACKS_INFO = [
       'rectangleDomainStrokeColor',
       'rectangleDomainOpacity',
       'minSquareSize',
-      'isClickable',
       'hoverColor',
       'selectColor',
       'exclude',
@@ -1314,6 +1314,7 @@ export const TRACKS_INFO = [
       'trackBorderBgAlpha',
     ],
     defaultOptions: {
+      interactive: true,
       labelColor: 'black',
       labelPosition: 'hidden',
       labelLeftMargin: 0,
@@ -1326,7 +1327,6 @@ export const TRACKS_INFO = [
       rectangleDomainStrokeColor: 'black',
       rectangleDomainOpacity: 0.6,
       minSquareSize: 'none',
-      isClickable: false,
       hoverColor: 'orange',
       selectColor: 'fuchsia',
       exclude: [],


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Added an option called `interactive` for `2d-annotation` tracks, which by default is `true` (same behavior as before this PR. Setting `interactive: false` will draw all annotation bounding boxes onto the same graphics object and dramatically improve the performance at the expense of not having interactivity anymore, i.e., the user can't click on and select individual annotations anymore.

The option is accessible through the track context menu.

> Why is it necessary?

This greatly improves the performance when rendering ~1000 annotations from 30-40 FPS to 60 FPS

## Checklist

- [ ] Add test
- [x] Updated CHANGELOG.md
