### PR TITLE
Limit icon size in plot type chooser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Next revision
+
+- Limit icon size in plot type chooser
+
+_[Detailed changes since v1.6.7](https://github.com/higlass/higlass/compare/v1.6.8...develop)_
+
 ## v1.6.8
 
 - Add infrastructure for value scale zooming
@@ -5,7 +11,7 @@
 - Added support for value scale zooming
 - Added utils/track-utils to provide track functionality for use without inheritance
 
-_[Detailed changes since v1.6.7](https://github.com/higlass/higlass/compare/v1.6.7...develop)_
+_[Detailed changes since v1.6.7](https://github.com/higlass/higlass/compare/v1.6.7...v1.6.8)_
 
 - Implemented a genbank data fetcher for gene annotation tracks
 

--- a/app/scripts/PlotTypeChooser.js
+++ b/app/scripts/PlotTypeChooser.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { select } from 'd3-selection';
 
 // Configs
 import {
@@ -15,8 +14,6 @@ class PlotTypeChooser extends React.Component {
   constructor(props) {
     super(props);
 
-    this.imageDiv = null;
-
     this.DATATYPE_TO_TRACK_TYPE = DATATYPE_TO_TRACK_TYPE(this.props.orientation);
     this.AVAILABLE_TRACK_TYPES = AVAILABLE_TRACK_TYPES(
       this.props.datatypes, this.props.orientation
@@ -25,20 +22,6 @@ class PlotTypeChooser extends React.Component {
     this.state = {
       selectedPlotType: this.AVAILABLE_TRACK_TYPES[0],
     };
-  }
-
-  componentDidUpdate() {
-    const ICON_WIDTH = 20;
-    const ICON_HEIGHT = 20;
-
-    if (this.imageDiv) {
-      // make sure that the SVG icons we use for tracks aren't
-      // too large
-      select(this.imageDiv)
-        .select('svg')
-        .attr('width', ICON_HEIGHT)
-        .attr('height', ICON_WIDTH);
-    }
   }
 
   componentWillReceiveProps(newProps) {
@@ -82,15 +65,8 @@ class PlotTypeChooser extends React.Component {
           const imgTag = trackTypeToInfo[x.type].thumbnail
             ? (
               <div
-                ref={(c) => { this.imageDiv = c; }}
+                className="track-thumbnail"
                 dangerouslySetInnerHTML={{ __html: thumbnail.outerHTML }}
-                style={{
-                  display: 'inline-block',
-                  marginRight: 10,
-                  verticalAlign: 'middle',
-                  height: 20,
-                  width: 30,
-                }}
               />
             )
             : (

--- a/app/scripts/PlotTypeChooser.js
+++ b/app/scripts/PlotTypeChooser.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { select } from 'd3-selection';
 
 // Configs
 import {
@@ -14,6 +15,8 @@ class PlotTypeChooser extends React.Component {
   constructor(props) {
     super(props);
 
+    this.imageDiv = null;
+
     this.DATATYPE_TO_TRACK_TYPE = DATATYPE_TO_TRACK_TYPE(this.props.orientation);
     this.AVAILABLE_TRACK_TYPES = AVAILABLE_TRACK_TYPES(
       this.props.datatypes, this.props.orientation
@@ -22,6 +25,20 @@ class PlotTypeChooser extends React.Component {
     this.state = {
       selectedPlotType: this.AVAILABLE_TRACK_TYPES[0],
     };
+  }
+
+  componentDidUpdate() {
+    const ICON_WIDTH = 20;
+    const ICON_HEIGHT = 20;
+
+    if (this.imageDiv) {
+      // make sure that the SVG icons we use for tracks aren't
+      // too large
+      select(this.imageDiv)
+        .select('svg')
+        .attr('width', ICON_HEIGHT)
+        .attr('height', ICON_WIDTH);
+    }
   }
 
   componentWillReceiveProps(newProps) {
@@ -65,8 +82,15 @@ class PlotTypeChooser extends React.Component {
           const imgTag = trackTypeToInfo[x.type].thumbnail
             ? (
               <div
+                ref={(c) => { this.imageDiv = c; }}
                 dangerouslySetInnerHTML={{ __html: thumbnail.outerHTML }}
-                style={{ display: 'inline-block', marginRight: 10, verticalAlign: 'middle' }}
+                style={{
+                  display: 'inline-block',
+                  marginRight: 10,
+                  verticalAlign: 'middle',
+                  height: 20,
+                  width: 30,
+                }}
               />
             )
             : (

--- a/app/styles/PlotTypeChooser.css
+++ b/app/styles/PlotTypeChooser.css
@@ -10,3 +10,15 @@
     border-radius: 5px;
     max-height: 15vh;
 }
+
+.track-thumbnail {
+  width: 30px;
+  height: 20px;
+  display: inline-block;
+  margin-right: 10;
+  vertical-align: middle;
+}
+.track-thumbnail > svg {
+  width: 20px;
+  height: 20px;
+}


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Makes sure that track's icon sizes are limited to 20px x 20px.

> Why is it necessary?

External tracks (like the epilogos track) can define huge icons which take up a lot of space unnecessarily.

Fixes #___

## Screenshot

Before:

![image](https://user-images.githubusercontent.com/2143629/64481829-b4800100-d199-11e9-84bc-b41343cfb4c2.png)

After:

![image](https://user-images.githubusercontent.com/2143629/64481828-ac27c600-d199-11e9-9a0e-15c88027c420.png)


## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [x] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
