### PR TITLE
Remove the deprecated componentWillMount function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 _[Detailed changes since v1.6.11](https://github.com/higlass/higlass/compare/v1.6.11...develop)_
 
+- Removed componentWillMount
+
 ## v1.6.11
 
 - Overlay track bug fixes

--- a/app/scripts/Autocomplete.js
+++ b/app/scripts/Autocomplete.js
@@ -9,6 +9,10 @@ class Autocomplete extends React.Component {
   constructor(props) {
     super(props);
 
+    this._ignoreBlur = false;
+    this._performAutoCompleteOnUpdate = false;
+    this._performAutoCompleteOnKeyUp = false;
+
     this.state = {
       highlightedIndex: null,
       menuTop: 0,
@@ -96,12 +100,6 @@ class Autocomplete extends React.Component {
       isOpen: false,
       highlightedIndex: null,
     };
-  }
-
-  componentWillMount() {
-    this._ignoreBlur = false;
-    this._performAutoCompleteOnUpdate = false;
-    this._performAutoCompleteOnKeyUp = false;
   }
 
   componentWillReceiveProps(nextProps) {

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -315,42 +315,6 @@ class HiGlassComponent extends React.Component {
     );
   }
 
-  componentWillMount() {
-    this.domEvent.register('keydown', document);
-    this.domEvent.register('keyup', document);
-    this.domEvent.register('scroll', document);
-    this.domEvent.register('resize', window);
-    this.domEvent.register('orientationchange', window);
-
-    this.domEvent.register('wheel', window);
-    this.domEvent.register('mousedown', window, true);
-    this.domEvent.register('mouseup', window, true);
-    this.domEvent.register('click', window, true);
-    this.domEvent.register('mousemove', window);
-    this.domEvent.register('blur', window);
-
-    this.pubSubs.push(
-      this.pubSub.subscribe('app.click', this.appClickHandlerBound),
-      this.pubSub.subscribe('blur', this.onBlurHandlerBound),
-      this.pubSub.subscribe('keydown', this.keyDownHandlerBound),
-      this.pubSub.subscribe('keyup', this.keyUpHandlerBound),
-      this.pubSub.subscribe('resize', this.resizeHandlerBound),
-      this.pubSub.subscribe('wheel', this.wheelHandlerBound),
-      this.pubSub.subscribe('orientationchange', this.resizeHandlerBound),
-      this.pubSub.subscribe('app.event', this.dispatchEventBound),
-      this.pubSub.subscribe('app.animateOnMouseMove', this.animateOnMouseMoveHandlerBound),
-      this.pubSub.subscribe('trackDropped', this.trackDroppedHandlerBound),
-      this.pubSub.subscribe('app.zoomStart', this.zoomStartHandlerBound),
-      this.pubSub.subscribe('app.zoomEnd', this.zoomEndHandlerBound),
-      this.pubSub.subscribe('app.zoom', this.zoomHandlerBound),
-      this.pubSub.subscribe('requestReceived', this.requestReceivedHandlerBound),
-    );
-
-    if (this.props.getApi) {
-      this.props.getApi(this.api);
-    }
-  }
-
   setBroadcastMousePositionGlobally(isBroadcastMousePositionGlobally = false) {
     this.isBroadcastMousePositionGlobally = isBroadcastMousePositionGlobally;
   }
@@ -492,6 +456,41 @@ class HiGlassComponent extends React.Component {
     icons.forEach(
       icon => createSymbolIcon(baseSvg, icon.id, icon.paths, icon.viewBox),
     );
+
+    // formerly in componentWillMount
+    this.domEvent.register('keydown', document);
+    this.domEvent.register('keyup', document);
+    this.domEvent.register('scroll', document);
+    this.domEvent.register('resize', window);
+    this.domEvent.register('orientationchange', window);
+
+    this.domEvent.register('wheel', window);
+    this.domEvent.register('mousedown', window, true);
+    this.domEvent.register('mouseup', window, true);
+    this.domEvent.register('click', window, true);
+    this.domEvent.register('mousemove', window);
+    this.domEvent.register('blur', window);
+
+    this.pubSubs.push(
+      this.pubSub.subscribe('app.click', this.appClickHandlerBound),
+      this.pubSub.subscribe('blur', this.onBlurHandlerBound),
+      this.pubSub.subscribe('keydown', this.keyDownHandlerBound),
+      this.pubSub.subscribe('keyup', this.keyUpHandlerBound),
+      this.pubSub.subscribe('resize', this.resizeHandlerBound),
+      this.pubSub.subscribe('wheel', this.wheelHandlerBound),
+      this.pubSub.subscribe('orientationchange', this.resizeHandlerBound),
+      this.pubSub.subscribe('app.event', this.dispatchEventBound),
+      this.pubSub.subscribe('app.animateOnMouseMove', this.animateOnMouseMoveHandlerBound),
+      this.pubSub.subscribe('trackDropped', this.trackDroppedHandlerBound),
+      this.pubSub.subscribe('app.zoomStart', this.zoomStartHandlerBound),
+      this.pubSub.subscribe('app.zoomEnd', this.zoomEndHandlerBound),
+      this.pubSub.subscribe('app.zoom', this.zoomHandlerBound),
+      this.pubSub.subscribe('requestReceived', this.requestReceivedHandlerBound),
+    );
+
+    if (this.props.getApi) {
+      this.props.getApi(this.api);
+    }
   }
 
   getTrackObject(viewUid, trackUid) {

--- a/app/scripts/TrackRenderer.js
+++ b/app/scripts/TrackRenderer.js
@@ -204,9 +204,8 @@ class TrackRenderer extends React.Component {
     this.boundForwardEvent = this.forwardEvent.bind(this);
     this.boundScrollEvent = this.scrollEvent.bind(this);
     this.boundForwardContextMenu = this.forwardContextMenu.bind(this);
-  }
 
-  componentWillMount() {
+    // formerly in componentWillMount
     this.pubSubs = [];
     this.pubSubs.push(
       this.props.pubSub.subscribe('scroll', this.windowScrolledBound),


### PR DESCRIPTION
## Description

> What was changed in this pull request?

React has deprecated this function and its contents need to be moved. This PR does that.

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
