### PR TITLE
Show Loading... when retrieving a tileset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.6.13
+
+- Properly display "Loading" while loading tileset info
+
 ## v1.6.12
 
 - Rename React lifecycle methods according to their recommendations

--- a/app/scripts/data-fetchers/genbank-fetcher.js
+++ b/app/scripts/data-fetchers/genbank-fetcher.js
@@ -127,7 +127,11 @@ class GBKDataFetcher {
   }
 
   tilesetInfo(callback) {
+    this.tilesetInfoLoading = true;
+
     return this.dataPromise.then(() => {
+      this.tilesetInfoLoading = false;
+
       const TILE_SIZE = 1024;
       let retVal = {};
       // retVal[this.trackUid] = {
@@ -148,6 +152,8 @@ class GBKDataFetcher {
       return retVal;
     })
       .catch((err) => {
+        this.tilesetInfoLoading = false;
+
         if (callback) {
           callback({
             error: `Error parsing genbank: ${err}`,


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Make sure to display "Loading..." when pulling tileset info for Genbank files.

> Why is it necessary?

If the `this.tilesetInfoLoading` variable isn't set, the track will display `Tileset info not found` while it's fetching the tileset info.

### Before

![image](https://user-images.githubusercontent.com/2143629/67895460-c6d24780-fb17-11e9-8d5f-efd323c952d5.png)

### After

![image](https://user-images.githubusercontent.com/2143629/67895434-ba4def00-fb17-11e9-9dd3-e5a6f389d732.png)

Fixes #___

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [o] Unit tests added or updated
- [o] Documentation added or updated
- [o] Example(s) added or updated
- [o] Update schema.json if there are changes to the viewconf JSON structure format
- [x] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
