### PR TITLE
Dynamically update dark theme when the options change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next Version
 
+- Dynamically update dark theme when the options change
 - Fix #722: added `labelShowResolution` as an option to allow hiding the `[Current data resolution...]` text
 - Add support for missing values (`NaN`s) to the 1D heatmap track
 

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -176,7 +176,7 @@ class HiGlassComponent extends React.Component {
 
     this.unsetOnLocationChange = [];
 
-    if (props.options.isDarkTheme) setDarkTheme();
+    setDarkTheme(!props.options.isDarkTheme);
 
     this.viewconfLoaded = false;
 
@@ -567,6 +567,8 @@ class HiGlassComponent extends React.Component {
   }
 
   componentDidUpdate() {
+    setDarkTheme(!this.props.options.isDarkTheme);
+
     this.animate();
     this.triggerViewChangeDb();
   }


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Dynamically update HiGlass theme

> Why is it necessary?

Previously the theme was only set once on init. By in Jupyter the same HG instance is reused when a cell is called multiple time. So changing between themes didn't work previously.

![Jul-05-2019 21-51-05](https://user-images.githubusercontent.com/932103/60749914-0ffdfa80-9f6f-11e9-9f69-253d4d0fadfe.gif)

## Checklist

- ~[ ] Unit tests added or updated~
- ~[ ] Documentation added or updated~
- ~[ ] Example added or updated~
- ~[ ] Update schema.json if there are changes to the viewconf JSON structure format~
- [x] Screenshot for visual changes (e.g. new tracks)
- [x] Updated CHANGELOG.md
