### PR TITLE
Support boolean values too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+**Next Version**
+
+- Treat `tilesetInfo.mirror_tiles = false` as a falsy value
+
+_[Detailed changes since v1.6.0](https://github.com/higlass/higlass/compare/v1.6.0...develop)_
+
 ## v1.6.0
 
 - Add an option to restrict the extent of central heatmaps to the upper-right or lower-left corner to enable comparison of two heatmaps in the center. Run `npm start` and see [http://localhost:8080/apis/svg.html?/viewconfs/diagonal-split-heatmap.json](http://localhost:8080/apis/svg.html?/viewconfs/diagonal-split-heatmap.json) for an example
@@ -18,28 +24,40 @@
 - Fix #651: set correct namespace for SVG exports
 - Fix #593: zoom to data extent when adding the first track to an empty view
 
+_[Detailed changes since v1.5.8](https://github.com/higlass/higlass/compare/v1.5.8...v1.6.0)_
+
 ## v1.5.8
 
 - Fix a value scale syncing bug
 - Update the docs
+
+_[Detailed changes since v1.5.7](https://github.com/higlass/higlass/compare/v1.5.7...v1.5.8)_
 
 ## v1.5.7
 
 - Fix #637 - SVG export fill color doesn't match what is selected
 - Switch to nearest neighbor interpolation for horizontal heatmaps
 
+_[Detailed changes since v1.5.8](https://github.com/higlass/higlass/compare/v1.5.6...v1.5.7)_
+
 ## v1.5.6
 
 - Allow any horizontal track to also be placed on the left or right
+
+_[Detailed changes since v1.5.8](https://github.com/higlass/higlass/compare/v1.5.6...v1.5.7)_
 
 ## v1.5.5
 
 - Fixed #612: resolved an issue with caseinsensitive chromosome names
 - Destroy heatmap sprites and axis texts to mitigate memory leak
 
+_[Detailed changes since v1.5.4](https://github.com/higlass/higlass/compare/v1.5.4...v1.5.5)_
+
 ## v1.5.4
 
 - Fix the multiple component passive event issue by replacing the dom-event.js handlers with a class so that each component maintains its own context
+
+_[Detailed changes since v1.5.3](https://github.com/higlass/higlass/compare/v1.5.3...v1.5.4)_
 
 ## v1.5.3
 
@@ -55,6 +73,8 @@ to be resized
 - Fixed horizontal-vector-heatmap error thrown bug by padding incomplete
   incoming data arrays
 
+_[Detailed changes since v1.5.1](https://github.com/higlass/higlass/compare/v1.5.1...v1.5.3)_
+
 ## v1.5.1
 
 - Fixed UI hanging on mouseover of zoomed out matrix bug
@@ -63,6 +83,8 @@ to be resized
 - Added a default track type for the chromsizes datatype
 - Fixed drag handler pubSub reference
 - Fixed #596: scrolling while zooming bug introduced in latest chrome
+
+_[Detailed changes since v1.5.0](https://github.com/higlass/higlass/compare/v1.5.0...v1.5.1)_
 
 ## v1.5.0
 
@@ -78,6 +100,8 @@ to be resized
 - Fix #291: allow web page scrolling when zoomFixed is set to true
 - Fix #578: BarTrack SVG export overplotting error.
 - Fix #584: Reset viewport is broken
+
+_[Detailed changes since v1.4.2](https://github.com/higlass/higlass/compare/v1.4.2...v1.5.0)_
 
 ## v1.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-**Next Version**
+## Next Version
 
 - Treat `tilesetInfo.mirror_tiles = false` as a falsy value
 

--- a/app/scripts/HeatmapTiledPixiTrack.js
+++ b/app/scripts/HeatmapTiledPixiTrack.js
@@ -1315,7 +1315,10 @@ class HeatmapTiledPixiTrack extends TiledPixiTrack {
   mirrorTiles() {
     return !(
       this.tilesetInfo.mirror_tiles
-      && this.tilesetInfo.mirror_tiles === 'false'
+      && (
+        this.tilesetInfo.mirror_tiles === false
+        || this.tilesetInfo.mirror_tiles === 'false'
+      )
     );
   }
 


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Treat `mirror_tiles = false` of `tilesetInfo` as a falsy value

> Why is it necessary?

Right now only `mirror_tiles = 'false'` will turn of tile mirroring. The boolean value should be treated equally otherwise it's confusing.

## Checklist

- ~[ ] Unit tests added or updated~
- ~[ ] Documentation added or updated~
- ~[ ] Example added or updated~
- ~[ ] Update schema.json if there are changes to the viewconf JSON structure format~
- ~[ ] Screenshot for visual changes (e.g. new tracks)~
- [x] Updated CHANGELOG.md
