### PR TITLE
Flekschas/enhance value locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add support for scrollable views. Activate via the option `scrollable: true`. Once you activate scrollable views all views are automatically zoomfixed! See [http://localhost:8080/others/scrollable-container.html](others/scrollable-container.html) for an example.
 - Add `option(key, value)` to the JS API for changing options. It supports getting all options when `value` is ommited and setting `scrollable`.
 - Properly display "Loading" while loading tileset info
+- Add support to ignore offscreen values for value scale locking by setting `ignoreOffScreenValues: true` for a lock group in `locksDict`.
 
 _[Detailed changes since v1.6.12](https://github.com/higlass/higlass/compare/v1.6.12...v1.6.13)_
 

--- a/app/schema.json
+++ b/app/schema.json
@@ -94,10 +94,11 @@
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
-                  "uid": { "$ref": "#/definitions/locks/slug" }
+                  "uid": { "$ref": "#/definitions/locks/slug" },
+                  "ignoreOffScreenValues": { "type": "boolean" }
                 },
                 "patternProperties": {
-                  "^(?!uid).": {
+                  "^(?!(uid|ignoreOffScreenValues)).": {
                     "type": "object",
                     "additionalProperties": false,
                     "required": ["view", "track"],

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -1054,25 +1054,28 @@ class HiGlassComponent extends React.Component {
     const sourceTrack = getTrackByUid(this.state.views[viewUid].tracks, trackUid);
 
     if (this.valueScaleLocks[uid]) {
-      const lockGroupValues = dictValues(this.valueScaleLocks[uid]);
+      const lockGroup = this.valueScaleLocks[uid];
 
       // /let trackObj = this.tiledPlots[viewUid].trackRenderer.getTrackObject(trackUid);
-      const lockedTracks = lockGroupValues
-        .filter(x => this.tiledPlots[x.view])
-        .map(x => this.tiledPlots[x.view].trackRenderer.getTrackObject(x.track))
-        .filter(x => x);
+      const lockedTracks = Object.values(lockGroup)
+        .filter(track => this.tiledPlots[track.view])
+        .map(track => this.tiledPlots[track.view].trackRenderer.getTrackObject(track.track));
 
       const minValues = lockedTracks
         // exclude tracks that don't set min and max values
-        .filter(x => x.minRawValue && x.maxRawValue)
-        .map(x => x.minRawValue())
-        .filter(x => x);
+        .filter(track => track.minRawValue && track.maxRawValue)
+        .map(track => (lockGroup.ignoreOffScreenValues
+          ? track.minRawValue()
+          : track.minVisibleValue(true)
+        ));
 
       const maxValues = lockedTracks
         // exclude tracks that don't set min and max values
-        .filter(x => x.minRawValue && x.maxRawValue)
-        .map(x => x.maxRawValue())
-        .filter(x => x);
+        .filter(track => track.minRawValue && track.maxRawValue)
+        .map(track => (lockGroup.ignoreOffScreenValues
+          ? track.maxRawValue()
+          : track.maxVisibleValue(true)
+        ));
 
       const allMin = Math.min(...minValues);
       const allMax = Math.max(...maxValues);

--- a/schema_build_test.sh
+++ b/schema_build_test.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -o errexit
+
+start() { echo travis_fold':'start:$1; echo $1; }
+end() { echo travis_fold':'end:$1; }
+die() { set +v; echo "$*" 1>&2 ; sleep 1; exit 1; }
+# Race condition truncates logs on Travis: "sleep" might help.
+# https://github.com/travis-ci/travis-ci/issues/6018
+
+start eslint
+./node_modules/eslint/bin/eslint.js karma.conf.js app test
+end eslint
+
+start viewconfs
+ls docs/examples/viewconfs/*.json \
+  test/view-configs/*.json \
+  test/view-configs-more/*.json \
+  | sed 's/^/-d /' \
+  | xargs npx ajv validate -s app/schema.json --errors=text \
+  || die "Invalid viewconf fixtures"
+end viewconfs
+
+start compile
+npm run compile
+[ -e dist.zip ] || die 'Missing dist.zip: Please check that it was produced by npm compile in build.sh.'
+end compile


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Added `ignoreOffScreenValues` as a property to lock groups in `locksDict` of `valueScaleLocks`.

> Why is it necessary?

To allow locking by visible values only.

> Can I add this through the UI

No

> How performant is this

It's 10x slower than the normal method because it's scanning the visual range of values instead of retrieving just a simple value.

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [x] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
