### PR TITLE
Overlay track bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next release
 
+- Overlay track bug fixes
+
 _[Detailed changes since v1.6.10](https://github.com/higlass/higlass/compare/v1.6.9...v1.6.10)_
 
 ## v1.6.10

--- a/app/scripts/HorizontalGeneAnnotationsTrack.js
+++ b/app/scripts/HorizontalGeneAnnotationsTrack.js
@@ -67,7 +67,6 @@ class HorizontalGeneAnnotationsTrack extends HorizontalTiled1DPixiTrack {
     // create texts
     tile.texts = {};
 
-    // console.log('tile:', tile.tileId, tile.tileData);
     tile.rectGraphics = new PIXI.Graphics();
     tile.textBgGraphics = new PIXI.Graphics();
     tile.textGraphics = new PIXI.Graphics();
@@ -242,7 +241,6 @@ class HorizontalGeneAnnotationsTrack extends HorizontalTiled1DPixiTrack {
         let yMiddle = this.dimensions[1] / 2;
         const geneId = this.geneId(geneInfo);
 
-        // console.log('geneInfo:', geneInfo);
         if (geneInfo[5] === '+') {
           // genes on the + strand drawn above and in a user-specified color or the
           // default blue
@@ -499,8 +497,6 @@ class HorizontalGeneAnnotationsTrack extends HorizontalTiled1DPixiTrack {
 
           const text = tile.texts[geneId];
 
-          // console.log('visible geneName:', geneName);
-
           if (!text) return;
 
           const chrOffset = +td.chrOffset;
@@ -534,9 +530,6 @@ class HorizontalGeneAnnotationsTrack extends HorizontalTiled1DPixiTrack {
             // dimensions are measured for the first tile and not for the second
             const textWidth = text.getBounds().width;
             const textHeight = text.getBounds().height;
-
-            // console.log('textWidth:', textWidth);
-            // console.log('textHeight:', textHeight);
 
             tile.textHeights[geneId] = textHeight;
             tile.textWidths[geneId] = textWidth;

--- a/app/scripts/OverlayTrack.js
+++ b/app/scripts/OverlayTrack.js
@@ -14,43 +14,13 @@ class OverlayTrack extends PixiTrack {
   drawHorizontalOverlay(graphics, position, extent) {
     if (!extent || extent.length < 2) return;
 
-    let xPos = this.position[0]
+    const xPos = this.position[0]
       + position.left
       + this._xScale(extent[0]);
+
     const yPos = this.position[1] + position.top;
-
     const height = position.height;
-
-
-    // the position of the left bounary of this track
-    const leftPosition = this.position[0] + position.left;
-    const rightPosition = this.position[0] + position.left + position.width;
-
-    if (xPos > rightPosition) {
-      // this annotation is off the bottom
-      return;
-    }
-
-    if (xPos < leftPosition) {
-      // this overlay is partially off the left side of the
-      // track and needs to be truncated
-      xPos = this.position[0] + position.left;
-    }
-
-    let width = this._xScale(extent[1])
-      - xPos
-      + position.left
-      + this.position[0];
-
-    if (width < 0) {
-      // this overlay is off the left end of the track and
-      // doesn't need to be drawn
-      return;
-    }
-
-    if (xPos + width > rightPosition) {
-      width += rightPosition - (xPos + width);
-    }
+    const width = this._xScale(extent[1]) - this._xScale(extent[0]);
 
     graphics.drawRect(xPos, yPos, width, height);
   }
@@ -99,6 +69,7 @@ class OverlayTrack extends PixiTrack {
 
   draw() {
     super.draw();
+
     const graphics = this.pMain;
     const fill = colorToHex(
       this.options.fillColor ? this.options.fillColor : 'blue'

--- a/app/scripts/TiledPlot.js
+++ b/app/scripts/TiledPlot.js
@@ -1011,7 +1011,7 @@ class TiledPlot extends React.Component {
               orientationsAndPositions: overlayTrack.includes.map((trackUuid) => {
                 // translate a trackUuid into that track's orientation
                 const includedTrack = getTrackByUid(this.props.tracks, trackUuid);
-                const trackPos = includedTrack.position;
+                const trackPos = getTrackPositionByUid(this.props.tracks, includedTrack.uid);
                 if (!includedTrack) {
                   console.warn(`OverlayTrack included uid (${trackUuid}) not found in the track list`);
                   return null;
@@ -1046,8 +1046,8 @@ class TiledPlot extends React.Component {
                 }
 
                 const position = {
-                  left: positionedTrack[0].left,
-                  top: positionedTrack[0].top,
+                  left: positionedTrack[0].left - this.props.paddingLeft,
+                  top: positionedTrack[0].top - this.props.paddingTop,
                   width: positionedTrack[0].width,
                   height: positionedTrack[0].height,
                 };
@@ -1064,8 +1064,8 @@ class TiledPlot extends React.Component {
           // the 2 * verticalMargin is to make up for the space taken away
           // in render(): this.centerHeight = this.state.height...
           return {
-            top: 0,
-            left: 0,
+            top: this.props.paddingTop,
+            left: this.props.paddingLeft,
             width: this.leftWidth + this.centerWidth + this.rightWidth,
             height: this.topHeight + this.centerHeight
             + this.bottomHeight
@@ -2245,14 +2245,6 @@ class TiledPlot extends React.Component {
 
   addEventListeners() {
     this.eventListeners = [
-      /*
-      {
-        name: 'dragstart',
-        callback: (event) => {
-          console.log('dragstart', event.dataTransfer.getData('text/json'));
-        },
-      },
-      */
     ];
 
     this.eventListeners.forEach(

--- a/app/scripts/TrackRenderer.js
+++ b/app/scripts/TrackRenderer.js
@@ -1107,7 +1107,10 @@ class TrackRenderer extends React.Component {
         const trackAtZoomStart = tracksAtZoomStart[0];
         const trackDef = this.getTrackDef(trackAtZoomStart);
 
-        trackOrientation = TRACKS_INFO_BY_TYPE[trackDef.type].orientation;
+        if (TRACKS_INFO_BY_TYPE[trackDef.type]) {
+          // some track types (like overlay-track don't have a track info)
+          trackOrientation = TRACKS_INFO_BY_TYPE[trackDef.type].orientation;
+        }
       }
     }
 


### PR DESCRIPTION
## Description

> What was changed in this pull request?

A few bug fixes.

1. Track orientation was not being populated because it's no longer added to the viewconf. Updated it to be properly updated.
2. Removed some unnecessary code which was preventing drawing when overlays were off the screen. This is all taken care of by the track mask so no need for it there.

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
