### PR TITLE
Flekschas/copy tile data before mutating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
-## v1.6.5 
+## Next release
+
+- Copy the tile data before mutation to fix an issue when displaying the same tileset twice (once in the upper right and lower left triangle)
+
+_[Detailed changes since v1.6.5](https://github.com/higlass/higlass/compare/v1.6.5...develop)_
+
+## v1.6.5
 
 - Fixed the replace track bug (where replacing a center track wouldn't do anything)
 
-_[Detailed changes since v1.6.3](https://github.com/higlass/higlass/compare/v1.6.4...v1.6.5)_
+_[Detailed changes since v1.6.4](https://github.com/higlass/higlass/compare/v1.6.4...v1.6.5)_
 
 ## v1.6.4
 

--- a/app/scripts/DataFetcher.js
+++ b/app/scripts/DataFetcher.js
@@ -191,10 +191,9 @@ export default class DataFetcher {
         done: resolve,
         ids: tileIds.map(x => `${this.dataConfig.tilesetUid}.${x}`),
       }, this.pubSub, true));
+
       promise.then((returnedTiles) => {
-        // console.log('tileIds:', tileIds);
         const tilesetUid = dictValues(returnedTiles)[0].tilesetUid;
-        // console.log('tilesetUid:', tilesetUid);
         const newTiles = {};
 
         for (let i = 0; i < tileIds.length; i++) {

--- a/app/scripts/TiledPixiTrack.js
+++ b/app/scripts/TiledPixiTrack.js
@@ -585,7 +585,7 @@ class TiledPixiTrack extends PixiTrack {
     for (let i = 0; i < this.visibleTiles.length; i++) {
       const { tileId } = this.visibleTiles[i];
 
-      if (!loadedTiles[this.visibleTiles[i].remoteId]) { continue; }
+      if (!loadedTiles[this.visibleTiles[i].remoteId]) continue;
 
 
       if (this.visibleTiles[i].remoteId in loadedTiles) {
@@ -594,8 +594,11 @@ class TiledPixiTrack extends PixiTrack {
           this.fetchedTiles[tileId] = this.visibleTiles[i];
         }
 
-
-        this.fetchedTiles[tileId].tileData = loadedTiles[this.visibleTiles[i].remoteId];
+        // Store a shallow copy. If necessary we perform a deep copy of the
+        // dense data in `tile-proxy.js :: tileDataToPixData()`
+        this.fetchedTiles[tileId].tileData = {
+          ...loadedTiles[this.visibleTiles[i].remoteId]
+        };
 
         if (this.fetchedTiles[tileId].tileData.error) {
           console.warn('Error in loaded tile', tileId, this.fetchedTiles[tileId].tileData);
@@ -617,8 +620,8 @@ class TiledPixiTrack extends PixiTrack {
 
 
     /*
-         * Mainly called to remove old unnecessary tiles
-         */
+     * Mainly called to remove old unnecessary tiles
+     */
     this.synchronizeTilesAndGraphics();
 
     // we need to draw when we receive new data

--- a/app/scripts/TiledPixiTrack.js
+++ b/app/scripts/TiledPixiTrack.js
@@ -594,11 +594,24 @@ class TiledPixiTrack extends PixiTrack {
           this.fetchedTiles[tileId] = this.visibleTiles[i];
         }
 
-        // Store a shallow copy. If necessary we perform a deep copy of the
-        // dense data in `tile-proxy.js :: tileDataToPixData()`
-        this.fetchedTiles[tileId].tileData = {
-          ...loadedTiles[this.visibleTiles[i].remoteId]
-        };
+        // Fritz: Store a shallow copy. If necessary we perform a deep copy of
+        // the dense data in `tile-proxy.js :: tileDataToPixData()`
+        // Somehow 2d rectangular domain tiles do not come in the flavor of an
+        // object but an object array...
+        if (Array.isArray(loadedTiles[this.visibleTiles[i].remoteId])) {
+          const tileData = loadedTiles[this.visibleTiles[i].remoteId];
+          this.fetchedTiles[tileId].tileData = [...tileData];
+          // Fritz: this is sooo hacky... we should really not use object arrays
+          Object.keys(tileData)
+            .filter(key => Number.isNaN(+key))
+            .forEach((key) => {
+              this.fetchedTiles[tileId].tileData[key] = tileData[key];
+            });
+        } else {
+          this.fetchedTiles[tileId].tileData = {
+            ...loadedTiles[this.visibleTiles[i].remoteId]
+          };
+        }
 
         if (this.fetchedTiles[tileId].tileData.error) {
           console.warn('Error in loaded tile', tileId, this.fetchedTiles[tileId].tileData);

--- a/app/scripts/services/tile-proxy.js
+++ b/app/scripts/services/tile-proxy.js
@@ -2,7 +2,6 @@ import { range } from 'd3-array';
 import slugid from 'slugid';
 
 import {
-  // workerFetchTiles,
   workerGetTiles,
   workerSetPix,
 } from '../worker';
@@ -249,20 +248,6 @@ export function fetchMultiRequestTiles(req, pubSub) {
 export const fetchTilesDebounced = throttleAndDebounce(
   fetchMultiRequestTiles, TILE_FETCH_DEBOUNCE, TILE_FETCH_DEBOUNCE
 );
-
-/**
- * Retrieve a set of tiles from the server
- *
- * Plenty of room for optimization and caching here.
- *
- * @param server: A string with the server's url (e.g. "http://127.0.0.1")
- * @param tileIds: The ids of the tiles to fetch (e.g. asdf-sdfs-sdfs.0.0.0)
- */
-// export const fetchTiles = (tilesetServer, tilesetIds, done) => workerFetchTiles(
-//   tilesetServer, tilesetIds, this.sessionId, (results) => {
-//     done(results);
-//   }
-// );
 
 /**
  * Calculate the zoom level from a list of available resolutions
@@ -676,7 +661,6 @@ const api = {
   calculateTileWidth,
   calculateZoomLevel,
   calculateZoomLevelFromResolutions,
-  // fetchTiles,
   fetchTilesDebounced,
   json,
   text,

--- a/app/scripts/services/tile-proxy.js
+++ b/app/scripts/services/tile-proxy.js
@@ -2,7 +2,7 @@ import { range } from 'd3-array';
 import slugid from 'slugid';
 
 import {
-  workerFetchTiles, // eslint-disable-line import/named
+  // workerFetchTiles,
   workerGetTiles,
   workerSetPix,
 } from '../worker';
@@ -258,11 +258,11 @@ export const fetchTilesDebounced = throttleAndDebounce(
  * @param server: A string with the server's url (e.g. "http://127.0.0.1")
  * @param tileIds: The ids of the tiles to fetch (e.g. asdf-sdfs-sdfs.0.0.0)
  */
-export const fetchTiles = (tilesetServer, tilesetIds, done) => workerFetchTiles(
-  tilesetServer, tilesetIds, this.sessionId, (results) => {
-    done(results);
-  }
-);
+// export const fetchTiles = (tilesetServer, tilesetIds, done) => workerFetchTiles(
+//   tilesetServer, tilesetIds, this.sessionId, (results) => {
+//     done(results);
+//   }
+// );
 
 /**
  * Calculate the zoom level from a list of available resolutions
@@ -535,6 +535,11 @@ export const tileDataToPixData = (
     && tile.tileData.tilePos.length > 0
     && tile.tileData.tilePos[0] === tile.tileData.tilePos[1]
   ) {
+    // Copy the data before mutating it in case the same data is used elsewhere.
+    // During throttling/debouncing tile requests we also merge the requests so
+    // the very same tile data might be used by different tracks.
+    tile.tileData.dense = tile.tileData.dense.slice();
+
     // if a center tile is mirrored, we'll just add its transpose
     const tileWidth = Math.floor(Math.sqrt(tile.tileData.dense.length));
     for (let row = 0; row < tileWidth; row++) {
@@ -671,7 +676,7 @@ const api = {
   calculateTileWidth,
   calculateZoomLevel,
   calculateZoomLevelFromResolutions,
-  fetchTiles,
+  // fetchTiles,
   fetchTilesDebounced,
   json,
   text,

--- a/test/HeatmapTests.js
+++ b/test/HeatmapTests.js
@@ -12,7 +12,8 @@ import { expect } from 'chai';
 import {
   mountHGComponent,
   removeHGComponent,
-  getTrackObjectFromHGC
+  getTrackObjectFromHGC,
+  waitForTilesLoaded
 } from '../app/scripts/utils';
 
 import {
@@ -93,7 +94,7 @@ describe('Heatmaps', () => {
     let div = null;
 
     beforeAll((done) => {
-      [div, hgc] = mountHGComponent(div, hgc, baseConf, done, { bounded: true });
+      [div, hgc] = mountHGComponent(div, hgc, baseConf, done);
     });
 
     it('should adjust options when new heatmap is added', () => {
@@ -111,7 +112,7 @@ describe('Heatmaps', () => {
       expect(options1.mousePositionColor).to.eql(options0.mousePositionColor);
     });
 
-    it('should adjust posiiton of name and colorbar when extent is triangular', () => {
+    it('should adjust position of name and colorbar when extent is triangular', () => {
       const views = JSON.parse(JSON.stringify(hgc.instance().state.views));
       const center = views.v.tracks.center[0];
 
@@ -135,6 +136,21 @@ describe('Heatmaps', () => {
       expect(options0.colorbarPosition).to.eql('bottomLeft');
       expect(options1.labelPosition).to.eql('topRight');
       expect(options1.colorbarPosition).to.eql('topRight');
+    });
+
+    it('tiles on the diagonal should be independent', (done) => {
+      const trackObj0 = getTrackObjectFromHGC(hgc.instance(), 'v', 'heatmap0');
+      const trackObj1 = getTrackObjectFromHGC(hgc.instance(), 'v', 'heatmap1');
+
+      waitForTilesLoaded(hgc.instance(), () => {
+        expect(trackObj0.fetchedTiles['2.1.1.false'].tileData)
+          .to.not.eql(trackObj1.fetchedTiles['2.1.1.true'].tileData);
+
+        expect(trackObj0.fetchedTiles['2.1.1.false'].tileData.dense)
+          .to.not.eql(trackObj1.fetchedTiles['2.1.1.true'].tileData.dense);
+
+        done();
+      });
     });
 
     afterAll(() => {
@@ -244,6 +260,7 @@ const baseConf = {
                 tilesetUid: 'CQMd6V_cRw6iCI_-Unl3PQ',
                 type: 'heatmap',
                 uid: 'heatmap0',
+                height: 400,
                 options: {
                   colorRange: ['white', 'black'],
                   showMousePosition: true,
@@ -264,5 +281,6 @@ const heatmapTrack = {
   tilesetUid: 'B2LevKBtRNiCMX372rRPLQ',
   type: 'heatmap',
   uid: 'heatmap1',
+  height: 400,
   options: { colorRange: ['white', 'black'] }
 };


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Copy tile data before mutating it.

> Why is it necessary?

To render the same tileset twice (once in the upper right triangle and once in the lower left triangle) without causing rendering issues for tiles on the diagonal.

Generally, due to throttling/debouncing tile requests are bundled (which is a great thing!) and duplicated tile requests are deduplicated. Unfortunately, this causes issues when rendering the same tileset in the upper and lower triangle because for tile mirroring we're mutating the tile data. Previously this wasn't an issue because central heatmaps with a full extent simply copied the data. For triangular matrices, we now only move the data such that one triangle of the diagonal tiles remains transparent. Therefore, I added a 2-way copying strategy. By default the base object is shallowly-copied, meaning that the dense data remains the same even if multiple tracks use the same tile data. This should be super cheap. Once a track wants to mutate the tile data it first creates a deep copy of the dense data so in case other tracks want the unmutated data they are not affected.

**Before:**

![Screen Shot 2019-07-16 at 4 19 54 PM](https://user-images.githubusercontent.com/932103/61326878-b3f46b00-a7e5-11e9-84f9-eb5a3dcaa149.png)

**After (with fix):**

![Screen Shot 2019-07-16 at 4 20 33 PM](https://user-images.githubusercontent.com/932103/61326887-b8208880-a7e5-11e9-9a72-d65b797a0eae.png)

## Checklist

- [x] Unit tests added or updated
- ~[ ] Documentation added or updated~
-~[ ] Example added or updated~
- ~[ ] Update schema.json if there are changes to the viewconf JSON structure format~
- [x] Screenshot for visual changes (e.g. new tracks)
- [x] Updated CHANGELOG.md
