### PR TITLE
Flekschas/expose pixi renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next Version
 
 - Render `horizontal-heatmap` track properly in PIXI v4 and v5
+- Expose pixi renderer to plugin tracks to allow them to render textures from grsphics objects. (More here: https://github.com/pixijs/pixi.js/issues/5394)
 
 _[Detailed changes since v1.6.1](https://github.com/higlass/higlass/compare/v1.6.0...develop)_
 

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -3935,6 +3935,7 @@ class HiGlassComponent extends React.Component {
             paddingLeft={this.viewPaddingLeft}
             paddingRight={this.viewPaddingRight}
             paddingTop={this.viewPaddingTop}
+            pixiRenderer={this.pixiRenderer}
             pixiStage={this.pixiStage}
             pluginTracks={this.state.pluginTracks}
             rangeSelection1dSize={this.state.rangeSelection1dSize}

--- a/app/scripts/TiledPlot.js
+++ b/app/scripts/TiledPlot.js
@@ -2052,6 +2052,7 @@ class TiledPlot extends React.Component {
           onValueScaleChanged={this.props.onValueScaleChanged}
           paddingLeft={this.props.paddingLeft}
           paddingTop={this.props.paddingTop}
+          pixiRenderer={this.props.pixiRenderer}
           pixiStage={this.props.pixiStage}
           pluginTracks={this.props.pluginTracks}
           positionedTracks={positionedTracks}
@@ -2298,6 +2299,7 @@ TiledPlot.propTypes = {
   onUnlockValueScale: PropTypes.func,
   onValueScaleChanged: PropTypes.func,
   openModal: PropTypes.func,
+  pixiRenderer: PropTypes.object,
   pixiStage: PropTypes.object,
   pluginTracks: PropTypes.object,
   rangeSelection1dSize: PropTypes.array,

--- a/app/scripts/TrackRenderer.js
+++ b/app/scripts/TrackRenderer.js
@@ -115,6 +115,7 @@ class TrackRenderer extends React.Component {
 
     this.availableForPlugins = AVAILABLE_FOR_PLUGINS;
     this.availableForPlugins.services.pubSub = this.props.pubSub;
+    this.availableForPlugins.services.pixiRenderer = this.props.pixiRenderer;
 
     this.mounted = false;
 
@@ -1759,6 +1760,7 @@ TrackRenderer.propTypes = {
   metaTracks: PropTypes.array,
   onMouseMoveZoom: PropTypes.func,
   onScalesChanged: PropTypes.func.isRequired,
+  pixiRenderer: PropTypes.object.isRequired,
   pixiStage: PropTypes.object.isRequired,
   pluginTracks: PropTypes.object,
   positionedTracks: PropTypes.array,


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Expose pixi renderer to plugin tracks through `services`.

> Why is it necessary?

`generateTexture()` was deprecated in PIXI v4 and moved from `graphics` to `PixiRenderer`. In PIXI `v5` `generateTexture()` was completely removed form `graphics`. Tracks that relied on it (e.g., `higlass-multivec`) failed in HiGlass `v1.6` when used with PIXI `v5`.

According to PIXI folks one has to expose the renderer globally to make use of `generateTexture()`: https://github.com/pixijs/pixi.js/issues/5394

## Checklist

- ~[ ] Unit tests added or updated~
- ~[ ] Documentation added or updated~
- ~[ ] Example added or updated~
- ~[ ] Update schema.json if there are changes to the viewconf JSON structure format~
- ~[ ] Screenshot for visual changes (e.g. new tracks)~
- [x] Updated CHANGELOG.md~
