### PR TITLE
Flekschas/svg export fix namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next Version
+
+- Really fix #651: set correct namespace for SVG exports
+
 ## v1.6.0
 
 - Add an option to restrict the extent of central heatmaps to the upper-right or lower-left corner to enable comparison of two heatmaps in the center. Run `npm start` and see [http://localhost:8080/apis/svg.html?/viewconfs/diagonal-split-heatmap.json](http://localhost:8080/apis/svg.html?/viewconfs/diagonal-split-heatmap.json) for an example

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -1138,13 +1138,9 @@ class HiGlassComponent extends React.Component {
   }
 
   createSVG() {
-    const xmlns = 'http://www.w3.org/2000/xmlns/';
-    const xlinkns = 'http://www.w3.org/1999/xlink';
-    const svgns = 'http://www.w3.org/2000/svg';
-
-    const svg = document.createElementNS(svgns, 'svg');
-    svg.setAttributeNS(xmlns, 'xmlns', svgns);
-    svg.setAttributeNS(xmlns, 'xmlns:xlink', xlinkns);
+    const svg = document.createElement('svg');
+    svg.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
+    svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
     svg.setAttribute('version', '1.1');
 
     for (const tiledPlot of dictValues(this.tiledPlots)) {
@@ -1173,6 +1169,14 @@ class HiGlassComponent extends React.Component {
 
     svgString = svgString.replace(/<a0:/g, '<');
     svgString = svgString.replace(/<\/a0:/g, '</');
+    // Remove duplicated xhtml namespace property
+    svgString = svgString.replace(
+      /(<svg[\n\r])(\s+xmlns="http:\/\/www\.w3\.org\/1999\/xhtml"[\n\r])/gm, '$1'
+    );
+    // Remove duplicated svg namespace
+    svgString = svgString.replace(
+      /(\s+<clipPath[\n\r]\s+)(xmlns="http:\/\/www\.w3\.org\/2000\/svg")/gm, '$1'
+    );
 
     const xmlDeclaration = '<?xml version="1.0" encoding="UTF-8" standalone="no"?>';
     const doctype = '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">';


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Finally fix the SVG namespace issues.

> Why is it necessary?

We introduced incorrect name spaces on group elements because they are created with `document.createElement()` and not `document.createElementNS()`.

Fixes #651

I've tested the exported SVG in Chrome, macOS preview, Affinity Designer. It works everywhere. Validating it with https://validator.w3.org/ reveals that the namespace issues are fixed. We still need to switch the `id` properties to `class` in the future to avoid the other warnings but the export should work properly now.

## Checklist

- ~[ ] Unit tests added or updated~
- ~[ ] Documentation added or updated~
- ~[ ] Example added or updated~
- ~[ ] Update schema.json if there are changes to the viewconf JSON structure format~
- ~[ ] Screenshot for visual changes (e.g. new tracks)~
- [x] Updated CHANGELOG.md
