### PR TITLE
Flekschas/fix drag handle styling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: node_js
 node_js:
 - '9'
@@ -11,10 +12,10 @@ before_install:
     - dpkg --compare-versions `npm -v` ge 6.5.0 || npm i -g npm@^6.5.0
 install:
     - npm install -g xvfb-maybe
-services:
-    - xvfb
 before_script:
     - export CHROME_BIN=chromium-browser
+    - export DISPLAY=:99.0	
+    - sh -e /etc/init.d/xvfb start
     - npm install --quiet -g gulp
     - npm install -g jsdoc
     - npm clean-install

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ before_install:
     - dpkg --compare-versions `npm -v` ge 6.5.0 || npm i -g npm@^6.5.0
 install:
     - npm install -g xvfb-maybe
+services:
+    - xvfb
 before_script:
     - export CHROME_BIN=chromium-browser
-    - export DISPLAY=:99.0
-    - sh -e /etc/init.d/xvfb start
     - npm install --quiet -g gulp
     - npm install -g jsdoc
     - npm clean-install

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
     - npm install -g xvfb-maybe
 before_script:
     - export CHROME_BIN=chromium-browser
-    - export DISPLAY=:99.0	
+    - export DISPLAY=:99.0
     - sh -e /etc/init.d/xvfb start
     - npm install --quiet -g gulp
     - npm install -g jsdoc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next release
 
+- Fix drag handle styling (typo)
+- Make drag handle area (not the style) bigger so it's easier to grab
+
 _[Detailed changes since v1.6.6](https://github.com/higlass/higlass/compare/v1.6.6...develop)_
 
 # v1.6.6

--- a/app/scripts/DraggableDiv.js
+++ b/app/scripts/DraggableDiv.js
@@ -268,34 +268,27 @@ class DraggableDiv extends React.Component {
   /* ------------------------------ Rendering ------------------------------- */
 
   render() {
-    const dragColor = this.props.theme === THEME_DARK ? 'black' : 'white';
+    const dragColor = this.props.theme === THEME_DARK ? 'white' : 'black';
 
     const divStyle = {
       top: this.state.top,
       left: this.state.left,
       width: this.state.width,
       height: this.state.height,
-      backgroundColor: 'transparent',
-      boxSizing: 'border-box',
       opacity: this.props.opacity
     };
 
-    const resizeWidth = 10;
-    const resizeHeight = 10;
+    const resizeWidth = 24;
+    const resizeHeight = 24;
 
     const horizStyle = {
       left: (this.state.width / 2) - (resizeWidth / 2),
       width: resizeWidth,
-      borderBottom: `1px solid ${dragColor}`,
-      borderTop: `1px solid ${dragColor}`,
     };
 
     const vertStyle = {
-      left: 1,
       top: (this.state.height / 2) - (resizeHeight / 2),
       height: resizeHeight,
-      borderLeft: `1px solid ${dragColor}`,
-      borderRight: `1px solid ${dragColor}`,
     };
 
     const styles = {
@@ -313,7 +306,12 @@ class DraggableDiv extends React.Component {
           style={styles[x]}
           styleName={`${x}-draggable-handle`}
           title="Resize track"
-        />
+        >
+          <div
+            style={{ borderColor: dragColor }}
+            styleName={`${x}-draggable-handle-grabber`}
+          />
+        </div>
       ));
 
     return (

--- a/app/styles/DraggableDiv.module.scss
+++ b/app/styles/DraggableDiv.module.scss
@@ -1,5 +1,4 @@
 @import './colors';
-@import './sizes';
 @import './transitions';
 
 .top-right-handle,
@@ -66,6 +65,9 @@
 .draggable-div:hover .left-draggable-handle,
 .draggable-div:hover .right-draggable-handle {
   opacity: 0.5;
+  background: rgba(255, 255, 255, 0.75);
+  box-shadow: 0 0 3px 1px rgba(255, 255, 255, 0.75);
+  border-radius: 3px;
 }
 
 .top-draggable-handle:hover, .top-draggable-handle:active,

--- a/app/styles/DraggableDiv.module.scss
+++ b/app/styles/DraggableDiv.module.scss
@@ -1,4 +1,5 @@
 @import './colors';
+@import './sizes';
 @import './transitions';
 
 .top-right-handle,
@@ -23,11 +24,48 @@
               opacity $fast $ease;
 }
 
+.draggable-div {
+  background-color: transparent;
+  box-sizing: border-box;
+}
+
+.top-draggable-handle-grabber,
+.bottom-draggable-handle-grabber {
+  width: 10px;
+  height: 4px;
+  border-top: 1px solid black;
+  border-bottom: 1px solid black;
+}
+
+.top-draggable-handle-grabber {
+  margin: 3px 7px 3px 7px;
+}
+
+.bottom-draggable-handle-grabber {
+  margin: 3px 7px 3px 7px;
+}
+
+.left-draggable-handle-grabber,
+.right-draggable-handle-grabber {
+  width: 4px;
+  height: 10px;
+  border-left: 1px solid black;
+  border-right: 1px solid black;
+}
+
+.left-draggable-handle-grabber {
+  margin: 7px 3px 7px 3px;
+}
+
+.right-draggable-handle-grabber {
+  margin: 7px 3px 7px 3px;
+}
+
 .draggable-div:hover .top-draggable-handle,
 .draggable-div:hover .bottom-draggable-handle,
 .draggable-div:hover .left-draggable-handle,
 .draggable-div:hover .right-draggable-handle {
-  opacity: 0.2;
+  opacity: 0.5;
 }
 
 .top-draggable-handle:hover, .top-draggable-handle:active,
@@ -36,19 +74,24 @@
 .right-draggable-handle:hover, .right-draggable-handle:active {
   opacity: 1 !important;
   transform: scale(2);
-  box-shadow: 0 0 3px 1px $blue-lighter;
-  background: $blue-lighter;
-}
 
+  .top-draggable-handle-grabber,
+  .bottom-draggable-handle-grabber,
+  .left-draggable-handle-grabber,
+  .right-draggable-handle-grabber {
+    box-shadow: 0 0 3px 1px $blue-lighter;
+    background: $blue-lighter;
+  }
+}
 
 .top-draggable-handle,
 .bottom-draggable-handle {
-  height: 4px;
+  height: 12px;
   cursor: row-resize;
 }
 
 .left-draggable-handle,
 .right-draggable-handle {
-  width: 4px;
+  width: 12px;
   cursor: col-resize;
 }

--- a/app/styles/DraggableDiv.module.scss
+++ b/app/styles/DraggableDiv.module.scss
@@ -38,11 +38,11 @@
 }
 
 .top-draggable-handle-grabber {
-  margin: 3px 7px 3px 7px;
+  margin: 4px 7px 4px 7px;
 }
 
 .bottom-draggable-handle-grabber {
-  margin: 3px 7px 3px 7px;
+  margin: 4px 7px 4px 7px;
 }
 
 .left-draggable-handle-grabber,
@@ -54,11 +54,11 @@
 }
 
 .left-draggable-handle-grabber {
-  margin: 7px 3px 7px 3px;
+  margin: 7px 4px 7px 4px;
 }
 
 .right-draggable-handle-grabber {
-  margin: 7px 3px 7px 3px;
+  margin: 7px 4px 7px 4px;
 }
 
 .draggable-div:hover .top-draggable-handle,


### PR DESCRIPTION
## Description

> What was changed in this pull request?

1. Fixes the drag handle color

**Working example**
![Jul-24-2019 10-11-48](https://user-images.githubusercontent.com/932103/61801338-93876a80-adfc-11e9-9891-c303afdd7f76.gif)

2. Making the handle area (not the visual representation) bigger

**See how the grabber is triggered before the mouse cursor enters the grabber**
![Jul-24-2019 10-14-36](https://user-images.githubusercontent.com/932103/61801381-a9952b00-adfc-11e9-896f-9b3c07f92818.gif)

This is achieved by invisible padding. For demonstration that area is drawn in yellow here:

![Screen Shot 2019-07-24 at 10 16 54 AM](https://user-images.githubusercontent.com/932103/61801425-bfa2eb80-adfc-11e9-8b1e-16bcc3266332.png)

![Screen Shot 2019-07-24 at 10 17 02 AM](https://user-images.githubusercontent.com/932103/61801433-c2054580-adfc-11e9-8786-6e6c5588ce83.png)

3. I added some translucent white background to the handle area to make it a tad easier to see

![Screen Shot 2019-07-24 at 10 33 05 AM](https://user-images.githubusercontent.com/932103/61802518-96835a80-adfe-11e9-9ab7-3da31e7ddfae.png)

![Screen Shot 2019-07-24 at 10 32 33 AM](https://user-images.githubusercontent.com/932103/61802521-997e4b00-adfe-11e9-9093-dc00275cc243.png)


> Why is it necessary?

1. Drag handle was drawn in white in the light theme... 😬 I accidentally introduced a typo.

2. Bigger drag handle area === easier grabbing

## Checklist

- ~[ ] Unit tests added or updated`
- ~[ ] Documentation added or updated~
- ~[ ] Example added or updated~
- ~[ ] Update schema.json if there are changes to the viewconf JSON structure format~
- [x] Screenshot for visual changes (e.g. new tracks)
- [x] Updated CHANGELOG.md
