### PR TITLE
Start improving gene annotation track creation docs

### DIFF
--- a/docs/data_preparation.rst
+++ b/docs/data_preparation.rst
@@ -310,14 +310,15 @@ http://hgdownload.cse.ucsc.edu/goldenpath/hg19/bigZips/hg19.chrom.sizes)
 
     See https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=gene&id=7157
 
+
 Set the assembly name and species ID
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: bash
+.. code-block:: bash 
 
     ASSEMBLY=mm9
     TAXID=10090
-
+    
     #ASSEMBLY=hg19
     #TAXID=9606
 
@@ -326,121 +327,86 @@ Set the assembly name and species ID
 
     #ASSEMBLY=dm6
     #TAXID=7227
+   
 
 Download data from UCSC and NCBI
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: bash
+.. code-block:: bash 
 
+    # Download NCBI genbank data
+    # gene2refseq : 
+    DATADIR=/tmp/bla/
+    mkdir DATADIR/genbank
+    wget -N -P $DATADIR ftp://ftp.ncbi.nlm.nih.gov/gene/DATA/gene2refseq.gz
+    wget -N -P $DATADIR ftp://ftp.ncbi.nlm.nih.gov/gene/DATA/gene_info.gz
+    wget -N -P $DATADIR ftp://ftp.ncbi.nlm.nih.gov/gene/DATA/gene2pubmed.gz
 
-    mkdir -p ~/data/genbank-data/${ASSEMBLY}
+    # Download UCSC refGene database for assembly of interest
+    mkdir $DATADIR/$ASSEMBLY
+    wget -N -P $DATADIR/$ASSEMBLY/ http://hgdownload.cse.ucsc.edu/goldenPath/$ASSEMBLY/database/refGene.txt.gz
 
-    wget -N -P ~/data/genbank-data/${ASSEMBLY}/ \
-        http://hgdownload.cse.ucsc.edu/goldenPath/${ASSEMBLY}/database/refGene.txt.gz
+    # Filter genbank data for species of interest
+    zcat $DATADIR/gene2refseq.gz | grep ^${TAXID} > $DATADIR/$ASSEMBLY/gene2refseq
+    zcat $DATADIR/gene_info.gz | grep ^${TAXID} | sort -k 2 > $DATADIR/$ASSEMBLY/gene_info
+    zcat $DATADIR/gene2pubmed.gz | grep ^${TAXID} > $DATADIR/$ASSEMBLY/gene2pubmed
 
-    wget -N -P ~/data/genbank-data/ \
-        ftp://ftp.ncbi.nlm.nih.gov/gene/DATA/gene2refseq.gz
-
-    wget -N -P ~/data/genbank-data/ \
-        ftp://ftp.ncbi.nlm.nih.gov/gene/DATA/gene_info.gz
-
-    wget -N -P ~/data/genbank-data/ \
-        ftp://ftp.ncbi.nlm.nih.gov/gene/DATA/gene2pubmed.gz
-
-
-Preprocess data
-^^^^^^^^^^^^^^^
-
-
-.. code-block:: bash
-
-    # remove entries to chr6_...
-
-    gzcat ~/data/genbank-data/${ASSEMBLY}/refGene.txt.gz \
-        | awk -F $'\t' '{if (!($3 ~ /_/)) print;}' \
-        | sort -k2 > ~/data/genbank-data/${ASSEMBLY}/sorted_refGene
-    wc -l ~/data/genbank-data/${ASSEMBLY}/sorted_refGene
-
-    zgrep ^${TAXID} ~/data/genbank-data/gene2refseq.gz \
-         > ~/data/genbank-data/${ASSEMBLY}/gene2refseq
-    head ~/data/genbank-data/${ASSEMBLY}/gene2refseq
-
-    zgrep ^${TAXID} ~/data/genbank-data/gene_info.gz \
+    # Sort
+    # Optional: filter out unplaced and unlocalized scaffolds (which have a "_" in the chrom name)
+    zcat $DATADIR/$ASSEMBLY/refGene.txt.gz \
+        | awk -F $'\t' '{if (!($3 ~ /_/)) print;}' $DATADIR/$ASSEMBLY/refGene_sorted \
         | sort -k 2 \
-         > ~/data/genbank-data/${ASSEMBLY}/gene_info
-    head ~/data/genbank-data/${ASSEMBLY}/gene_info
+        > $DATADIR/$ASSEMBLY/refGene_sorted
 
-    zgrep ^${TAXID} ~/data/genbank-data/gene2pubmed.gz \
-        > ~/data/genbank-data/${ASSEMBLY}/gene2pubmed
-    head ~/data/genbank-data/${ASSEMBLY}/gene2pubmed
 
-    # awk '{print $2}' ~/data/genbank-data/hg19/gene_info \
-    # | xargs python scripts/gene_info_by_id.py \
-    # | tee ~/data/genbank-data/hg19/gene_summaries.tsv
-
-    # output -> geneid \t citation_count
-
-Processing
-^^^^^^^^^^
+Get full model and citation count for each gene
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: bash
 
-    cat ~/data/genbank-data/${ASSEMBLY}/gene2pubmed \
+    # Count pubmed citations
+    # Output: {gene_id} \t {citation_count}
+    cat $DATADIR/$ASSEMBLY/gene2pubmed \
         | awk '{print $2}' \
         | sort \
         | uniq -c \
         | awk '{print $2 "\t" $1}' \
         | sort \
-        > ~/data/genbank-data/${ASSEMBLY}/gene2pubmed-count
-    head ~/data/genbank-data/${ASSEMBLY}/gene2pubmed-count
+        > $DATADIR/$ASSEMBLY/gene2pubmed-count
 
-
-    # output -> geneid \t refseq_id
-
-    cat ~/data/genbank-data/${ASSEMBLY}/gene2refseq \
+    # Gene2refseq dictionary
+    # Output: {gene_id} \t {refseq_id}
+    cat $DATADIR/$ASSEMBLY/gene2refseq \
         | awk -F $'\t' '{ split($4,a,"."); if (a[1] != "-") print $2 "\t" a[1];}' \
         | sort \
         | uniq  \
-        > ~/data/genbank-data/${ASSEMBLY}/geneid_refseqid
-    head ~/data/genbank-data/${ASSEMBLY}/geneid_refseqid
-    wc -l ~/data/genbank-data/${ASSEMBLY}/geneid_refseqid
+        > $DATADIR/$ASSEMBLY/geneid_refseqid
 
-
-    #output -> geneid \t refseq_id \t citation_count
-
-    join ~/data/genbank-data/${ASSEMBLY}/geneid_refseqid \
-        ~/data/genbank-data/${ASSEMBLY}/gene2pubmed-count  \
+    # Append refseq IDs to citation count table
+    # Output: {gene_id} \t {refseq_id} \t {citation_count}
+    join $DATADIR/$ASSEMBLY/geneid_refseqid \
+        $DATADIR/$ASSEMBLY/gene2pubmed-count  \
         | sort -k2 \
-        > ~/data/genbank-data/${ASSEMBLY}/geneid_refseqid_count
+        > $DATADIR/$ASSEMBLY/geneid_refseqid_count
 
-    head ~/data/genbank-data/${ASSEMBLY}/geneid_refseqid_count
-    wc -l ~/data/genbank-data/${ASSEMBLY}/geneid_refseqid_count
-
-
-    # output -> geneid \t refseq_id \t chr (5) \t strand(6) \t txStart(7) \t txEnd(8) \t cdsStart(9) \t cdsEnd (10) \t exonCount(11) \t exonStarts(12) \t exonEnds(13)
-
+    # Join the refseq gene model against gene IDs
+    # Output: {gene_id} \t {refseq_id} \t {chrom}(5) \t {strand}(6) \t {txStart}(7) \t {txEnd}(8) \t {cdsStart}(9) \t {cdsEnd}(10) \t {exonCount}(11) \t {exonStarts}(12) \t {exonEnds}(13)
     join -1 2 -2 2 \
-        ~/data/genbank-data/${ASSEMBLY}/geneid_refseqid_count \
-        ~/data/genbank-data/${ASSEMBLY}/sorted_refGene \
+        $DATADIR/$ASSEMBLY/geneid_refseqid_count \
+        $DATADIR/$ASSEMBLY/refGene_sorted \
         | awk '{ print $2 "\t" $1 "\t" $5 "\t" $6 "\t" $7 "\t" $8 "\t" $9 "\t" $10 "\t" $11 "\t" $12 "\t" $13 "\t" $3; }' \
         | sort -k1   \
-        > ~/data/genbank-data/${ASSEMBLY}/geneid_refGene_count
+        > $DATADIR/$ASSEMBLY/geneid_refGene_count
 
-    head ~/data/genbank-data/${ASSEMBLY}/geneid_refGene_count
-    wc -l ~/data/genbank-data/${ASSEMBLY}/geneid_refGene_count
-
+    # Join citation counts against gene information
     # output -> geneid \t symbol \t gene_type \t name \t citation_count
-
     join -1 2 -2 1 -t $'\t' \
-        ~/data/genbank-data/${ASSEMBLY}/gene_info \
-        ~/data/genbank-data/${ASSEMBLY}/gene2pubmed-count \
+        $DATADIR/$ASSEMBLY/gene_info \
+        $DATADIR/$ASSEMBLY/gene2pubmed-count \
         | awk -F $'\t' '{print $1 "\t" $3 "\t" $10 "\t" $12 "\t" $16}' \
         | sort -k1 \
-        > ~/data/genbank-data/${ASSEMBLY}/gene_subinfo_citation_count
-    head ~/data/genbank-data/${ASSEMBLY}/gene_subinfo_citation_count
-    wc -l ~/data/genbank-data/${ASSEMBLY}/gene_subinfo_citation_count
-
-
+        > $DATADIR/$ASSEMBLY/gene_subinfo_citation_count
+        
     # 1: chr (chr1)
     # 2: txStart (52301201) [9]
     # 3: txEnd (52317145) [10]
@@ -455,27 +421,20 @@ Processing
     # 12: cdsEnd (52314677)
     # 14: exonStarts (52301201,52306253,52306882,52307342,52307757,52308222,52309008,52309819,52312768,52314542,)
     # 15: exonEnds (52301479,52306319,52307134,52307554,52307857,52308369,52309284,52310017,52312899,52317145,)
-
     join -t $'\t' \
-        ~/data/genbank-data/${ASSEMBLY}/gene_subinfo_citation_count \
-        ~/data/genbank-data/${ASSEMBLY}/geneid_refGene_count \
+        $DATADIR/$ASSEMBLY/gene_subinfo_citation_count \
+        $DATADIR/$ASSEMBLY/geneid_refGene_count \
         | awk -F $'\t' '{print $7 "\t" $9 "\t" $10 "\t" $2 "\t" $16 "\t" $8 "\t" $6 "\t" $1 "\t" $3 "\t" $4 "\t" $11 "\t" $12 "\t" $14 "\t" $15}' \
-        > ~/data/genbank-data/${ASSEMBLY}/geneAnnotations.bed
-    head ~/data/genbank-data/${ASSEMBLY}/geneAnnotations.bed
-    wc -l ~/data/genbank-data/${ASSEMBLY}/geneAnnotations.bed
+        > $DATADIR/$ASSEMBLY/geneAnnotations.bed
 
-    python scripts/exonU.py \
-        ~/data/genbank-data/${ASSEMBLY}/geneAnnotations.bed \
-        > ~/data/genbank-data/${ASSEMBLY}/geneAnnotationsExonUnions.bed
-    wc -l ~/data/genbank-data/${ASSEMBLY}/geneAnnotationsExonUnions.bed
+    # Download: https://raw.githubusercontent.com/higlass/clodius/develop/scripts/exonU.py
+    python exonU.py $DATADIR/$ASSEMBLY/geneAnnotations.bed > $DATADIR/$ASSEMBLY/geneAnnotationsExonUnions.bed
 
-Creating a HiGlass Track
-^^^^^^^^^^^^^^^^^^^^^^^^
+
+Create a gene annotation track file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: bash
-
-    workon hg-server
-    ASSEMBLY=mm9
 
     clodius aggregate bedfile \
         --max-per-tile 20 --importance-column 5 \
@@ -484,8 +443,6 @@ Creating a HiGlass Track
         --delimiter $'\t' \
         ~/data/genbank-data/${ASSEMBLY}/geneAnnotationsExonUnions.bed 
 
-    aws s3 cp ~/data/tiled-data/gene-annotations-${ASSEMBLY}.db \
-        s3://pkerp/public/hg-server/data/${ASSEMBLY}/
 
 Importing into HiGlass
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/data_preparation.rst
+++ b/docs/data_preparation.rst
@@ -438,7 +438,7 @@ Create a gene annotation track file
     clodius aggregate bedfile \
         --max-per-tile 20 \
         --importance-column 5 \
-        --assembly $ASSEMBLY \
+        --chromsizes-filename assembly.chromSizes \
         --output-file $DATADIR/$ASSEMBLY/gene-annotations-${ASSEMBLY}.db \
         --delimiter $'\t' \
         $DATADIR/$ASSEMBLY/geneAnnotationsExonUnions.bed 

--- a/docs/data_preparation.rst
+++ b/docs/data_preparation.rst
@@ -444,35 +444,6 @@ Create a gene annotation track file
         $DATADIR/$ASSEMBLY/geneAnnotationsExonUnions.bed 
 
 
-Importing into HiGlass
-^^^^^^^^^^^^^^^^^^^^^^
-
-.. code-block:: bash
-
-    curl -u `cat ~/.higlass-server-login`    \
-        -F "datafile=@/Users/peter/data/tiled-data/gene-annotations-${ASSEMBLY}.db"    \
-        -F "name=Gene Annotations (${ASSEMBLY})"   \ 
-        -F 'filetype=beddb'  \
-        -F 'datatype=gene-annotation'  \
-        -F 'coordSystem=${ASSEMBLY}' \
-        -F 'coordSystem2=${ASSEMBLY}'  \
-        http://higlass.io:80/api/v1/tilesets/
-
-
-Chromosomes
-^^^^^^^^^^^
-
-.. code-block:: bash
-
-    curl -u `cat ~/.higlass-server-login`    \
-        -F "datafile=@/Users/peter/tmp/chromSizes_hg38.tsv"    \
-        -F "name=Chromosomes (hg38)"   \ 
-        -F 'filetype=chromsizes-tsv'  \
-        -F 'datatype=chromsizes'  \
-        -F "coordSystem=${ASSEMBLY}" \
-        -F "coordSystem2=${ASSEMBLY}"  \
-        http://higlass.io:80/api/v1/tilesets/
-
 Hitile files
 ------------
 

--- a/docs/data_preparation.rst
+++ b/docs/data_preparation.rst
@@ -335,8 +335,7 @@ Download data from UCSC and NCBI
 .. code-block:: bash 
 
     # Download NCBI genbank data
-    # gene2refseq : 
-    DATADIR=/tmp/bla/
+    DATADIR=~/data
     mkdir DATADIR/genbank
     wget -N -P $DATADIR ftp://ftp.ncbi.nlm.nih.gov/gene/DATA/gene2refseq.gz
     wget -N -P $DATADIR ftp://ftp.ncbi.nlm.nih.gov/gene/DATA/gene_info.gz
@@ -437,11 +436,12 @@ Create a gene annotation track file
 .. code-block:: bash
 
     clodius aggregate bedfile \
-        --max-per-tile 20 --importance-column 5 \
-        --assembly ${ASSEMBLY} \
-        --output-file ~/data/tiled-data/gene-annotations-${ASSEMBLY}.db \
+        --max-per-tile 20 \
+        --importance-column 5 \
+        --assembly $ASSEMBLY \
+        --output-file $DATADIR/$ASSEMBLY/gene-annotations-${ASSEMBLY}.db \
         --delimiter $'\t' \
-        ~/data/genbank-data/${ASSEMBLY}/geneAnnotationsExonUnions.bed 
+        $DATADIR/$ASSEMBLY/geneAnnotationsExonUnions.bed 
 
 
 Importing into HiGlass
@@ -457,6 +457,7 @@ Importing into HiGlass
         -F 'coordSystem=${ASSEMBLY}' \
         -F 'coordSystem2=${ASSEMBLY}'  \
         http://higlass.io:80/api/v1/tilesets/
+
 
 Chromosomes
 ^^^^^^^^^^^


### PR DESCRIPTION
Steps still need better descriptions.

Fixes:

* `gzcat` and `zgrep` are esoteric (installing GNU utils on Mac). `zcat` should be available on most linux/mac environments.

* what were those virtualenv-wrapper and s3 commands doing there?

* provided download link for `exonU.py`

