### PR TITLE
Add check for setting proper GitHub labels to the PR template. Minor changes to the wording.

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,21 @@
 ## Description
 
-What was changed in this pull request?
+> What was changed in this pull request?
 
-Why is it necessary?
+...
+
+> Why is it necessary?
+
+...
 
 Fixes #___
 
 ## Checklist
 
+- [ ] Set proper GitHub labels
 - [ ] Unit tests added or updated
 - [ ] Documentation added or updated
-- [ ] Example added or updated
+- [ ] Example(s) added or updated
 - [ ] Update schema.json if there are changes to the viewconf JSON structure format
-- [ ] Screenshot for visual changes (e.g. new tracks)
+- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
 - [ ] Updated CHANGELOG.md

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,11 +2,9 @@
 
 > What was changed in this pull request?
 
-...
+
 
 > Why is it necessary?
-
-...
 
 Fixes #___
 


### PR DESCRIPTION
## Description

> What was changed in this pull request?

- Added a new check called `Set proper GitHub labels` as a reminder to add GitHub labels
- Minor changes to the wording

> Why is it necessary?

As the author, labels are easy to add and they give others a quick idea about the kind of PR.

## Checklist

- ~[ ] Unit tests added or updated~
- [x] Documentation added or updated
- ~[ ] Example added or updated~
- ~[ ] Update schema.json if there are changes to the viewconf JSON structure format~
- ~[ ] Screenshot for visual changes (e.g. new tracks)~
- ~[ ] Updated CHANGELOG.md~
