### PR TITLE
Flekschas/fix tooltip position when page was scrolled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: node_js
 node_js:
 - '9'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next release
 
+- Fix #743: the tool tip position now incorporates the scroll position
+
 _[Detailed changes since v1.6.6](https://github.com/higlass/higlass/compare/v1.6.6...develop)_
 
 # v1.6.6

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -3715,7 +3715,10 @@ class HiGlassComponent extends React.Component {
 
     mouseOverDiv = select('body').selectAll('.track-mouseover-menu');
     const mousePos = clientPoint(select('body').node(), evt.origEvt);
-
+    const normalizedMousePos = [
+      mousePos[0] - window.scrollX,
+      mousePos[1] - window.scrollY,
+    ];
 
     /*
     mouseOverDiv.selectAll('.mouseover-marker')
@@ -3726,8 +3729,8 @@ class HiGlassComponent extends React.Component {
     */
 
     mouseOverDiv
-      .style('left', `${mousePos[0]}px`)
-      .style('top', `${mousePos[1]}px`);
+      .style('left', `${normalizedMousePos[0]}px`)
+      .style('top', `${normalizedMousePos[1]}px`);
 
     // probably not over a track so there's no mouseover rectangle
     if (!mouseOverDiv.node()) return;
@@ -3737,13 +3740,17 @@ class HiGlassComponent extends React.Component {
     if (bbox.x + bbox.width > window.innerWidth) {
       // the overlay box is spilling outside of the track so switch
       // to showing it on the left
-      mouseOverDiv.style('left', `${(mousePos[0] - bbox.width)}px`);
+      mouseOverDiv.style(
+        'left', `${(normalizedMousePos[0] - bbox.width)}px`
+      );
     }
 
     if (bbox.y + bbox.height > window.innerHeight) {
       // the overlay box is spilling outside of the track so switch
       // to showing it on the left
-      mouseOverDiv.style('top', `${(mousePos[1] - bbox.height)}px`);
+      mouseOverDiv.style(
+        'top', `${(normalizedMousePos[1] - bbox.height)}px`
+      );
     }
 
     mouseOverDiv.html(mouseOverHtml);


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Normalize the mouse position by the page's scroll offset

**Before**

![before](https://user-images.githubusercontent.com/932103/61804510-02b38d80-ae02-11e9-96f9-968127a25a0f.gif)


**After (i.e., with fix)**

![after](https://user-images.githubusercontent.com/932103/61804429-e9aadc80-ae01-11e9-8aaa-62bf3b810655.gif)


> Why is it necessary?

Fixes #743

## Checklist

- ~[ ] Unit tests added or updated~
- ~[ ] Documentation added or updated~
- ~[ ] Example added or updated~
- ~[ ] Update schema.json if there are changes to the viewconf JSON structure format~
- [x] Screenshot for visual changes (e.g. new tracks)
- [x] Updated CHANGELOG.md
