### PR TITLE
Add api call to show track chooser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Next release
+
+- Add API call for show track chooser
+
+_[Detailed changes since v1.6.8](https://github.com/higlass/higlass/compare/v1.6.8...develop)_
+
 ## v1.6.8
 
 - Add infrastructure for value scale zooming
@@ -5,7 +11,7 @@
 - Added support for value scale zooming
 - Added utils/track-utils to provide track functionality for use without inheritance
 
-_[Detailed changes since v1.6.7](https://github.com/higlass/higlass/compare/v1.6.7...develop)_
+_[Detailed changes since v1.6.7](https://github.com/higlass/higlass/compare/v1.6.7...v1.6.8)_
 
 - Implemented a genbank data fetcher for gene annotation tracks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next release
 
-- Add API call for show track chooser
+- Add API call for show track chooser (hgApi. showTrackChooser()`)
 
 _[Detailed changes since v1.6.9](https://github.com/higlass/higlass/compare/v1.6.9...develop)_
 

--- a/app/scripts/TiledPlot.js
+++ b/app/scripts/TiledPlot.js
@@ -2138,6 +2138,7 @@ class TiledPlot extends React.Component {
 
     let overlays = null;
     if (this.props.chooseTrackHandler) {
+      console.log('adding choose track overlay');
       // We want to choose a track and call a function. To choose the track, we display
       // an overlay on top of each track
       overlays = positionedTracks
@@ -2164,6 +2165,8 @@ class TiledPlot extends React.Component {
               this.setState({ mouseOverOverlayUid: null });
               this.props.chooseTrackHandler(pTrack.track.uid);
             }}
+            onDragEnter={() => this.handleOverlayMouseEnter(pTrack.track.uid)}
+            onDragLeave={() => this.handleOverlayMouseLeave(pTrack.track.uid)}
             onMouseEnter={() => this.handleOverlayMouseEnter(pTrack.track.uid)}
             onMouseLeave={() => this.handleOverlayMouseLeave(pTrack.track.uid)}
             style={{

--- a/app/scripts/TiledPlot.js
+++ b/app/scripts/TiledPlot.js
@@ -495,19 +495,18 @@ class TiledPlot extends React.Component {
     });
   }
 
-  handleOverlayMouseLeave() {
-    this.setState({
-      mouseOverOverlayUid: null,
-    });
+  handleOverlayMouseLeave(uid) {
+    if (uid === this.state.mouseOverOverlayUid) {
+      this.setState({
+        mouseOverOverlayUid: null,
+      });
+    }
   }
 
 
-  handleTrackPositionChosen(position) {
-    this.handleAddTrack(position);
-
-    // have our parent close the menu
-    // parent needs to do it because the button is located in the parent's scope
-    this.props.onTrackPositionChosen(position);
+  handleTrackPositionChosen(pTrack) {
+    this.setState({ mouseOverOverlayUid: null });
+    this.props.chooseTrackHandler(pTrack.track.uid);
   }
 
 
@@ -2138,7 +2137,6 @@ class TiledPlot extends React.Component {
 
     let overlays = null;
     if (this.props.chooseTrackHandler) {
-      console.log('adding choose track overlay');
       // We want to choose a track and call a function. To choose the track, we display
       // an overlay on top of each track
       overlays = positionedTracks
@@ -2161,12 +2159,14 @@ class TiledPlot extends React.Component {
             // to choose an overlay track, the previously selected one isn't
             // automatically highlighted
 
-            onClick={() => {
-              this.setState({ mouseOverOverlayUid: null });
-              this.props.chooseTrackHandler(pTrack.track.uid);
+            onClick={() => this.handleTrackPositionChosen(pTrack)}
+            onDragEnter={(evt) => {
+              this.handleOverlayMouseEnter(pTrack.track.uid);
+              evt.preventDefault();
             }}
-            onDragEnter={() => this.handleOverlayMouseEnter(pTrack.track.uid)}
             onDragLeave={() => this.handleOverlayMouseLeave(pTrack.track.uid)}
+            onDragOver={evt => evt.preventDefault()}
+            onDrop={() => this.handleTrackPositionChosen(pTrack)}
             onMouseEnter={() => this.handleOverlayMouseEnter(pTrack.track.uid)}
             onMouseLeave={() => this.handleOverlayMouseLeave(pTrack.track.uid)}
             style={{

--- a/app/scripts/api.js
+++ b/app/scripts/api.js
@@ -345,7 +345,13 @@ const createApi = function api(context, pubSub) {
        */
       showTrackChooser(callback) {
         self.setState({
-          chooseTrackHandler: callback,
+          chooseTrackHandler: (...args) => {
+            self.setState({
+              chooseTrackHandler: null,
+            });
+
+            callback(...args);
+          },
         });
       },
 

--- a/app/scripts/api.js
+++ b/app/scripts/api.js
@@ -336,6 +336,28 @@ const createApi = function api(context, pubSub) {
       },
 
       /**
+       * Show the track chooser which highlights tracks
+       * when the mouse is over them.
+       *
+       * @param  {Function} callback (toViewUid, toTrackUid) =>: A function
+       *                             to be called when a track is chosen.
+       * @return {[type]}            [description]
+       */
+      showTrackChooser(callback) {
+        self.setState({
+          chooseTrackHandler: callback,
+        });
+      },
+
+      /**
+       * Hide the track chooser.
+       */
+      hideTrackChooser() {
+        this.setState({
+          chooseTrackHandler: null,
+        });
+      },
+      /**
        *
        * When comparing different 1D tracks it can be desirable to fix their y or value
        * scale

--- a/docs/examples/others/test_drag.html
+++ b/docs/examples/others/test_drag.html
@@ -33,7 +33,7 @@
     </div>
 
     <div style="display: flex">
-        <div style="draggable: true; border: 1px solid black" ondragstart="randomDragStart(event)" ondragend="dragEnd(event)"><img src="../images/thumbnails/heatmap-thumbnail.png"/></div>
+        <div style="draggable: true; border: 1px solid black" ondragstart="randomDragStart(event)"><img src="../images/thumbnails/heatmap-thumbnail.png"/></div>
         <div style="draggable: true; border: 1px solid black" ondragstart="heatmapDragStart(event)"><img src="../images/thumbnails/heatmap-thumbnail.png"/></div>
         <div style="draggable: true; border: 1px solid black" ondragstart="lineDragStart(event)"><img src="../images/thumbnails/horizontal-line-thumbnail.png"/></div>
         <div style="draggable: true; border: 1px solid black" ondragstart="multivecDragStart(event)"><img src="../images/thumbnails/horizontal-multivec-thumbnail.png"/></div>
@@ -45,7 +45,8 @@
 <script>
 
 console.log('window.higlassTracks', window.higlassTracks);
-function dragEnd(ev) {
+function dragEnd(evt) {
+  // console.log('evt:', evt);
     //window.hgApi.hideAvailableTrackPositions();
 }
 
@@ -56,11 +57,42 @@ function randomDragStart(ev) {
         "datatype": "geo-json",
     }
 
-    window.hgApi.showTrackChooser(
-      (viewUid, trackUid) => {
-        console.log('viewUid:', viewUid, trackUid);
+    let prevX = -1;
+    let prevY = -1;
+
+    let timeout = null;
+
+    const dragged = (evt) => {
+      if (evt.clientX != prevX || evt.clientY != prevY) {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+
+        timeout = setTimeout(() => {
+          document.removeEventListener('drag', dragged);
+          window.hgApi.hideAvailableTrackPositions();
+         window.hgApi.showTrackChooser(
+           (viewUid, trackUid) => {
+             console.log('viewUid:', viewUid, trackUid);
+             }
+         );
+        }, 500);
       }
-    );
+
+      prevX = evt.clientX;
+      prevY = evt.clientY;
+    }
+
+    document.addEventListener('drag', dragged);
+
+    //window.hgApi.hideAvailableTrackPositions();
+    window.hgApi.showAvailableTrackPositions(track);
+
+    // window.hgApi.showTrackChooser(
+    //   (viewUid, trackUid) => {
+    //     console.log('viewUid:', viewUid, trackUid);
+    //   }
+    // );
   }
 
 function lineDragStart(ev) {
@@ -131,15 +163,16 @@ function heatmapDragStart(ev) {
     {
       "uid": "a",
       "initialXDomain": [
-        1502666124.488715,
-        1511074199.6112716
+        1502439972.6753309,
+        1517324845.500473
       ],
       "initialYDomain": [
-        1504683396.5786693,
-        1510784034.7532685
+        1504602643.1146064,
+        1515225230.3978314
       ],
       "tracks": {
-        "top": [],
+        "top": [
+        ],
         "left": [],
         "center": [
           {
@@ -174,26 +207,60 @@ function heatmapDragStart(ev) {
                   "showTooltip": false,
                   "name": "Rao et al. (2014) GM12878 MboI (allreps) 1kb",
                   "scaleStartPercent": "0.00000",
-                  "scaleEndPercent": "1.00000"
+                  "scaleEndPercent": "1.00000",
+                  "labelShowResolution": true,
+                  "colorbarBackgroundColor": "#ffffff",
+                  "extent": "full"
                 },
-                "width": 747,
-                "height": 522,
-                "name": "Rao et al. (2014) GM12878 MboI (allreps) 1kb",
+                "width": 674,
+                "height": 542,
                 "transforms": [
                   {
                     "name": "ICE",
                     "value": "weight"
                   }
-                ],
-                "position": "center"
+                ]
               }
             ],
-            "position": "center",
-            "width": 747,
-            "height": 522
+            "width": 674,
+            "height": 542,
+            "options": {}
           }
         ],
-        "bottom": [],
+        "bottom": [
+          {
+            "server": "http://higlass.io/api/v1",
+            "tilesetUid": "P1l8t23ZSk-akHgOM4I9dQ",
+            "uid": "YFqytm3RTc6SMn2Jmi_ntA",
+            "type": "horizontal-1d-heatmap",
+            "options": {
+              "labelColor": "black",
+              "labelPosition": "topLeft",
+              "labelLeftMargin": 0,
+              "labelRightMargin": 0,
+              "labelTopMargin": 0,
+              "labelBottomMargin": 0,
+              "labelShowResolution": false,
+              "axisPositionHorizontal": "right",
+              "colorRange": [
+                "white",
+                "rgba(245,166,35,1.0)",
+                "rgba(208,2,27,1.0)",
+                "black"
+              ],
+              "valueScaling": "linear",
+              "trackBorderWidth": 0,
+              "trackBorderColor": "black",
+              "labelTextOpacity": 0.4,
+              "showMousePosition": false,
+              "mousePositionColor": "#000000",
+              "showTooltip": false,
+              "name": "wgEncodeLicrHistoneLiverH3k04me1UE14halfC57bl6StdSig.hitile"
+            },
+            "width": 674,
+            "height": 61
+          }
+        ],
         "right": [],
         "whole": [],
         "gallery": []
@@ -203,7 +270,6 @@ function heatmapDragStart(ev) {
         "h": 6,
         "x": 0,
         "y": 0,
-        "i": "a",
         "moved": false,
         "static": false
       }

--- a/docs/examples/others/test_drag.html
+++ b/docs/examples/others/test_drag.html
@@ -56,8 +56,12 @@ function randomDragStart(ev) {
         "datatype": "geo-json",
     }
 
-    window.hgApi.showAvailableTrackPositions(track);
-}
+    window.hgApi.showTrackChooser(
+      (viewUid, trackUid) => {
+        console.log('viewUid:', viewUid, trackUid);
+      }
+    );
+  }
 
 function lineDragStart(ev) {
 
@@ -69,7 +73,11 @@ function lineDragStart(ev) {
         "defaultTracks": ['horizontal-bar']
     }
 
-    window.hgApi.showAvailableTrackPositions(lineTrack);
+    window.hgApi.showTrackChooser(
+      (viewUid, trackUid) => {
+        console.log('viewUid:', viewUid, trackUid);
+      }
+    );
 }
 
 function multivecDragStart(ev) {

--- a/docs/examples/others/test_drag.html
+++ b/docs/examples/others/test_drag.html
@@ -45,10 +45,6 @@
 <script>
 
 console.log('window.higlassTracks', window.higlassTracks);
-function dragEnd(evt) {
-  // console.log('evt:', evt);
-    //window.hgApi.hideAvailableTrackPositions();
-}
 
 function randomDragStart(ev) {
     var track = {
@@ -87,12 +83,6 @@ function randomDragStart(ev) {
 
     //window.hgApi.hideAvailableTrackPositions();
     window.hgApi.showAvailableTrackPositions(track);
-
-    // window.hgApi.showTrackChooser(
-    //   (viewUid, trackUid) => {
-    //     console.log('viewUid:', viewUid, trackUid);
-    //   }
-    // );
   }
 
 function lineDragStart(ev) {


### PR DESCRIPTION
## Description

> What was changed in this pull request?

This PR adds an API call to let an external program show the track chooser (yellow overlay where the mouse is). It also enables the track chooser to respond to drag events in addition to mouse move events.

> Why is it necessary?

If we want to be able to drag something over a track we need a way to be able to show which track we're currently over.

## Screen capture

![Sep-07-2019 14-49-22](https://user-images.githubusercontent.com/2143629/64480559-b8525a00-d17e-11e9-8226-ae4713244a71.gif)

Fixes #___

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [x] Documentation added or updated
- [x] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [x] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
