### PR TITLE
Flekschas/fix 1d heatmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next Version
 
+- Add support for missing values (`NaN`s) to the 1D heatmap track
+
 _[Detailed changes since v1.6.2](https://github.com/higlass/higlass/compare/v1.6.2...develop)_
 
 ## v1.6.2

--- a/app/scripts/Horizontal1dHeatmapTrack.js
+++ b/app/scripts/Horizontal1dHeatmapTrack.js
@@ -87,8 +87,13 @@ class Horizontal1dHeatmapTrack extends HorizontalLine1DPixiTrack {
     // const logScaling = this.options.valueScaling === 'log';
 
     for (let i = 0; i < tileValues.length; i++) {
-      const xPos = this._xScale(tileXScale(i));
+      if (Number.isNaN(tileValues[i])) continue;
+
       const rgbIdx = Math.round(this.valueScale(tileValues[i] + pseudocount));
+
+      if (Number.isNaN(+rgbIdx)) continue;
+
+      const xPos = this._xScale(tileXScale(i));
       const width = this._xScale(tileXScale(i + 1)) - xPos;
       const height = this.dimensions[1];
 


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Skip drawing for `NaN` values, i.e., keep that position transparent.

> Why is it necessary?

Previously 1D heatmap tracks crashed on `NaN` values

## Checklist

- ~[ ] Unit tests added or updated~
- ~[ ] Documentation added or updated~
- ~[ ] Example added or updated~
- ~[ ] Update schema.json if there are changes to the viewconf JSON structure format~
- ~[ ] Screenshot for visual changes (e.g. new tracks)~
- [x] Updated CHANGELOG.md
