### PR TITLE
Flekschas/fix scrollable multi views

### DIFF
--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -2486,7 +2486,10 @@ class HiGlassComponent extends React.Component {
       // topDiv are the same but when the scroll is active `topDiv` can be
       // smaller or larger than `totalTrackHeight`.
       view.layout.h = Math.ceil(
-        this.topDiv.parentNode.getBoundingClientRect().height / rowHeight
+        Math.min(
+          this.topDiv.parentNode.getBoundingClientRect().height,
+          totalTrackHeight
+        ) / rowHeight
       );
     } else if (!this.props.options.bounded) {
       view.layout.h = Math.ceil(totalTrackHeight / rowHeight);

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -3755,9 +3755,9 @@ class HiGlassComponent extends React.Component {
 
   }
 
-  onScrollHandler(e) {
-    this.pixiStage.y = -e.target.scrollTop;
-    this.pubSub.publish('app.scroll', e.target.scrollTop);
+  onScrollHandler() {
+    this.pixiStage.y = -this.scrollContainer.scrollTop;
+    this.pubSub.publish('app.scroll', this.scrollContainer.scrollTop);
     this.animate();
   }
 
@@ -4156,7 +4156,6 @@ class HiGlassComponent extends React.Component {
         className="higlass"
         onMouseLeave={this.onMouseLeaveHandlerBound}
         onMouseMove={this.mouseMoveHandlerBound}
-        onScroll={this.onScrollHandlerBound}
         style={this.props.options.scrollable ? scrollStyles : {}}
         styleName={styleNames}
       >
@@ -4170,6 +4169,9 @@ class HiGlassComponent extends React.Component {
                 styleName="styles.higlass-canvas"
               />
               <div
+                ref={(c) => { this.scrollContainer = c; }}
+                className="higlass-scroll-container"
+                onScroll={this.onScrollHandlerBound}
                 style={this.props.options.scrollable
                   ? {
                     ...scrollStyles,
@@ -4180,25 +4182,26 @@ class HiGlassComponent extends React.Component {
               >
                 <div
                   ref={(c) => { this.divDrawingSurface = c; }}
+                  className="higlass-drawing-surface"
                   styleName="styles.higlass-drawing-surface"
                 >
                   {gridLayout}
                 </div>
+                <svg
+                  ref={(c) => { this.svgElement = c; }}
+                  style={{
+                    // inline the styles so they aren't overriden by other css
+                    // on the web page
+                    position: 'absolute',
+                    width: '100%',
+                    height: '100%',
+                    left: 0,
+                    top: 0,
+                    pointerEvents: 'none',
+                  }}
+                  styleName="styles.higlass-svg"
+                />
               </div>
-              <svg
-                ref={(c) => { this.svgElement = c; }}
-                style={{
-                  // inline the styles so they aren't overriden by other css
-                  // on the web page
-                  position: 'absolute',
-                  width: '100%',
-                  height: '100%',
-                  left: 0,
-                  top: 0,
-                  pointerEvents: 'none',
-                }}
-                styleName="styles.higlass-svg"
-              />
             </ThemeProvider>
           </ModalProvider>
         </PubSubProvider>

--- a/app/scripts/TiledPlot.js
+++ b/app/scripts/TiledPlot.js
@@ -2065,7 +2065,6 @@ class TiledPlot extends React.Component {
           positionedTracks={positionedTracks}
           registerDraggingChangedListener={this.props.registerDraggingChangedListener}
           removeDraggingChangedListener={this.props.removeDraggingChangedListener}
-          scrollable={this.props.scrollable}
           setCentersFunction={this.props.setCentersFunction}
           svgElement={this.props.svgElement}
           topHeight={this.topHeight}
@@ -2266,7 +2265,6 @@ TiledPlot.defaultProps = {
   isShowGlobalMousePosition: false,
   pluginTracks: {},
   metaTracks: [],
-  scrollable: false,
   zoomable: true,
 };
 
@@ -2313,7 +2311,6 @@ TiledPlot.propTypes = {
   rangeSelectionToInt: PropTypes.bool,
   registerDraggingChangedListener: PropTypes.func,
   removeDraggingChangedListener: PropTypes.func,
-  scrollable: PropTypes.bool,
   setCentersFunction: PropTypes.func,
   svgElement: PropTypes.object,
   theme: PropTypes.symbol.isRequired,

--- a/app/scripts/TrackRenderer.js
+++ b/app/scripts/TrackRenderer.js
@@ -205,6 +205,8 @@ class TrackRenderer extends React.Component {
     this.boundForwardEvent = this.forwardEvent.bind(this);
     this.boundScrollEvent = this.scrollEvent.bind(this);
     this.boundForwardContextMenu = this.forwardContextMenu.bind(this);
+    this.dispatchEventBound = this.dispatchEvent.bind(this);
+    this.zoomToDataPosHandlerBound = this.zoomToDataPosHandler.bind(this);
     this.onScrollHandlerBound = this.onScrollHandler.bind(this);
   }
 
@@ -215,10 +217,13 @@ class TrackRenderer extends React.Component {
       this.props.pubSub.subscribe('scroll', this.windowScrolledBound),
     );
     this.pubSubs.push(
-      this.props.pubSub.subscribe('app.event', this.dispatchEvent.bind(this)),
+      this.props.pubSub.subscribe('app.event', this.dispatchEventBound),
     );
     this.pubSubs.push(
-      this.props.pubSub.subscribe('zoomToDataPos', this.zoomToDataPosHandler.bind(this)),
+      this.props.pubSub.subscribe('zoomToDataPos', this.zoomToDataPosHandlerBound),
+    );
+    this.pubSubs.push(
+      this.props.pubSub.subscribe('app.scroll', this.onScrollHandlerBound),
     );
   }
 
@@ -466,7 +471,7 @@ class TrackRenderer extends React.Component {
     this.pMask.beginFill();
     this.pMask.drawRect(
       this.xPositionOffset,
-      this.yPositionOffset + this.scrollTop,
+      this.yPositionOffset,
       this.currentProps.width,
       this.currentProps.height
     );
@@ -754,6 +759,7 @@ class TrackRenderer extends React.Component {
       this.yPositionOffset = (
         this.element.getBoundingClientRect().top
         - this.currentProps.canvasElement.getBoundingClientRect().top
+        + this.scrollTop
       );
       this.xPositionOffset = (
         this.element.getBoundingClientRect().left
@@ -1884,10 +1890,8 @@ class TrackRenderer extends React.Component {
     this.props.pubSub.publish('app.event', e);
   }
 
-  onScrollHandler(e) {
-    this.scrollTop = e.target.scrollTop;
-    this.setMask();
-    this.props.pubSub.publish('app.viewScroll', this.scrollTop);
+  onScrollHandler(scrollTop) {
+    this.scrollTop = scrollTop;
   }
 
   /* ------------------------------- Render ------------------------------- */
@@ -1911,11 +1915,6 @@ class TrackRenderer extends React.Component {
         <div
           ref={(c) => { this.eventTracker = c; }}
           className="track-renderer-events"
-          onScroll={this.onScrollHandlerBound}
-          style={{
-            overflowX: 'hidden',
-            overflowY: this.props.scrollable ? 'auto' : 'hidden',
-          }}
           styleName="track-renderer-events"
         >
           {this.currentProps.children}
@@ -1942,7 +1941,6 @@ TrackRenderer.defaultProps = {
   paddingLeft: 0,
   paddingTop: 0,
   positionedTracks: [],
-  scrollable: false,
   topHeight: 0,
   topHeightNoGallery: 0,
   width: 0,
@@ -1972,7 +1970,6 @@ TrackRenderer.propTypes = {
   pixiStage: PropTypes.object.isRequired,
   pluginTracks: PropTypes.object,
   positionedTracks: PropTypes.array,
-  scrollable: PropTypes.bool,
   setCentersFunction: PropTypes.func,
   svgElement: PropTypes.object.isRequired,
   theme: PropTypes.symbol.isRequired,

--- a/docs/examples/others/scrollable-container-multiple-views.html
+++ b/docs/examples/others/scrollable-container-multiple-views.html
@@ -8,9 +8,7 @@
 
 <style type="text/css">
 #container {
-  position: absolute;
-  top: 1rem;
-  left: 1rem;
+  position: relative;
   width: 600px;
   height: 400px;
   background: #eee;
@@ -31,6 +29,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/react-bootstrap/0.32.1/react-bootstrap.min.js"></script>
 </head>
 <body>
+  <label>Scroll the container <input id="scrollable" type="checkbox" checked="checked"></label>
   <div id="container">
     <div id="demo"></div>
   </div>
@@ -42,7 +41,7 @@ const viewConfig = {
   zoomFixed: true,
   views: [
     {
-      layout: { w: 12, h, x: 0, y: 0 * h, i: 'a', moved: false, static: false },
+      layout: { w: 12, h, x: 0, y: 0 * h },
       uid: 'a',
       initialXDomain: [0, 2547598956],
       tracks: {
@@ -118,7 +117,7 @@ const viewConfig = {
       },
     },
     {
-      layout: { w: 12, h, x: 0, y: 1 * h, i: 'b', moved: false, static: false },
+      layout: { w: 12, h, x: 0, y: 1 * h },
       uid: 'b',
       initialXDomain: [0, 2547598956],
       tracks: {
@@ -194,7 +193,7 @@ const viewConfig = {
       },
     },
     {
-      layout: { w: 12, h, x: 0, y: 2 * h, i: 'c', moved: false, static: false },
+      layout: { w: 12, h, x: 0, y: 2 * h },
       uid: 'c',
       initialXDomain: [0, 2547598956],
       tracks: {
@@ -270,7 +269,7 @@ const viewConfig = {
       },
     },
     {
-      layout: { w: 12, h, x: 0, y: 3 * h, i: 'd', moved: false, static: false },
+      layout: { w: 12, h, x: 0, y: 3 * h },
       uid: 'd',
       initialXDomain: [0, 2547598956],
       tracks: {
@@ -346,7 +345,7 @@ const viewConfig = {
       },
     },
     {
-      layout: { w: 12, h, x: 0, y: 4 * h, i: 'e', moved: false, static: false },
+      layout: { w: 12, h, x: 0, y: 4 * h },
       uid: 'e',
       initialXDomain: [0, 2547598956],
       tracks: {
@@ -422,7 +421,7 @@ const viewConfig = {
       },
     },
     {
-      layout: { w: 12, h, x: 0, y: 5 * h, i: 'f', moved: false, static: false },
+      layout: { w: 12, h, x: 0, y: 5 * h },
       uid: 'f',
       initialXDomain: [0, 2547598956],
       tracks: {
@@ -498,7 +497,7 @@ const viewConfig = {
       },
     },
     {
-      layout: { w: 12, h, x: 0, y: 6 * h, i: 'g', moved: false, static: false },
+      layout: { w: 12, h, x: 0, y: 6 * h },
       uid: 'g',
       initialXDomain: [0, 2547598956],
       tracks: {
@@ -574,7 +573,7 @@ const viewConfig = {
       },
     },
     {
-      layout: { w: 12, h, x: 0, y: 7 * h, i: 'h', moved: false, static: false },
+      layout: { w: 12, h, x: 0, y: 7 * h },
       uid: 'h',
       initialXDomain: [0, 2547598956],
       tracks: {
@@ -650,7 +649,7 @@ const viewConfig = {
       },
     },
     {
-      layout: { w: 12, h, x: 0, y: 8 * h, i: 'i', moved: false, static: false },
+      layout: { w: 12, h, x: 0, y: 8 * h },
       uid: 'i',
       initialXDomain: [0, 2547598956],
       tracks: {
@@ -726,7 +725,7 @@ const viewConfig = {
       },
     },
     {
-      layout: { w: 12, h, x: 0, y: 9 * h, i: 'j', moved: false, static: false },
+      layout: { w: 12, h, x: 0, y: 9 * h },
       uid: 'j',
       initialXDomain: [0, 2547598956],
       tracks: {
@@ -802,7 +801,7 @@ const viewConfig = {
       },
     },
     {
-      layout: { w: 12, h, x: 0, y: 10 * h, i: 'k', moved: false, static: false },
+      layout: { w: 12, h, x: 0, y: 10 * h },
       uid: 'k',
       initialXDomain: [0, 2547598956],
       tracks: {
@@ -878,7 +877,7 @@ const viewConfig = {
       },
     },
     {
-      layout: { w: 12, h, x: 0, y: 11 * h, i: 'l', moved: false, static: false },
+      layout: { w: 12, h, x: 0, y: 11 * h },
       uid: 'l',
       initialXDomain: [0, 2547598956],
       tracks: {
@@ -967,5 +966,10 @@ const hgApi = hglib.viewer(
     scrollable: true,
   },
 );
+
+document.getElementById('scrollable').addEventListener('change', () => {
+  console.log('Scrolling: ', document.getElementById('scrollable').checked);
+  hgApi.option('scrollable', document.getElementById('scrollable').checked);
+});
 </script>
 </html>

--- a/docs/examples/others/scrollable-container-multiple-views.html
+++ b/docs/examples/others/scrollable-container-multiple-views.html
@@ -113,6 +113,56 @@ const viewConfig = {
             name: 'GM12878-E116-H3K27ac.fc.signal'
           },
         ],
+        center: [
+          {
+            uid: 'c1',
+            type: 'combined',
+            height: 200,
+            contents: [
+              {
+                server: '//higlass.io/api/v1',
+                tilesetUid: 'CQMd6V_cRw6iCI_-Unl3PQ',
+                type: 'heatmap',
+                options: {
+                  maxZoom: null,
+                  labelPosition: 'bottomRight',
+                  name: 'Rao et al. (2014) GM12878 MboI (allreps) 1kb',
+                  backgroundColor: '#eeeeee',
+                  labelLeftMargin: 0,
+                  labelRightMargin: 0,
+                  labelTopMargin: 0,
+                  labelBottomMargin: 0,
+                  labelShowResolution: true,
+                  colorRange: [
+                    'white',
+                    'rgba(245,166,35,1.0)',
+                    'rgba(208,2,27,1.0)',
+                    'black'
+                  ],
+                  colorbarBackgroundColor: '#ffffff',
+                  colorbarPosition: 'topRight',
+                  trackBorderWidth: 0,
+                  trackBorderColor: 'black',
+                  heatmapValueScaling: 'log',
+                  showMousePosition: false,
+                  mousePositionColor: '#000000',
+                  showTooltip: false,
+                  extent: 'full',
+                  scaleStartPercent: '0.00000',
+                  scaleEndPercent: '1.00000'
+                },
+                uid: 'GjuZed1ySGW1IzZZqFB9BA',
+                transforms: [
+                  {
+                    name: 'ICE',
+                    value: 'weight'
+                  }
+                ]
+              }
+            ],
+            options: {}
+          }
+        ]
       },
     },
     {

--- a/docs/examples/others/scrollable-container-multiple-views.html
+++ b/docs/examples/others/scrollable-container-multiple-views.html
@@ -38,7 +38,6 @@
 <script>
 const h = 6;
 const viewConfig = {
-  zoomFixed: true,
   views: [
     {
       layout: { w: 12, h, x: 0, y: 0 * h },

--- a/test/APITests.js
+++ b/test/APITests.js
@@ -12,6 +12,7 @@ import {
   simpleCenterViewConfig,
   simple1And2dAnnotations,
   stackedTopTracks,
+  stackedTopViews,
 } from './view-configs';
 
 import emptyConf from './view-configs-more/emptyConf';
@@ -332,12 +333,11 @@ describe('API Tests', () => {
       const hgc = api.getComponent();
 
       waitForTilesLoaded(hgc, () => {
-        const trackRenderer = document.querySelector('.track-renderer-events');
-        trackRenderer.scrollTop = 20;
+        const scrollContainer = div.querySelector('.higlass-scroll-container');
+        scrollContainer.scrollTop = 20;
 
         setTimeout(() => {
-          expect(trackRenderer.scrollTop).toEqual(20);
-          expect(hgc.scrollTop).toEqual(20);
+          expect(scrollContainer.scrollTop).toEqual(20);
           expect(hgc.pixiStage.y).toEqual(-20);
           done();
         }, 0);
@@ -356,13 +356,35 @@ describe('API Tests', () => {
       const hgc = api.getComponent();
 
       waitForTilesLoaded(hgc, () => {
-        const trackRenderer = document.querySelector('.track-renderer-events');
-        trackRenderer.scrollTop = 20;
+        const scrollContainer = div.querySelector('.higlass-scroll-container');
+        scrollContainer.scrollTop = 20;
 
         setTimeout(() => {
-          expect(trackRenderer.scrollTop).toEqual(0);
-          expect(hgc.scrollTop).toEqual(0);
+          expect(scrollContainer.scrollTop).toEqual(0);
           expect(hgc.pixiStage.y).toEqual(0);
+          done();
+        }, 0);
+      });
+    });
+
+    it('can scroll multiple views', (done) => {
+      [div, api] = createElementAndApi(
+        stackedTopViews,
+        { editable: false, scrollable: true, bounded: true },
+        600, 200, true
+      );
+
+      expect(api.option('scrollable')).toEqual(true);
+
+      const hgc = api.getComponent();
+
+      waitForTilesLoaded(hgc, () => {
+        const scrollContainer = div.querySelector('.higlass-scroll-container');
+        scrollContainer.scrollTop = 20;
+
+        setTimeout(() => {
+          expect(scrollContainer.scrollTop).toEqual(20);
+          expect(hgc.pixiStage.y).toEqual(-20);
           done();
         }, 0);
       });

--- a/test/view-configs-more/stacked-top-views.json
+++ b/test/view-configs-more/stacked-top-views.json
@@ -1,0 +1,968 @@
+{
+  "views": [{
+    "layout": {
+      "w": 12,
+      "h": 6,
+      "x": 0,
+      "y": 0
+    },
+    "uid": "a",
+    "initialXDomain": [0, 2547598956],
+    "tracks": {
+      "top": [{
+        "uid": "genes",
+        "tilesetUid": "OHJakQICQD6gTD7skx4EWA",
+        "position": "top",
+        "server": "http://higlass.io/api/v1",
+        "type": "horizontal-gene-annotations",
+        "height": 64,
+        "options": {
+          "labelColor": "black",
+          "plusStrandColor": "black",
+          "name": "Gene Annotations (hg19)",
+          "labelPosition": "hidden",
+          "minusStrandColor": "black",
+          "fontSize": 12,
+          "trackBorderWidth": 0,
+          "trackBorderColor": "black",
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000",
+          "geneAnnotationHeight": 12,
+          "geneLabelPosition": "outside",
+          "geneStrandSpacing": 4
+        },
+        "name": "Gene Annotations (hg19)"
+      }, {
+        "uid": "chroms",
+        "height": 20,
+        "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
+        "position": "top",
+        "type": "horizontal-chromosome-labels",
+        "options": {
+          "color": "#777777",
+          "stroke": "#FFFFFF",
+          "fontSize": 12,
+          "fontIsLeftAligned": true,
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000"
+        },
+        "name": "Chromosome Labels (hg19)"
+      }, {
+        "uid": "line1",
+        "tilesetUid": "PjIJKXGbSNCalUZO21e_HQ",
+        "height": 64,
+        "position": "top",
+        "server": "http://higlass.io/api/v1",
+        "type": "horizontal-line",
+        "options": {
+          "name": "GM12878-E116-H3K27ac.fc.signal",
+          "valueScaling": "linear",
+          "lineStrokeWidth": 2,
+          "lineStrokeColor": "blue",
+          "labelPosition": "topLeft",
+          "labelColor": "black",
+          "axisPositionHorizontal": "right",
+          "trackBorderWidth": 0,
+          "trackBorderColor": "black",
+          "labelTextOpacity": 0.4,
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000",
+          "showTooltip": false
+        },
+        "name": "GM12878-E116-H3K27ac.fc.signal"
+      }],
+      "center": [
+        {
+          "uid": "c1",
+          "type": "combined",
+          "height": 200,
+          "contents": [
+            {
+              "server": "//higlass.io/api/v1",
+              "tilesetUid": "CQMd6V_cRw6iCI_-Unl3PQ",
+              "type": "heatmap",
+              "options": {
+                "maxZoom": null,
+                "labelPosition": "bottomRight",
+                "name": "Rao et al. (2014) GM12878 MboI (allreps) 1kb",
+                "backgroundColor": "#eeeeee",
+                "labelLeftMargin": 0,
+                "labelRightMargin": 0,
+                "labelTopMargin": 0,
+                "labelBottomMargin": 0,
+                "labelShowResolution": true,
+                "colorRange": [
+                  "white",
+                  "rgba(245,166,35,1.0)",
+                  "rgba(208,2,27,1.0)",
+                  "black"
+                ],
+                "colorbarBackgroundColor": "#ffffff",
+                "colorbarPosition": "topRight",
+                "trackBorderWidth": 0,
+                "trackBorderColor": "black",
+                "heatmapValueScaling": "log",
+                "showMousePosition": false,
+                "mousePositionColor": "#000000",
+                "showTooltip": false,
+                "extent": "full",
+                "scaleStartPercent": "0.00000",
+                "scaleEndPercent": "1.00000"
+              },
+              "uid": "GjuZed1ySGW1IzZZqFB9BA",
+              "transforms": [
+                {
+                  "name": "ICE",
+                  "value": "weight"
+                }
+              ]
+            }
+          ],
+          "options": {}
+        }
+      ]
+    }
+  }, {
+    "layout": {
+      "w": 12,
+      "h": 6,
+      "x": 0,
+      "y": 6
+    },
+    "uid": "b",
+    "initialXDomain": [0, 2547598956],
+    "tracks": {
+      "top": [{
+        "uid": "genes",
+        "tilesetUid": "OHJakQICQD6gTD7skx4EWA",
+        "position": "top",
+        "server": "http://higlass.io/api/v1",
+        "type": "horizontal-gene-annotations",
+        "height": 64,
+        "options": {
+          "labelColor": "black",
+          "plusStrandColor": "black",
+          "name": "Gene Annotations (hg19)",
+          "labelPosition": "hidden",
+          "minusStrandColor": "black",
+          "fontSize": 12,
+          "trackBorderWidth": 0,
+          "trackBorderColor": "black",
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000",
+          "geneAnnotationHeight": 12,
+          "geneLabelPosition": "outside",
+          "geneStrandSpacing": 4
+        },
+        "name": "Gene Annotations (hg19)"
+      }, {
+        "uid": "chroms",
+        "height": 20,
+        "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
+        "position": "top",
+        "type": "horizontal-chromosome-labels",
+        "options": {
+          "color": "#777777",
+          "stroke": "#FFFFFF",
+          "fontSize": 12,
+          "fontIsLeftAligned": true,
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000"
+        },
+        "name": "Chromosome Labels (hg19)"
+      }, {
+        "uid": "line2",
+        "tilesetUid": "PdAaSdibTLK34hCw7ubqKA",
+        "height": 64,
+        "position": "top",
+        "server": "http://higlass.io/api/v1",
+        "type": "horizontal-line",
+        "options": {
+          "name": "GM12878-E116-H3K27me3.fc.signal",
+          "valueScaling": "linear",
+          "lineStrokeWidth": 2,
+          "lineStrokeColor": "#7414cc",
+          "labelPosition": "topLeft",
+          "labelColor": "black",
+          "axisPositionHorizontal": "right",
+          "trackBorderWidth": 0,
+          "trackBorderColor": "black",
+          "labelTextOpacity": 0.4,
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000",
+          "showTooltip": false
+        },
+        "name": "GM12878-E116-H3K27me3.fc.signal"
+      }]
+    }
+  }, {
+    "layout": {
+      "w": 12,
+      "h": 6,
+      "x": 0,
+      "y": 12
+    },
+    "uid": "c",
+    "initialXDomain": [0, 2547598956],
+    "tracks": {
+      "top": [{
+        "uid": "genes",
+        "tilesetUid": "OHJakQICQD6gTD7skx4EWA",
+        "position": "top",
+        "server": "http://higlass.io/api/v1",
+        "type": "horizontal-gene-annotations",
+        "height": 64,
+        "options": {
+          "labelColor": "black",
+          "plusStrandColor": "black",
+          "name": "Gene Annotations (hg19)",
+          "labelPosition": "hidden",
+          "minusStrandColor": "black",
+          "fontSize": 12,
+          "trackBorderWidth": 0,
+          "trackBorderColor": "black",
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000",
+          "geneAnnotationHeight": 12,
+          "geneLabelPosition": "outside",
+          "geneStrandSpacing": 4
+        },
+        "name": "Gene Annotations (hg19)"
+      }, {
+        "uid": "chroms",
+        "height": 20,
+        "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
+        "position": "top",
+        "type": "horizontal-chromosome-labels",
+        "options": {
+          "color": "#777777",
+          "stroke": "#FFFFFF",
+          "fontSize": 12,
+          "fontIsLeftAligned": true,
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000"
+        },
+        "name": "Chromosome Labels (hg19)"
+      }, {
+        "uid": "line3",
+        "tilesetUid": "e0DYtZBSTqiMLHoaimsSpg",
+        "height": 48,
+        "position": "top",
+        "server": "http://higlass.io/api/v1",
+        "type": "horizontal-line",
+        "options": {
+          "name": "GM12878-E116-H3K4me1.fc.signal",
+          "valueScaling": "linear",
+          "lineStrokeWidth": 2,
+          "lineStrokeColor": "#a800a8",
+          "labelPosition": "topLeft",
+          "labelColor": "black",
+          "axisPositionHorizontal": "right",
+          "trackBorderWidth": 0,
+          "trackBorderColor": "black",
+          "labelTextOpacity": 0.4,
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000",
+          "showTooltip": false
+        },
+        "name": "GM12878-E116-H3K4me1.fc.signal"
+      }]
+    }
+  }, {
+    "layout": {
+      "w": 12,
+      "h": 6,
+      "x": 0,
+      "y": 18
+    },
+    "uid": "d",
+    "initialXDomain": [0, 2547598956],
+    "tracks": {
+      "top": [{
+        "uid": "genes",
+        "tilesetUid": "OHJakQICQD6gTD7skx4EWA",
+        "position": "top",
+        "server": "http://higlass.io/api/v1",
+        "type": "horizontal-gene-annotations",
+        "height": 64,
+        "options": {
+          "labelColor": "black",
+          "plusStrandColor": "black",
+          "name": "Gene Annotations (hg19)",
+          "labelPosition": "hidden",
+          "minusStrandColor": "black",
+          "fontSize": 12,
+          "trackBorderWidth": 0,
+          "trackBorderColor": "black",
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000",
+          "geneAnnotationHeight": 12,
+          "geneLabelPosition": "outside",
+          "geneStrandSpacing": 4
+        },
+        "name": "Gene Annotations (hg19)"
+      }, {
+        "uid": "chroms",
+        "height": 20,
+        "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
+        "position": "top",
+        "type": "horizontal-chromosome-labels",
+        "options": {
+          "color": "#777777",
+          "stroke": "#FFFFFF",
+          "fontSize": 12,
+          "fontIsLeftAligned": true,
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000"
+        },
+        "name": "Chromosome Labels (hg19)"
+      }, {
+        "uid": "line4",
+        "tilesetUid": "cE0nGyd0Q_yVYSyBUe89Ww",
+        "height": 64,
+        "position": "top",
+        "server": "http://higlass.io/api/v1",
+        "type": "horizontal-line",
+        "options": {
+          "name": "GM12878-E116-H3K4me3.fc.signal",
+          "valueScaling": "linear",
+          "lineStrokeWidth": 2,
+          "lineStrokeColor": "#c51671",
+          "labelPosition": "topLeft",
+          "labelColor": "black",
+          "axisPositionHorizontal": "right",
+          "trackBorderWidth": 0,
+          "trackBorderColor": "black",
+          "labelTextOpacity": 0.4,
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000",
+          "showTooltip": false
+        },
+        "name": "GM12878-E116-H3K4me3.fc.signal"
+      }]
+    }
+  }, {
+    "layout": {
+      "w": 12,
+      "h": 6,
+      "x": 0,
+      "y": 24
+    },
+    "uid": "e",
+    "initialXDomain": [0, 2547598956],
+    "tracks": {
+      "top": [{
+        "uid": "genes",
+        "tilesetUid": "OHJakQICQD6gTD7skx4EWA",
+        "position": "top",
+        "server": "http://higlass.io/api/v1",
+        "type": "horizontal-gene-annotations",
+        "height": 64,
+        "options": {
+          "labelColor": "black",
+          "plusStrandColor": "black",
+          "name": "Gene Annotations (hg19)",
+          "labelPosition": "hidden",
+          "minusStrandColor": "black",
+          "fontSize": 12,
+          "trackBorderWidth": 0,
+          "trackBorderColor": "black",
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000",
+          "geneAnnotationHeight": 12,
+          "geneLabelPosition": "outside",
+          "geneStrandSpacing": 4
+        },
+        "name": "Gene Annotations (hg19)"
+      }, {
+        "uid": "chroms",
+        "height": 20,
+        "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
+        "position": "top",
+        "type": "horizontal-chromosome-labels",
+        "options": {
+          "color": "#777777",
+          "stroke": "#FFFFFF",
+          "fontSize": 12,
+          "fontIsLeftAligned": true,
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000"
+        },
+        "name": "Chromosome Labels (hg19)"
+      }, {
+        "uid": "line5",
+        "tilesetUid": "cE0nGyd0Q_yVYSyBUe89Ww",
+        "height": 64,
+        "position": "top",
+        "server": "http://higlass.io/api/v1",
+        "type": "horizontal-line",
+        "options": {
+          "name": "GM12878-E116-H3K4me3.fc.signal",
+          "valueScaling": "linear",
+          "lineStrokeWidth": 2,
+          "lineStrokeColor": "#ff0000",
+          "labelPosition": "topLeft",
+          "labelColor": "black",
+          "axisPositionHorizontal": "right",
+          "trackBorderWidth": 0,
+          "trackBorderColor": "black",
+          "labelTextOpacity": 0.4,
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000",
+          "showTooltip": false
+        },
+        "name": "GM12878-E116-H3K4me3.fc.signal"
+      }]
+    }
+  }, {
+    "layout": {
+      "w": 12,
+      "h": 6,
+      "x": 0,
+      "y": 30
+    },
+    "uid": "f",
+    "initialXDomain": [0, 2547598956],
+    "tracks": {
+      "top": [{
+        "uid": "genes",
+        "tilesetUid": "OHJakQICQD6gTD7skx4EWA",
+        "position": "top",
+        "server": "http://higlass.io/api/v1",
+        "type": "horizontal-gene-annotations",
+        "height": 64,
+        "options": {
+          "labelColor": "black",
+          "plusStrandColor": "black",
+          "name": "Gene Annotations (hg19)",
+          "labelPosition": "hidden",
+          "minusStrandColor": "black",
+          "fontSize": 12,
+          "trackBorderWidth": 0,
+          "trackBorderColor": "black",
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000",
+          "geneAnnotationHeight": 12,
+          "geneLabelPosition": "outside",
+          "geneStrandSpacing": 4
+        },
+        "name": "Gene Annotations (hg19)"
+      }, {
+        "uid": "chroms",
+        "height": 20,
+        "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
+        "position": "top",
+        "type": "horizontal-chromosome-labels",
+        "options": {
+          "color": "#777777",
+          "stroke": "#FFFFFF",
+          "fontSize": 12,
+          "fontIsLeftAligned": true,
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000"
+        },
+        "name": "Chromosome Labels (hg19)"
+      }, {
+        "uid": "line6",
+        "tilesetUid": "cE0nGyd0Q_yVYSyBUe89Ww",
+        "height": 64,
+        "position": "top",
+        "server": "http://higlass.io/api/v1",
+        "type": "horizontal-line",
+        "options": {
+          "name": "GM12878-E116-H3K4me3.fc.signal",
+          "valueScaling": "linear",
+          "lineStrokeWidth": 2,
+          "lineStrokeColor": "#f2a93b",
+          "labelPosition": "topLeft",
+          "labelColor": "black",
+          "axisPositionHorizontal": "right",
+          "trackBorderWidth": 0,
+          "trackBorderColor": "black",
+          "labelTextOpacity": 0.4,
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000",
+          "showTooltip": false
+        },
+        "name": "GM12878-E116-H3K4me3.fc.signal"
+      }]
+    }
+  }, {
+    "layout": {
+      "w": 12,
+      "h": 6,
+      "x": 0,
+      "y": 36
+    },
+    "uid": "g",
+    "initialXDomain": [0, 2547598956],
+    "tracks": {
+      "top": [{
+        "uid": "genes",
+        "tilesetUid": "OHJakQICQD6gTD7skx4EWA",
+        "position": "top",
+        "server": "http://higlass.io/api/v1",
+        "type": "horizontal-gene-annotations",
+        "height": 64,
+        "options": {
+          "labelColor": "black",
+          "plusStrandColor": "black",
+          "name": "Gene Annotations (hg19)",
+          "labelPosition": "hidden",
+          "minusStrandColor": "black",
+          "fontSize": 12,
+          "trackBorderWidth": 0,
+          "trackBorderColor": "black",
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000",
+          "geneAnnotationHeight": 12,
+          "geneLabelPosition": "outside",
+          "geneStrandSpacing": 4
+        },
+        "name": "Gene Annotations (hg19)"
+      }, {
+        "uid": "chroms",
+        "height": 20,
+        "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
+        "position": "top",
+        "type": "horizontal-chromosome-labels",
+        "options": {
+          "color": "#777777",
+          "stroke": "#FFFFFF",
+          "fontSize": 12,
+          "fontIsLeftAligned": true,
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000"
+        },
+        "name": "Chromosome Labels (hg19)"
+      }, {
+        "uid": "line7",
+        "tilesetUid": "PjIJKXGbSNCalUZO21e_HQ",
+        "height": 64,
+        "position": "top",
+        "server": "http://higlass.io/api/v1",
+        "type": "horizontal-line",
+        "options": {
+          "name": "GM12878-E116-H3K27ac.fc.signal",
+          "valueScaling": "linear",
+          "lineStrokeWidth": 2,
+          "lineStrokeColor": "blue",
+          "labelPosition": "topLeft",
+          "labelColor": "black",
+          "axisPositionHorizontal": "right",
+          "trackBorderWidth": 0,
+          "trackBorderColor": "black",
+          "labelTextOpacity": 0.4,
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000",
+          "showTooltip": false
+        },
+        "name": "GM12878-E116-H3K27ac.fc.signal"
+      }]
+    }
+  }, {
+    "layout": {
+      "w": 12,
+      "h": 6,
+      "x": 0,
+      "y": 42
+    },
+    "uid": "h",
+    "initialXDomain": [0, 2547598956],
+    "tracks": {
+      "top": [{
+        "uid": "genes",
+        "tilesetUid": "OHJakQICQD6gTD7skx4EWA",
+        "position": "top",
+        "server": "http://higlass.io/api/v1",
+        "type": "horizontal-gene-annotations",
+        "height": 64,
+        "options": {
+          "labelColor": "black",
+          "plusStrandColor": "black",
+          "name": "Gene Annotations (hg19)",
+          "labelPosition": "hidden",
+          "minusStrandColor": "black",
+          "fontSize": 12,
+          "trackBorderWidth": 0,
+          "trackBorderColor": "black",
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000",
+          "geneAnnotationHeight": 12,
+          "geneLabelPosition": "outside",
+          "geneStrandSpacing": 4
+        },
+        "name": "Gene Annotations (hg19)"
+      }, {
+        "uid": "chroms",
+        "height": 20,
+        "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
+        "position": "top",
+        "type": "horizontal-chromosome-labels",
+        "options": {
+          "color": "#777777",
+          "stroke": "#FFFFFF",
+          "fontSize": 12,
+          "fontIsLeftAligned": true,
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000"
+        },
+        "name": "Chromosome Labels (hg19)"
+      }, {
+        "uid": "line8",
+        "tilesetUid": "PdAaSdibTLK34hCw7ubqKA",
+        "height": 64,
+        "position": "top",
+        "server": "http://higlass.io/api/v1",
+        "type": "horizontal-line",
+        "options": {
+          "name": "GM12878-E116-H3K27me3.fc.signal",
+          "valueScaling": "linear",
+          "lineStrokeWidth": 2,
+          "lineStrokeColor": "#7414cc",
+          "labelPosition": "topLeft",
+          "labelColor": "black",
+          "axisPositionHorizontal": "right",
+          "trackBorderWidth": 0,
+          "trackBorderColor": "black",
+          "labelTextOpacity": 0.4,
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000",
+          "showTooltip": false
+        },
+        "name": "GM12878-E116-H3K27me3.fc.signal"
+      }]
+    }
+  }, {
+    "layout": {
+      "w": 12,
+      "h": 6,
+      "x": 0,
+      "y": 48
+    },
+    "uid": "i",
+    "initialXDomain": [0, 2547598956],
+    "tracks": {
+      "top": [{
+        "uid": "genes",
+        "tilesetUid": "OHJakQICQD6gTD7skx4EWA",
+        "position": "top",
+        "server": "http://higlass.io/api/v1",
+        "type": "horizontal-gene-annotations",
+        "height": 64,
+        "options": {
+          "labelColor": "black",
+          "plusStrandColor": "black",
+          "name": "Gene Annotations (hg19)",
+          "labelPosition": "hidden",
+          "minusStrandColor": "black",
+          "fontSize": 12,
+          "trackBorderWidth": 0,
+          "trackBorderColor": "black",
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000",
+          "geneAnnotationHeight": 12,
+          "geneLabelPosition": "outside",
+          "geneStrandSpacing": 4
+        },
+        "name": "Gene Annotations (hg19)"
+      }, {
+        "uid": "chroms",
+        "height": 20,
+        "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
+        "position": "top",
+        "type": "horizontal-chromosome-labels",
+        "options": {
+          "color": "#777777",
+          "stroke": "#FFFFFF",
+          "fontSize": 12,
+          "fontIsLeftAligned": true,
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000"
+        },
+        "name": "Chromosome Labels (hg19)"
+      }, {
+        "uid": "line9",
+        "tilesetUid": "e0DYtZBSTqiMLHoaimsSpg",
+        "height": 48,
+        "position": "top",
+        "server": "http://higlass.io/api/v1",
+        "type": "horizontal-line",
+        "options": {
+          "name": "GM12878-E116-H3K4me1.fc.signal",
+          "valueScaling": "linear",
+          "lineStrokeWidth": 2,
+          "lineStrokeColor": "#a800a8",
+          "labelPosition": "topLeft",
+          "labelColor": "black",
+          "axisPositionHorizontal": "right",
+          "trackBorderWidth": 0,
+          "trackBorderColor": "black",
+          "labelTextOpacity": 0.4,
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000",
+          "showTooltip": false
+        },
+        "name": "GM12878-E116-H3K4me1.fc.signal"
+      }]
+    }
+  }, {
+    "layout": {
+      "w": 12,
+      "h": 6,
+      "x": 0,
+      "y": 54
+    },
+    "uid": "j",
+    "initialXDomain": [0, 2547598956],
+    "tracks": {
+      "top": [{
+        "uid": "genes",
+        "tilesetUid": "OHJakQICQD6gTD7skx4EWA",
+        "position": "top",
+        "server": "http://higlass.io/api/v1",
+        "type": "horizontal-gene-annotations",
+        "height": 64,
+        "options": {
+          "labelColor": "black",
+          "plusStrandColor": "black",
+          "name": "Gene Annotations (hg19)",
+          "labelPosition": "hidden",
+          "minusStrandColor": "black",
+          "fontSize": 12,
+          "trackBorderWidth": 0,
+          "trackBorderColor": "black",
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000",
+          "geneAnnotationHeight": 12,
+          "geneLabelPosition": "outside",
+          "geneStrandSpacing": 4
+        },
+        "name": "Gene Annotations (hg19)"
+      }, {
+        "uid": "chroms",
+        "height": 20,
+        "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
+        "position": "top",
+        "type": "horizontal-chromosome-labels",
+        "options": {
+          "color": "#777777",
+          "stroke": "#FFFFFF",
+          "fontSize": 12,
+          "fontIsLeftAligned": true,
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000"
+        },
+        "name": "Chromosome Labels (hg19)"
+      }, {
+        "uid": "line10",
+        "tilesetUid": "cE0nGyd0Q_yVYSyBUe89Ww",
+        "height": 64,
+        "position": "top",
+        "server": "http://higlass.io/api/v1",
+        "type": "horizontal-line",
+        "options": {
+          "name": "GM12878-E116-H3K4me3.fc.signal",
+          "valueScaling": "linear",
+          "lineStrokeWidth": 2,
+          "lineStrokeColor": "#c51671",
+          "labelPosition": "topLeft",
+          "labelColor": "black",
+          "axisPositionHorizontal": "right",
+          "trackBorderWidth": 0,
+          "trackBorderColor": "black",
+          "labelTextOpacity": 0.4,
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000",
+          "showTooltip": false
+        },
+        "name": "GM12878-E116-H3K4me3.fc.signal"
+      }]
+    }
+  }, {
+    "layout": {
+      "w": 12,
+      "h": 6,
+      "x": 0,
+      "y": 60
+    },
+    "uid": "k",
+    "initialXDomain": [0, 2547598956],
+    "tracks": {
+      "top": [{
+        "uid": "genes",
+        "tilesetUid": "OHJakQICQD6gTD7skx4EWA",
+        "position": "top",
+        "server": "http://higlass.io/api/v1",
+        "type": "horizontal-gene-annotations",
+        "height": 64,
+        "options": {
+          "labelColor": "black",
+          "plusStrandColor": "black",
+          "name": "Gene Annotations (hg19)",
+          "labelPosition": "hidden",
+          "minusStrandColor": "black",
+          "fontSize": 12,
+          "trackBorderWidth": 0,
+          "trackBorderColor": "black",
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000",
+          "geneAnnotationHeight": 12,
+          "geneLabelPosition": "outside",
+          "geneStrandSpacing": 4
+        },
+        "name": "Gene Annotations (hg19)"
+      }, {
+        "uid": "chroms",
+        "height": 20,
+        "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
+        "position": "top",
+        "type": "horizontal-chromosome-labels",
+        "options": {
+          "color": "#777777",
+          "stroke": "#FFFFFF",
+          "fontSize": 12,
+          "fontIsLeftAligned": true,
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000"
+        },
+        "name": "Chromosome Labels (hg19)"
+      }, {
+        "uid": "line11",
+        "tilesetUid": "cE0nGyd0Q_yVYSyBUe89Ww",
+        "height": 64,
+        "position": "top",
+        "server": "http://higlass.io/api/v1",
+        "type": "horizontal-line",
+        "options": {
+          "name": "GM12878-E116-H3K4me3.fc.signal",
+          "valueScaling": "linear",
+          "lineStrokeWidth": 2,
+          "lineStrokeColor": "#ff0000",
+          "labelPosition": "topLeft",
+          "labelColor": "black",
+          "axisPositionHorizontal": "right",
+          "trackBorderWidth": 0,
+          "trackBorderColor": "black",
+          "labelTextOpacity": 0.4,
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000",
+          "showTooltip": false
+        },
+        "name": "GM12878-E116-H3K4me3.fc.signal"
+      }]
+    }
+  }, {
+    "layout": {
+      "w": 12,
+      "h": 6,
+      "x": 0,
+      "y": 66
+    },
+    "uid": "l",
+    "initialXDomain": [0, 2547598956],
+    "tracks": {
+      "top": [{
+        "uid": "genes",
+        "tilesetUid": "OHJakQICQD6gTD7skx4EWA",
+        "position": "top",
+        "server": "http://higlass.io/api/v1",
+        "type": "horizontal-gene-annotations",
+        "height": 64,
+        "options": {
+          "labelColor": "black",
+          "plusStrandColor": "black",
+          "name": "Gene Annotations (hg19)",
+          "labelPosition": "hidden",
+          "minusStrandColor": "black",
+          "fontSize": 12,
+          "trackBorderWidth": 0,
+          "trackBorderColor": "black",
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000",
+          "geneAnnotationHeight": 12,
+          "geneLabelPosition": "outside",
+          "geneStrandSpacing": 4
+        },
+        "name": "Gene Annotations (hg19)"
+      }, {
+        "uid": "chroms",
+        "height": 20,
+        "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
+        "position": "top",
+        "type": "horizontal-chromosome-labels",
+        "options": {
+          "color": "#777777",
+          "stroke": "#FFFFFF",
+          "fontSize": 12,
+          "fontIsLeftAligned": true,
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000"
+        },
+        "name": "Chromosome Labels (hg19)"
+      }, {
+        "uid": "line12",
+        "tilesetUid": "cE0nGyd0Q_yVYSyBUe89Ww",
+        "height": 64,
+        "position": "top",
+        "server": "http://higlass.io/api/v1",
+        "type": "horizontal-line",
+        "options": {
+          "name": "GM12878-E116-H3K4me3.fc.signal",
+          "valueScaling": "linear",
+          "lineStrokeWidth": 2,
+          "lineStrokeColor": "#f2a93b",
+          "labelPosition": "topLeft",
+          "labelColor": "black",
+          "axisPositionHorizontal": "right",
+          "trackBorderWidth": 0,
+          "trackBorderColor": "black",
+          "labelTextOpacity": 0.4,
+          "showMousePosition": true,
+          "showGlobalMousePosition": true,
+          "mousePositionColor": "#000000",
+          "showTooltip": false
+        },
+        "name": "GM12878-E116-H3K4me3.fc.signal"
+      }]
+    }
+  }],
+  "editable": false,
+  "exportViewUrl": "/api/v1/viewconfs",
+  "trackSourceServers": ["http://higlass.io/api/v1"]
+}

--- a/test/view-configs.js
+++ b/test/view-configs.js
@@ -35,3 +35,4 @@ export { default as twoViewConfig } from './view-configs-more/twoViewConfig';
 export { default as valueIntervalTrackViewConf } from './view-configs-more/valueIntervalTrackViewConf';
 export { default as verticalHeatmapTrack } from './view-configs-tracks/verticalHeatmapTrack';
 export { default as stackedTopTracks } from './view-configs-more/stacked-top-tracks';
+export { default as stackedTopViews } from './view-configs-more/stacked-top-views';


### PR DESCRIPTION
## Description

> What was changed in this pull request?

One can now enable scrolling for multi-view figures:

![Oct-31-2019 19-05-50](https://user-images.githubusercontent.com/932103/67992022-95d63d80-fc11-11e9-97e3-27d26934dcdd.gif)

From a user's perspective, nothing has changed. 

> Why is it necessary?

Previously, only single view figures could be made scrollable.

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [x] Unit tests added or updated
- [ ] Documentation added or updated
- [x] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [x] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
