### PR TITLE
Fix moving horizontal rules bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 _[Detailed changes since v1.6.11](https://github.com/higlass/higlass/compare/v1.6.11...develop)_
 
+## v1.6.12
+
+- Fixed horizontal rule bug (from Slack)
+
 ## v1.6.11
 
 - Overlay track bug fixes

--- a/app/scripts/HorizontalRule.js
+++ b/app/scripts/HorizontalRule.js
@@ -23,7 +23,6 @@ export const HorizontalRuleMixin = Mixin(superclass => class extends superclass 
     const dashLength = 5;
     const dashGap = 3;
 
-    // console.log('this._yScale.range()', this._yScale.range());
     while (pos < this.dimensions[0]) {
       graphics.moveTo(pos, this._yScale(this.yPosition));
       graphics.lineTo(pos + dashLength, this._yScale(this.yPosition));

--- a/app/scripts/TrackRenderer.js
+++ b/app/scripts/TrackRenderer.js
@@ -1266,7 +1266,12 @@ class TrackRenderer extends React.Component {
     for (const uid in this.trackDefObjects) {
       const track = this.trackDefObjects[uid].trackObject;
       const trackDef = this.trackDefObjects[uid].trackDef;
-      const orientation = TRACKS_INFO_BY_TYPE[trackDef.track.type].orientation;
+
+      let orientation = 'unknown';
+
+      if (TRACKS_INFO_BY_TYPE[trackDef.track.type]) {
+        orientation = TRACKS_INFO_BY_TYPE[trackDef.track.type].orientation;
+      }
 
       if (orientation === 'whole') {
         // whole tracks need different scales which go beyond the ends of

--- a/app/scripts/TrackRenderer.js
+++ b/app/scripts/TrackRenderer.js
@@ -863,6 +863,7 @@ class TrackRenderer extends React.Component {
     } // we need a pixi stage to start rendering
     // the parent component where it lives probably
     // hasn't been mounted yet
+
     for (let i = 0; i < newTrackDefinitions.length; i++) {
       const newTrackDef = newTrackDefinitions[i];
       const newTrackObj = this.createTrackObject(newTrackDef.track);
@@ -1270,7 +1271,6 @@ class TrackRenderer extends React.Component {
       if (orientation === 'whole') {
         // whole tracks need different scales which go beyond the ends of
         // center track and encompass the whole view
-
         const trackXScale = scaleLinear()
           .domain(
             [

--- a/app/scripts/TrackRenderer.js
+++ b/app/scripts/TrackRenderer.js
@@ -863,7 +863,6 @@ class TrackRenderer extends React.Component {
     } // we need a pixi stage to start rendering
     // the parent component where it lives probably
     // hasn't been mounted yet
-
     for (let i = 0; i < newTrackDefinitions.length; i++) {
       const newTrackDef = newTrackDefinitions[i];
       const newTrackObj = this.createTrackObject(newTrackDef.track);
@@ -1265,8 +1264,10 @@ class TrackRenderer extends React.Component {
 
     for (const uid in this.trackDefObjects) {
       const track = this.trackDefObjects[uid].trackObject;
+      const trackDef = this.trackDefObjects[uid].trackDef;
+      const orientation = TRACKS_INFO_BY_TYPE[trackDef.track.type].orientation;
 
-      if (this.trackDefObjects[uid].trackDef.track.position === 'whole') {
+      if (orientation === 'whole') {
         // whole tracks need different scales which go beyond the ends of
         // center track and encompass the whole view
 

--- a/app/scripts/VerticalRule.js
+++ b/app/scripts/VerticalRule.js
@@ -20,7 +20,8 @@ export const VerticalRuleMixin = Mixin(superclass => class extends superclass {
     const dashLength = 5;
     const dashGap = 3;
 
-    // console.log('this._yScale.range()', this._yScale.range());
+    // console.log('this.position', this.position);
+    // console.log('this._xScale.range()', this._xScale.range());
 
     while (pos < this.dimensions[1]) {
       graphics.moveTo(this._xScale(this.xPosition), pos);

--- a/test/RuleTests.js
+++ b/test/RuleTests.js
@@ -22,12 +22,20 @@ describe('Minimal viewconfs', () => {
           initialXDomain: [0, 200],
           initialYDomain: [0, 200],
           tracks: {
+            left: [
+              { type: 'left-axis', width: 20 }
+            ],
             whole: [
               {
                 uid: 'a',
                 type: 'cross-rule',
                 x: 100,
                 y: 100
+              },
+              {
+                uid: 'b',
+                type: 'vertical-rule',
+                x: 110,
               }
             ]
           }
@@ -49,6 +57,30 @@ describe('Minimal viewconfs', () => {
 
       expect(obj.xPosition).to.eql(100);
       expect(obj.yPosition).to.eql(100);
+    });
+
+    it('has the same range if a new track is added', () => {
+      const obj1 = getTrackObjectFromHGC(hgc.instance(), 'aa', 'b');
+      const obj1Width = obj1._xScale.range()[1];
+
+
+      hgc.instance().handleTrackAdded('aa', {
+        uid: 'c',
+        type: 'vertical-rule',
+        x: 120
+      }, 'whole');
+
+      hgc.setState(hgc.instance().state);
+      hgc.update();
+
+      const obj2 = getTrackObjectFromHGC(hgc.instance(), 'aa', 'c');
+      const obj2Width = obj2._xScale.range()[1];
+
+      // "whole" tracks have different scale ranges that have to be
+      // properly set in TrackRenderer. There was a bug where loading
+      // a viewconf with pre-configured rules didn't properly set the
+      // range and led to the rules moving about
+      expect(obj1Width).to.equal(obj2Width);
     });
 
     afterAll(() => {


### PR DESCRIPTION
## Description

> What was changed in this pull request?

This PR fixes a bug where rules in a loaded viewconf would move relative to the underlying data.

> Why is it necessary?

Rules should never move relative to the underlying data.

![Oct-20-2019 16-58-58](https://user-images.githubusercontent.com/2143629/67168595-f84e5480-f35a-11e9-9fcd-0d71de605fb1.gif)


Fixes #___

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [x] Unit tests added or updated
- [o] Documentation added or updated
- [x] Example(s) added or updated
- [o] Update schema.json if there are changes to the viewconf JSON structure format
- [x] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
