### PR TITLE
Flekschas/fix horizontal heatmap track rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next Version
 
+- Render `horizontal-heatmap` track properly in PIXI v4 and v5
+
 _[Detailed changes since v1.6.1](https://github.com/higlass/higlass/compare/v1.6.0...develop)_
 
 ## v1.6.1

--- a/app/scripts/HorizontalHeatmapTrack.js
+++ b/app/scripts/HorizontalHeatmapTrack.js
@@ -163,8 +163,7 @@ class HorizontalHeatmapTrack extends HeatmapTiledPixiTrack {
         // draw it out to understand better!
         const tileBottomPosition = ((j - i) - 2)
           * (this._xScale(tileWidth) - this._xScale(0))
-          * Math.sqrt(2)
-          / 2;
+          * Math.sqrt(2) / 2;
 
         if (tileBottomPosition > this.dimensions[1]) {
           // this tile won't be visible so we don't need to fetch it
@@ -293,10 +292,11 @@ class HorizontalHeatmapTrack extends HeatmapTiledPixiTrack {
 
           const canvas = this.tileDataToCanvas(pixData.pixData);
 
-          let sprite = null;
-          sprite = new PIXI.Sprite(PIXI.Texture.fromCanvas(canvas, PIXI.SCALE_MODES.NEAREST));
+          const texture = PIXI.VERSION[0] === '4'
+            ? PIXI.Texture.fromCanvas(canvas, PIXI.SCALE_MODES.NEAREST)
+            : PIXI.Texture.from(canvas, { scaleMode: PIXI.SCALE_MODES.NEAREST });
 
-          tile.sprite = sprite;
+          tile.sprite = new PIXI.Sprite(texture);
           tile.canvas = canvas;
 
           this.setSpriteProperties(


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Render horizontal heatmap track properly in PIXI v4 and v5

> Why is it necessary?

In PIXI v5 the syntax changes slightly causing a deprecation warning and ignoring nearest neighbor interpolation.

## Checklist

- ~[ ] Unit tests added or updated~
- ~[ ] Documentation added or updated~
- ~[ ] Example added or updated~
- ~[ ] Update schema.json if there are changes to the viewconf JSON structure format~
- ~[ ] Screenshot for visual changes (e.g. new tracks)~
- [x] Updated CHANGELOG.md
