### PR TITLE
Switch to the new share link url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix #722: added `labelShowResolution` as an option to allow hiding the `[Current data resolution...]` text
 - Add support for missing values (`NaN`s) to the 1D heatmap track
+- Use the new link format
 
 _[Detailed changes since v1.6.2](https://github.com/higlass/higlass/compare/v1.6.2...develop)_
 

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -2806,7 +2806,7 @@ class HiGlassComponent extends React.Component {
       })
       .then(_json => ({
         id: _json.uid,
-        url: `${parsedUrl.origin}/app/?config=${_json.uid}`
+        url: `${parsedUrl.origin}/l/?d=${_json.uid}`
       }));
 
     if (!fromApi) {


### PR DESCRIPTION
## Description

What was changed in this pull request?

The export as link dialog will now create links with the format `server/l/?d=uuid`. This will return a small dummy page with metadata for link unfurling.

Why is it necessary?

So that we can use link unfurling in Slack and Twitter

Fixes #___

## Checklist

- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks)
- [x] Updated CHANGELOG.md
