### PR TITLE
Fixed the hideTrackChooser API call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release notes
 
 - Fix: Add missing initializer value to `utils.reduce`
+- Fix `api.hideTrackChooser`
 
 ## v1.13.5
 

--- a/app/scripts/api.js
+++ b/app/scripts/api.js
@@ -391,7 +391,7 @@ const createApi = function api(context, pubSub) {
        * Hide the track chooser.
        */
       hideTrackChooser() {
-        this.setState({
+        self.setState({
           chooseTrackHandler: null,
         });
       },

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -37,6 +37,14 @@ describe('API Tests', () => {
   });
 
   describe('Options tests', () => {
+    it('shows and hides the track chooser', () => {
+      [div, api] = createElementAndApi(simpleCenterViewConfig);
+
+      api.showTrackChooser();
+
+      api.hideTrackChooser();
+    });
+
     it('adjust view spacing', () => {
       const options = {
         pixelPreciseMarginPadding: true,


### PR DESCRIPTION
## Description

> What was changed in this pull request?

The previous `hideTrackChooser` API call was calling a non-existent `this` object. This PR fixes it and adds a test.

> Why is it necessary?

Prevent an error when calling `hideTrackChooser`.

Fixes #___

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [x] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
