### PR TITLE
Flekschas/fix minor issue with the positioning of track-related divs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Support semi-transparent colormaps through RGBA colors
 - Update Mapbox endpoint. See [http://localhost:8080/others/mapbox.html](http://localhost:8080/others/mapbox.html) for an example.
 - Improve performance of the `mousemove`-related event handling
+- Fix a minor visual glitch with the positioning of the gallery track
 - Fix OSM track to avoid CORS issues in Chrome and allow setting `minPos` to `0`
 - Fix #648: Auto select and copy URL when exporting a view by link
 - Fix #647: Shows correct URL when specifying an absolute URL as `exportViewUrl` in the viewconf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Support semi-transparent colormaps through RGBA colors
 - Update Mapbox endpoint. See [http://localhost:8080/others/mapbox.html](http://localhost:8080/others/mapbox.html) for an example.
 - Improve performance of the `mousemove`-related event handling
-- Fix a minor visual glitch with the positioning of the gallery track
+- Fix a minor visual glitch with the positioning of track-related `div`s
 - Fix OSM track to avoid CORS issues in Chrome and allow setting `minPos` to `0`
 - Fix #648: Auto select and copy URL when exporting a view by link
 - Fix #647: Shows correct URL when specifying an absolute URL as `exportViewUrl` in the viewconf

--- a/app/scripts/TiledPlot.js
+++ b/app/scripts/TiledPlot.js
@@ -1759,8 +1759,8 @@ class TiledPlot extends React.Component {
       <div
         className="top-track-container"
         style={{
-          left: this.leftWidth + this.props.marginLeft,
-          top: this.props.marginTop,
+          left: this.leftWidth + this.props.paddingLeft,
+          top: this.props.paddingTop,
           width: this.centerWidth,
           height: this.topHeightNoGallery,
           outline: trackOutline,
@@ -1798,8 +1798,8 @@ class TiledPlot extends React.Component {
       <div
         className="left-track-container"
         style={{
-          left: this.props.marginLeft,
-          top: this.topHeight + this.props.marginTop,
+          left: this.props.paddingLeft,
+          top: this.topHeight + this.props.paddingTop,
           width: this.leftWidthNoGallery,
           height: this.centerHeight,
           outline: trackOutline,
@@ -1836,8 +1836,8 @@ class TiledPlot extends React.Component {
       <div
         className="right-track-container"
         style={{
-          right: this.props.marginRight,
-          top: this.topHeight + this.props.marginTop,
+          right: this.props.paddingRight,
+          top: this.topHeight + this.props.paddingTop,
           width: this.rightWidthNoGallery,
           height: this.centerHeight,
           outline: trackOutline,
@@ -1875,8 +1875,8 @@ class TiledPlot extends React.Component {
       <div
         className="bottom-track-container"
         style={{
-          left: this.leftWidth + this.props.marginLeft,
-          bottom: this.props.marginBottom,
+          left: this.leftWidth + this.props.paddingLeft,
+          bottom: this.props.paddingBottom,
           width: this.centerWidth,
           height: this.bottomHeightNoGallery,
           outline: trackOutline,
@@ -1914,8 +1914,8 @@ class TiledPlot extends React.Component {
         key="galleryTracksDiv"
         className="gallery-track-container"
         style={{
-          left: this.leftWidthNoGallery + this.props.marginLeft,
-          top: this.topHeightNoGallery + this.props.marginTop,
+          left: this.leftWidthNoGallery + this.props.paddingLeft,
+          top: this.topHeightNoGallery + this.props.paddingTop,
           width: this.centerWidth + (2 * this.galleryDim),
           height: this.centerHeight + (2 * this.galleryDim),
           outline: trackOutline,
@@ -1940,8 +1940,8 @@ class TiledPlot extends React.Component {
       <div
         className="center-track-container"
         style={{
-          left: this.leftWidth + this.props.marginLeft,
-          top: this.topHeight + this.props.marginTop,
+          left: this.leftWidth + this.props.paddingLeft,
+          top: this.topHeight + this.props.paddingTop,
           width: this.centerWidth,
           height: this.bottomHeight,
           outline: trackOutline,
@@ -1955,8 +1955,8 @@ class TiledPlot extends React.Component {
         <div
           className="center-track-container"
           style={{
-            left: this.leftWidth + this.props.marginLeft,
-            top: this.topHeight + this.props.marginTop,
+            left: this.leftWidth + this.props.paddingLeft,
+            top: this.topHeight + this.props.paddingTop,
             width: this.centerWidth,
             height: this.centerHeight,
             outline: trackOutline,

--- a/app/scripts/TiledPlot.js
+++ b/app/scripts/TiledPlot.js
@@ -786,9 +786,6 @@ class TiledPlot extends React.Component {
     let offsetX = 0;
     let offsetY = 0;
 
-    const verticalPadding = this.props.paddingTop + this.props.paddingBottom;
-    const horizontalPadding = this.props.paddingLeft + this.props.paddingRight;
-
     switch (location) {
       case 'top':
         left += this.leftWidth;
@@ -862,13 +859,13 @@ class TiledPlot extends React.Component {
           this.state.width
           - this.leftWidthNoGallery
           - this.rightWidthNoGallery
-          - (2 * horizontalPadding)
+          - this.props.paddingLeft
         );
         height = (
           this.state.height
           - this.topHeightNoGallery
           - this.bottomHeightNoGallery
-          - (2 * verticalPadding)
+          - this.props.paddingTop
         );
         offsetX = this.galleryDim;
         offsetY = this.galleryDim;
@@ -1943,8 +1940,8 @@ class TiledPlot extends React.Component {
       <div
         className="center-track-container"
         style={{
-          left: this.leftWidth + this.props.paddingLeft,
-          top: verticalPadding + this.topHeight,
+          left: this.leftWidth + this.props.marginLeft,
+          top: this.topHeight + this.props.marginTop,
           width: this.centerWidth,
           height: this.bottomHeight,
           outline: trackOutline,
@@ -1958,8 +1955,8 @@ class TiledPlot extends React.Component {
         <div
           className="center-track-container"
           style={{
-            left: this.leftWidth + this.props.paddingLeft,
-            top: verticalPadding + this.topHeight,
+            left: this.leftWidth + this.props.marginLeft,
+            top: this.topHeight + this.props.marginTop,
             width: this.centerWidth,
             height: this.centerHeight,
             outline: trackOutline,


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Fixed an issue where padding and margin were mixed up and created a small offset in the positioning of the `center` and `gallery` tracks

> Why is it necessary?

Interaction-wise I don't think this glitch was noticeable because the padding is usually minor and all tracks were offset equally but it became noticeable in Scalable Insets. 

**Previously**:

![Screen Shot 2019-06-24 at 9 01 03 PM](https://user-images.githubusercontent.com/932103/60061636-d8b46180-96c3-11e9-81fb-3589c266db74.png)

![Screen Shot 2019-06-24 at 9 03 00 PM](https://user-images.githubusercontent.com/932103/60061643-e36ef680-96c3-11e9-8a7d-114e0a2abb9a.png)


**Now**:

![Screen Shot 2019-06-24 at 9 00 09 PM](https://user-images.githubusercontent.com/932103/60061621-d225ea00-96c3-11e9-8cc7-cc32819bf5c4.png)

![Screen Shot 2019-06-24 at 9 03 24 PM](https://user-images.githubusercontent.com/932103/60061650-e79b1400-96c3-11e9-9956-9f73d9c047a4.png)

## Checklist

- [x] Screenshot for visual changes (e.g. new tracks)
- [x] Updated CHANGELOG.md
