### PR TITLE
Ensure that the valueScale is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.7.3
+
+- In `HorizontalLine1DPixiTrack`, make sure that `this.valueScale` is set when `getMouseOverHtml()` is called.
+
+_[Detailed changes since v1.7.2](https://github.com/higlass/higlass/compare/v1.7.2...v1.7.3)_
+
 ## v1.7.2
 
 - Refactored the scroll options and `bounded` into a new property called `sizeMode`. There are now 4 different size modes, which determine the visible height of the HiGlass instance:

--- a/app/scripts/HorizontalLine1DPixiTrack.js
+++ b/app/scripts/HorizontalLine1DPixiTrack.js
@@ -25,7 +25,11 @@ class HorizontalLine1DPixiTrack extends HorizontalTiled1DPixiTrack {
     // if we're not supposed to show the tooltip, don't show it
     // we return here so that the mark isn't drawn in the code
     // below
-    if (!this.tilesetInfo || !this.options.showTooltip) return '';
+    if (
+      !this.tilesetInfo
+      || !this.options.showTooltip
+      || !this.valueScale
+    ) return '';
 
     const value = this.getDataAtPos(trackX);
     let textValue = '';


### PR DESCRIPTION
## Description

> What was changed in this pull request?

In `HorizontalLine1DPixiTrack`, make sure that `this.valueScale` is set when calling `getMouseOverHtml()`

> Why is it necessary?

When mousing over a track, which has the tooltip enabled, too quickly, `getMouseOverHtml()` was called before `this.valueScale` was set. 

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
