### PR TITLE
Pkerpedjiev/value scale zoom 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+## v1.6.6
+
+- Added support for value scale zooming
+
+_[Detailed changes since v1.6.6](https://github.com/higlass/higlass/compare/v1.6.5...v1.6.6)_
+
 ## v1.6.5 
 
 - Fixed the replace track bug (where replacing a center track wouldn't do anything)
 
-_[Detailed changes since v1.6.3](https://github.com/higlass/higlass/compare/v1.6.4...v1.6.5)_
+_[Detailed changes since v1.6.5](https://github.com/higlass/higlass/compare/v1.6.4...v1.6.5)_
 
 ## v1.6.4
 

--- a/app/scripts/BarTrack.js
+++ b/app/scripts/BarTrack.js
@@ -298,68 +298,75 @@ class BarTrack extends HorizontalLine1DPixiTrack {
   }
 
   movedY(dY) {
-    Object.values(this.fetchedTiles).forEach((tile) => {
-      const vst = this.valueScaleTransform;
-      const height = this.dimensions[1];
+    // see the reasoning behind why the code in
+    // zoomedY is commented out.
+    //
+    // Object.values(this.fetchedTiles).forEach((tile) => {
+    //   const vst = this.valueScaleTransform;
+    //   const height = this.dimensions[1];
 
-      // clamp at the bottom and top
-      if (
-        vst.y + dY / vst.k > -(vst.k - 1) * height
-        && vst.y + dY / vst.k < 0
-      ) {
-        this.valueScaleTransform = vst.translate(
-          0, dY / vst.k
-        );
-      }
+    //   // clamp at the bottom and top
+    //   if (
+    //     vst.y + dY / vst.k > -(vst.k - 1) * height
+    //     && vst.y + dY / vst.k < 0
+    //   ) {
+    //     this.valueScaleTransform = vst.translate(
+    //       0, dY / vst.k
+    //     );
+    //   }
 
-      tile.graphics.position.y = this.valueScaleTransform.y;
-    });
+    //   tile.graphics.position.y = this.valueScaleTransform.y;
+    // });
 
-    this.animate();
+    // this.animate();
   }
 
   zoomedY(yPos, kMultiplier) {
-    const k0 = this.valueScaleTransform.k;
-    const t0 = this.valueScaleTransform.y;
-    const dp = (yPos - t0) / k0;
-    const k1 = Math.max(k0 / kMultiplier, 1.0);
-    let t1 = k0 * dp + t0 - k1 * dp;
-
-    const height = this.dimensions[1];
-
-    // clamp at the bottom
-    t1 = Math.max(t1, -(k1 - 1) * height);
-
-    // clamp at the top
-    t1 = Math.min(t1, 0);
-
-    // right now, the point at position 162 is at position 0
-    // 0 = 1 * 162 - 162
+    // this is commented out to serve as an example
+    // of how valueScale zooming works
+    // dont' want to support it just yet though
     //
-    // we want that when k = 2, that point is still at position
-    // 0 = 2 * 162 - t1
-    //  ypos = k0 * dp + t0
-    //  dp = (ypos - t0) / k0
-    //  nypos = k1 * dp + t1
-    //  k1 * dp + t1 = k0 * dp + t0
-    //  t1 = k0 * dp +t0 - k1 * dp
+    // const k0 = this.valueScaleTransform.k;
+    // const t0 = this.valueScaleTransform.y;
+    // const dp = (yPos - t0) / k0;
+    // const k1 = Math.max(k0 / kMultiplier, 1.0);
+    // let t1 = k0 * dp + t0 - k1 * dp;
 
-    // we're only interested in scaling along one axis so we
-    // leave the translation of the other axis blank
-    this.valueScaleTransform = zoomIdentity.translate(0, t1).scale(k1);
-    this.zoomedValueScale = this.valueScaleTransform.rescaleY(
-      this.valueScale.clamp(false)
-    );
-    // this.pMain.scale.y = k1;
-    // this.pMain.position.y = t1;
-    Object.values(this.fetchedTiles).forEach((tile) => {
-      tile.graphics.scale.y = k1;
-      tile.graphics.position.y = t1;
+    // const height = this.dimensions[1];
 
-      this.drawAxis(this.zoomedValueScale);
-    });
+    // // clamp at the bottom
+    // t1 = Math.max(t1, -(k1 - 1) * height);
 
-    this.animate();
+    // // clamp at the top
+    // t1 = Math.min(t1, 0);
+
+    // // right now, the point at position 162 is at position 0
+    // // 0 = 1 * 162 - 162
+    // //
+    // // we want that when k = 2, that point is still at position
+    // // 0 = 2 * 162 - t1
+    // //  ypos = k0 * dp + t0
+    // //  dp = (ypos - t0) / k0
+    // //  nypos = k1 * dp + t1
+    // //  k1 * dp + t1 = k0 * dp + t0
+    // //  t1 = k0 * dp +t0 - k1 * dp
+
+    // // we're only interested in scaling along one axis so we
+    // // leave the translation of the other axis blank
+    // this.valueScaleTransform = zoomIdentity.translate(0, t1).scale(k1);
+    // this.zoomedValueScale = this.valueScaleTransform.rescaleY(
+    //   this.valueScale.clamp(false)
+    // );
+    // // this.pMain.scale.y = k1;
+    // // this.pMain.position.y = t1;
+    // Object.values(this.fetchedTiles).forEach((tile) => {
+    //   tile.graphics.scale.y = k1;
+    //   tile.graphics.position.y = t1;
+
+    //   this.drawAxis(this.zoomedValueScale);
+    // });
+
+    // this.animate();
   }
 
   /**

--- a/app/scripts/BarTrack.js
+++ b/app/scripts/BarTrack.js
@@ -300,73 +300,73 @@ class BarTrack extends HorizontalLine1DPixiTrack {
   movedY(dY) {
     // see the reasoning behind why the code in
     // zoomedY is commented out.
-    //
-    // Object.values(this.fetchedTiles).forEach((tile) => {
-    //   const vst = this.valueScaleTransform;
-    //   const height = this.dimensions[1];
 
-    //   // clamp at the bottom and top
-    //   if (
-    //     vst.y + dY / vst.k > -(vst.k - 1) * height
-    //     && vst.y + dY / vst.k < 0
-    //   ) {
-    //     this.valueScaleTransform = vst.translate(
-    //       0, dY / vst.k
-    //     );
-    //   }
+    Object.values(this.fetchedTiles).forEach((tile) => {
+      const vst = this.valueScaleTransform;
+      const height = this.dimensions[1];
 
-    //   tile.graphics.position.y = this.valueScaleTransform.y;
-    // });
+      // clamp at the bottom and top
+      if (
+        vst.y + dY / vst.k > -(vst.k - 1) * height
+        && vst.y + dY / vst.k < 0
+      ) {
+        this.valueScaleTransform = vst.translate(
+          0, dY / vst.k
+        );
+      }
 
-    // this.animate();
+      tile.graphics.position.y = this.valueScaleTransform.y;
+    });
+
+    this.animate();
   }
 
   zoomedY(yPos, kMultiplier) {
     // this is commented out to serve as an example
     // of how valueScale zooming works
     // dont' want to support it just yet though
+
+    const k0 = this.valueScaleTransform.k;
+    const t0 = this.valueScaleTransform.y;
+    const dp = (yPos - t0) / k0;
+    const k1 = Math.max(k0 / kMultiplier, 1.0);
+    let t1 = k0 * dp + t0 - k1 * dp;
+
+    const height = this.dimensions[1];
+
+    // clamp at the bottom
+    t1 = Math.max(t1, -(k1 - 1) * height);
+
+    // clamp at the top
+    t1 = Math.min(t1, 0);
+
+    // right now, the point at position 162 is at position 0
+    // 0 = 1 * 162 - 162
     //
-    // const k0 = this.valueScaleTransform.k;
-    // const t0 = this.valueScaleTransform.y;
-    // const dp = (yPos - t0) / k0;
-    // const k1 = Math.max(k0 / kMultiplier, 1.0);
-    // let t1 = k0 * dp + t0 - k1 * dp;
+    // we want that when k = 2, that point is still at position
+    // 0 = 2 * 162 - t1
+    //  ypos = k0 * dp + t0
+    //  dp = (ypos - t0) / k0
+    //  nypos = k1 * dp + t1
+    //  k1 * dp + t1 = k0 * dp + t0
+    //  t1 = k0 * dp +t0 - k1 * dp
 
-    // const height = this.dimensions[1];
+    // we're only interested in scaling along one axis so we
+    // leave the translation of the other axis blank
+    this.valueScaleTransform = zoomIdentity.translate(0, t1).scale(k1);
+    this.zoomedValueScale = this.valueScaleTransform.rescaleY(
+      this.valueScale.clamp(false)
+    );
+    // this.pMain.scale.y = k1;
+    // this.pMain.position.y = t1;
+    Object.values(this.fetchedTiles).forEach((tile) => {
+      tile.graphics.scale.y = k1;
+      tile.graphics.position.y = t1;
 
-    // // clamp at the bottom
-    // t1 = Math.max(t1, -(k1 - 1) * height);
+      this.drawAxis(this.zoomedValueScale);
+    });
 
-    // // clamp at the top
-    // t1 = Math.min(t1, 0);
-
-    // // right now, the point at position 162 is at position 0
-    // // 0 = 1 * 162 - 162
-    // //
-    // // we want that when k = 2, that point is still at position
-    // // 0 = 2 * 162 - t1
-    // //  ypos = k0 * dp + t0
-    // //  dp = (ypos - t0) / k0
-    // //  nypos = k1 * dp + t1
-    // //  k1 * dp + t1 = k0 * dp + t0
-    // //  t1 = k0 * dp +t0 - k1 * dp
-
-    // // we're only interested in scaling along one axis so we
-    // // leave the translation of the other axis blank
-    // this.valueScaleTransform = zoomIdentity.translate(0, t1).scale(k1);
-    // this.zoomedValueScale = this.valueScaleTransform.rescaleY(
-    //   this.valueScale.clamp(false)
-    // );
-    // // this.pMain.scale.y = k1;
-    // // this.pMain.position.y = t1;
-    // Object.values(this.fetchedTiles).forEach((tile) => {
-    //   tile.graphics.scale.y = k1;
-    //   tile.graphics.position.y = t1;
-
-    //   this.drawAxis(this.zoomedValueScale);
-    // });
-
-    // this.animate();
+    this.animate();
   }
 
   /**

--- a/app/scripts/BarTrack.js
+++ b/app/scripts/BarTrack.js
@@ -298,75 +298,75 @@ class BarTrack extends HorizontalLine1DPixiTrack {
   }
 
   movedY(dY) {
-    // // see the reasoning behind why the code in
-    // // zoomedY is commented out.
+    // see the reasoning behind why the code in
+    // zoomedY is commented out.
 
-    // Object.values(this.fetchedTiles).forEach((tile) => {
-    //   const vst = this.valueScaleTransform;
-    //   const height = this.dimensions[1];
+    Object.values(this.fetchedTiles).forEach((tile) => {
+      const vst = this.valueScaleTransform;
+      const height = this.dimensions[1];
 
-    //   // clamp at the bottom and top
-    //   if (
-    //     vst.y + dY / vst.k > -(vst.k - 1) * height
-    //     && vst.y + dY / vst.k < 0
-    //   ) {
-    //     this.valueScaleTransform = vst.translate(
-    //       0, dY / vst.k
-    //     );
-    //   }
+      // clamp at the bottom and top
+      if (
+        vst.y + dY / vst.k > -(vst.k - 1) * height
+        && vst.y + dY / vst.k < 0
+      ) {
+        this.valueScaleTransform = vst.translate(
+          0, dY / vst.k
+        );
+      }
 
-    //   tile.graphics.position.y = this.valueScaleTransform.y;
-    // });
+      tile.graphics.position.y = this.valueScaleTransform.y;
+    });
 
-    // this.animate();
+    this.animate();
   }
 
   zoomedY(yPos, kMultiplier) {
-    // // this is commented out to serve as an example
-    // // of how valueScale zooming works
-    // // dont' want to support it just yet though
+    // this is commented out to serve as an example
+    // of how valueScale zooming works
+    // dont' want to support it just yet though
 
-    // const k0 = this.valueScaleTransform.k;
-    // const t0 = this.valueScaleTransform.y;
-    // const dp = (yPos - t0) / k0;
-    // const k1 = Math.max(k0 / kMultiplier, 1.0);
-    // let t1 = k0 * dp + t0 - k1 * dp;
+    const k0 = this.valueScaleTransform.k;
+    const t0 = this.valueScaleTransform.y;
+    const dp = (yPos - t0) / k0;
+    const k1 = Math.max(k0 / kMultiplier, 1.0);
+    let t1 = k0 * dp + t0 - k1 * dp;
 
-    // const height = this.dimensions[1];
+    const height = this.dimensions[1];
 
-    // // clamp at the bottom
-    // t1 = Math.max(t1, -(k1 - 1) * height);
+    // clamp at the bottom
+    t1 = Math.max(t1, -(k1 - 1) * height);
 
-    // // clamp at the top
-    // t1 = Math.min(t1, 0);
+    // clamp at the top
+    t1 = Math.min(t1, 0);
 
-    // // right now, the point at position 162 is at position 0
-    // // 0 = 1 * 162 - 162
-    // //
-    // // we want that when k = 2, that point is still at position
-    // // 0 = 2 * 162 - t1
-    // //  ypos = k0 * dp + t0
-    // //  dp = (ypos - t0) / k0
-    // //  nypos = k1 * dp + t1
-    // //  k1 * dp + t1 = k0 * dp + t0
-    // //  t1 = k0 * dp +t0 - k1 * dp
+    // right now, the point at position 162 is at position 0
+    // 0 = 1 * 162 - 162
+    //
+    // we want that when k = 2, that point is still at position
+    // 0 = 2 * 162 - t1
+    //  ypos = k0 * dp + t0
+    //  dp = (ypos - t0) / k0
+    //  nypos = k1 * dp + t1
+    //  k1 * dp + t1 = k0 * dp + t0
+    //  t1 = k0 * dp +t0 - k1 * dp
 
-    // // we're only interested in scaling along one axis so we
-    // // leave the translation of the other axis blank
-    // this.valueScaleTransform = zoomIdentity.translate(0, t1).scale(k1);
-    // this.zoomedValueScale = this.valueScaleTransform.rescaleY(
-    //   this.valueScale.clamp(false)
-    // );
-    // // this.pMain.scale.y = k1;
-    // // this.pMain.position.y = t1;
-    // Object.values(this.fetchedTiles).forEach((tile) => {
-    //   tile.graphics.scale.y = k1;
-    //   tile.graphics.position.y = t1;
+    // we're only interested in scaling along one axis so we
+    // leave the translation of the other axis blank
+    this.valueScaleTransform = zoomIdentity.translate(0, t1).scale(k1);
+    this.zoomedValueScale = this.valueScaleTransform.rescaleY(
+      this.valueScale.clamp(false)
+    );
+    // this.pMain.scale.y = k1;
+    // this.pMain.position.y = t1;
+    Object.values(this.fetchedTiles).forEach((tile) => {
+      tile.graphics.scale.y = k1;
+      tile.graphics.position.y = t1;
 
-    //   this.drawAxis(this.zoomedValueScale);
-    // });
+      this.drawAxis(this.zoomedValueScale);
+    });
 
-    // this.animate();
+    this.animate();
   }
 
   /**

--- a/app/scripts/BarTrack.js
+++ b/app/scripts/BarTrack.js
@@ -298,75 +298,75 @@ class BarTrack extends HorizontalLine1DPixiTrack {
   }
 
   movedY(dY) {
-    // see the reasoning behind why the code in
-    // zoomedY is commented out.
+    // // see the reasoning behind why the code in
+    // // zoomedY is commented out.
 
-    Object.values(this.fetchedTiles).forEach((tile) => {
-      const vst = this.valueScaleTransform;
-      const height = this.dimensions[1];
+    // Object.values(this.fetchedTiles).forEach((tile) => {
+    //   const vst = this.valueScaleTransform;
+    //   const height = this.dimensions[1];
 
-      // clamp at the bottom and top
-      if (
-        vst.y + dY / vst.k > -(vst.k - 1) * height
-        && vst.y + dY / vst.k < 0
-      ) {
-        this.valueScaleTransform = vst.translate(
-          0, dY / vst.k
-        );
-      }
+    //   // clamp at the bottom and top
+    //   if (
+    //     vst.y + dY / vst.k > -(vst.k - 1) * height
+    //     && vst.y + dY / vst.k < 0
+    //   ) {
+    //     this.valueScaleTransform = vst.translate(
+    //       0, dY / vst.k
+    //     );
+    //   }
 
-      tile.graphics.position.y = this.valueScaleTransform.y;
-    });
+    //   tile.graphics.position.y = this.valueScaleTransform.y;
+    // });
 
-    this.animate();
+    // this.animate();
   }
 
   zoomedY(yPos, kMultiplier) {
-    // this is commented out to serve as an example
-    // of how valueScale zooming works
-    // dont' want to support it just yet though
+    // // this is commented out to serve as an example
+    // // of how valueScale zooming works
+    // // dont' want to support it just yet though
 
-    const k0 = this.valueScaleTransform.k;
-    const t0 = this.valueScaleTransform.y;
-    const dp = (yPos - t0) / k0;
-    const k1 = Math.max(k0 / kMultiplier, 1.0);
-    let t1 = k0 * dp + t0 - k1 * dp;
+    // const k0 = this.valueScaleTransform.k;
+    // const t0 = this.valueScaleTransform.y;
+    // const dp = (yPos - t0) / k0;
+    // const k1 = Math.max(k0 / kMultiplier, 1.0);
+    // let t1 = k0 * dp + t0 - k1 * dp;
 
-    const height = this.dimensions[1];
+    // const height = this.dimensions[1];
 
-    // clamp at the bottom
-    t1 = Math.max(t1, -(k1 - 1) * height);
+    // // clamp at the bottom
+    // t1 = Math.max(t1, -(k1 - 1) * height);
 
-    // clamp at the top
-    t1 = Math.min(t1, 0);
+    // // clamp at the top
+    // t1 = Math.min(t1, 0);
 
-    // right now, the point at position 162 is at position 0
-    // 0 = 1 * 162 - 162
-    //
-    // we want that when k = 2, that point is still at position
-    // 0 = 2 * 162 - t1
-    //  ypos = k0 * dp + t0
-    //  dp = (ypos - t0) / k0
-    //  nypos = k1 * dp + t1
-    //  k1 * dp + t1 = k0 * dp + t0
-    //  t1 = k0 * dp +t0 - k1 * dp
+    // // right now, the point at position 162 is at position 0
+    // // 0 = 1 * 162 - 162
+    // //
+    // // we want that when k = 2, that point is still at position
+    // // 0 = 2 * 162 - t1
+    // //  ypos = k0 * dp + t0
+    // //  dp = (ypos - t0) / k0
+    // //  nypos = k1 * dp + t1
+    // //  k1 * dp + t1 = k0 * dp + t0
+    // //  t1 = k0 * dp +t0 - k1 * dp
 
-    // we're only interested in scaling along one axis so we
-    // leave the translation of the other axis blank
-    this.valueScaleTransform = zoomIdentity.translate(0, t1).scale(k1);
-    this.zoomedValueScale = this.valueScaleTransform.rescaleY(
-      this.valueScale.clamp(false)
-    );
-    // this.pMain.scale.y = k1;
-    // this.pMain.position.y = t1;
-    Object.values(this.fetchedTiles).forEach((tile) => {
-      tile.graphics.scale.y = k1;
-      tile.graphics.position.y = t1;
+    // // we're only interested in scaling along one axis so we
+    // // leave the translation of the other axis blank
+    // this.valueScaleTransform = zoomIdentity.translate(0, t1).scale(k1);
+    // this.zoomedValueScale = this.valueScaleTransform.rescaleY(
+    //   this.valueScale.clamp(false)
+    // );
+    // // this.pMain.scale.y = k1;
+    // // this.pMain.position.y = t1;
+    // Object.values(this.fetchedTiles).forEach((tile) => {
+    //   tile.graphics.scale.y = k1;
+    //   tile.graphics.position.y = t1;
 
-      this.drawAxis(this.zoomedValueScale);
-    });
+    //   this.drawAxis(this.zoomedValueScale);
+    // });
 
-    this.animate();
+    // this.animate();
   }
 
   /**

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -717,8 +717,6 @@ class HiGlassComponent extends React.Component {
       });
     }
 
-    console.log('event.key', event.key);
-
     if (event.key === 'Shift') {
       this.setState({
         valueScaleZoom: true,
@@ -734,7 +732,6 @@ class HiGlassComponent extends React.Component {
     }
 
     if (event.key === 'Shift') {
-      console.log('setting false');
       this.setState({
         valueScaleZoom: false,
       });

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -241,6 +241,7 @@ class HiGlassComponent extends React.Component {
       rangeSelection1dSize: [0, Infinity],
       rangeSelectionToInt: false,
       modal: null,
+      valueScaleZoom: false,
     };
 
     Object.values(views).map(view => this.adjustLayoutToTrackSizes(view));
@@ -715,12 +716,27 @@ class HiGlassComponent extends React.Component {
         mouseTool: MOUSE_TOOL_SELECT,
       });
     }
+
+    console.log('event.key', event.key);
+
+    if (event.key === 'Shift') {
+      this.setState({
+        valueScaleZoom: true,
+      });
+    }
   }
 
   keyUpHandler(event) {
     if (this.props.options.rangeSelectionOnAlt && event.key === 'Alt') {
       this.setState({
         mouseTool: MOUSE_TOOL_MOVE,
+      });
+    }
+
+    if (event.key === 'Shift') {
+      console.log('setting false');
+      this.setState({
+        valueScaleZoom: false,
       });
     }
   }
@@ -3951,6 +3967,7 @@ class HiGlassComponent extends React.Component {
             tracks={view.tracks}
             trackSourceServers={this.state.viewConfig.trackSourceServers}
             uid={view.uid}
+            valueScaleZoom={this.state.valueScaleZoom}
             verticalMargin={this.verticalMargin}
             viewOptions={view.options}
             // dragging={this.state.dragging}

--- a/app/scripts/LeftTrackModifier.js
+++ b/app/scripts/LeftTrackModifier.js
@@ -155,6 +155,14 @@ class LeftTrackModifier {
     this.originalTrack.draw();
   }
 
+  zoomedY(yPos, kMultiplier) {
+    this.originalTrack.zoomedY(yPos, kMultiplier);
+  }
+
+  movedY(dY) {
+    this.originalTrack.movedY(dY);
+  }
+
   refScalesChanged(refXScale, refYScale) {
     this.originalTrack.refScalesChanged(refYScale, refXScale);
   }

--- a/app/scripts/TiledPlot.js
+++ b/app/scripts/TiledPlot.js
@@ -1316,6 +1316,7 @@ class TiledPlot extends React.Component {
       initialXDomain: props.initialXDomain,
       initialYDomain: props.initialYDomain,
       trackSourceServers: props.trackSourceServers,
+      valueScaleZoom: props.valueScaleZoom,
       zoomable: props.zoomable,
       draggingHappending: props.draggingHappening,
     });
@@ -2067,6 +2068,7 @@ class TiledPlot extends React.Component {
           topHeight={this.topHeight}
           topHeightNoGallery={this.topHeightNoGallery}
           uid={this.props.uid}
+          valueScaleZoom={this.props.valueScaleZoom}
           viewOptions={this.props.viewOptions}
           width={this.state.width}
           xDomainLimits={this.props.xDomainLimits}
@@ -2315,6 +2317,7 @@ TiledPlot.propTypes = {
   tracks: PropTypes.object,
   trackSourceServers: PropTypes.array,
   uid: PropTypes.string,
+  valueScaleZoom: PropTypes.bool,
   viewOptions: PropTypes.object,
   zoomable: PropTypes.bool,
   zoomToDataExtentOnInit: PropTypes.func

--- a/app/scripts/Track.js
+++ b/app/scripts/Track.js
@@ -168,6 +168,10 @@ class Track {
   respondsToPosition(x, y) {
     return this.isWithin(x, y);
   }
+
+  zoomedY(trackY, kMultiplier) {
+
+  }
 }
 
 export default Track;

--- a/app/scripts/Track.js
+++ b/app/scripts/Track.js
@@ -172,6 +172,10 @@ class Track {
   zoomedY(trackY, kMultiplier) {
 
   }
+
+  movedY(dY) {
+
+  }
 }
 
 export default Track;

--- a/app/scripts/TrackRenderer.js
+++ b/app/scripts/TrackRenderer.js
@@ -1068,11 +1068,11 @@ class TrackRenderer extends React.Component {
 
   valueScaleZoom(orientation) {
     // mouse move probably from a drag event
-    const dy = event.sourceEvent.deltaY;
-    const dm = event.sourceEvent.deltaMode;
+    const mdy = event.sourceEvent.deltaY;
+    const mdm = event.sourceEvent.deltaMode;
 
     const myWheelDelta = (dy, dm) => dy * (dm ? 120 : 1) / 500;
-    const mwd = myWheelDelta(dy, dm);
+    const mwd = myWheelDelta(mdy, mdm);
 
     const cp = clientPoint(this.props.canvasElement, event.sourceEvent);
 

--- a/app/scripts/TrackRenderer.js
+++ b/app/scripts/TrackRenderer.js
@@ -1059,6 +1059,11 @@ class TrackRenderer extends React.Component {
       for (const track of this.getTracksAtPosition(...cp)) {
         track.zoomedY(cp[1] - track.position[1], 2 ** mwd);
       }
+    } else if (event.sourceEvent && event.sourceEvent.movementY) {
+      // const cp = clientPoint(this.props.canvasElement, event.sourceEvent);
+      for (const track of this.getTracksAtPosition(...this.zoomStartPos)) {
+        track.movedY(event.sourceEvent.movementY);
+      }
     }
   }
 
@@ -1116,11 +1121,18 @@ class TrackRenderer extends React.Component {
   zoomStarted() {
     this.zooming = true;
 
+    if (event.sourceEvent) {
+      this.zoomStartPos = clientPoint(this.props.canvasElement, event.sourceEvent);
+    }
+
+
     this.props.pubSub.publish('app.zoomStart');
   }
 
   zoomEnded() {
     this.zooming = false;
+
+    this.zoomStartPos = null;
 
     this.props.pubSub.publish('app.zoomEnd');
   }


### PR DESCRIPTION
## Description

> What was changed in this pull request?

This PR lays the framework for zooming along the y-axis in horizontal tracks.

> Why is it necessary?

To enable zooming into individual reads once the pileup track is implemented.

Fixes #___

## Screen grab

If it were enabled, it would look like this...

![Aug-17-2019 14-56-29](https://user-images.githubusercontent.com/2143629/63217668-3d59ce80-c0ff-11e9-9096-4d33424f9710.gif)

To properly support this we need to consider what happens when new data is received and the scales are changed. That is not addressed in this PR so the code implementing the actual zooming is commented out.

The hooks to the track methods, however, are still there and can be implemented by any other track.

Even though the actual value scale zooming is *not* implemented, this PR introduces a substantial change in behavior wherein 1D tracks no longer allow panning along the secondary axis. Horizontal tracks, for example, do not allow panning along the vertical higlass axis and vertical tracks do not allow panning along the horizontal axis. Panning along center tracks is allowed along both dimensions.

![Aug-25-2019 19-57-40](https://user-images.githubusercontent.com/2143629/63662249-a8944800-c772-11e9-80f4-a27cd4915f30.gif)

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [x] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
