### PR TITLE
alexander-veit/default plot types when adding tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Update heatmap docs with colorRange parameter
 - Update BedLikeTrack to display strand-specific entries
+- Updated default plot types when adding tracks
+- When adding multiple tracks at once that have different datatype, each track is added with its default plot type. The plot type chooser is hidden.
 
 ## v1.7.3
 

--- a/app/scripts/AddTrackDialog.js
+++ b/app/scripts/AddTrackDialog.js
@@ -24,14 +24,13 @@ class AddTrackDialog extends React.Component {
 
     this.state = {
       selectedTilesets: [{ datatype: 'none' }],
+      allTracksSameDatatype: true, // Do all selected tracks have the same datatype
     };
 
     this.handleSubmitBound = this.handleSubmit.bind(this);
 
     this.handleTilesetPickerDoubleClickBound = this.handleTilesetPickerDoubleClick.bind(this);
     this.selectedTilesetsChangedBound = this.selectedTilesetsChanged.bind(this);
-
-    this.allTracksSameDatatype = true; // Do all selected tracks have the same datatype
   }
 
   /**
@@ -115,13 +114,13 @@ class AddTrackDialog extends React.Component {
       selectedTilesets = selectedTilesetsIn;
     }
 
-    this.allTracksSameDatatype = true;
+    let allTracksSameDatatype = true;
     const firstDatatype = selectedTilesets[0].datatype;
     for (const tileset of selectedTilesets) {
-      if (tileset.datatype !== firstDatatype) { this.allTracksSameDatatype = false; }
+      if (tileset.datatype !== firstDatatype) { allTracksSameDatatype = false; }
     }
 
-    if (this.allTracksSameDatatype) {
+    if (allTracksSameDatatype) {
       // only one datatype is present in the set of selected tilesets
       for (const tileset of selectedTilesets) {
         tileset.type = this.selectedPlotType;
@@ -148,7 +147,7 @@ class AddTrackDialog extends React.Component {
       }
     }
 
-    this.setState({ selectedTilesets });
+    this.setState({ selectedTilesets, allTracksSameDatatype });
   }
 
   render() {
@@ -182,7 +181,7 @@ class AddTrackDialog extends React.Component {
             <PlotTypeChooser
               // Only for testing purposes
               ref={(c) => { this.plotTypeChooser = c; }}
-              allTracksSameDatatype={this.allTracksSameDatatype}
+              allTracksSameDatatype={this.state.allTracksSameDatatype}
               datatypes={this.state.selectedTilesets.map((x) => {
                 if (x.filetype === 'cooler') {
                   // cooler files can also supply chromsizes

--- a/app/scripts/AddTrackDialog.js
+++ b/app/scripts/AddTrackDialog.js
@@ -8,6 +8,11 @@ import PlotTypeChooser from './PlotTypeChooser';
 // Configs
 import { AVAILABLE_TRACK_TYPES } from './configs';
 
+// Utils
+import {
+  getDefaultTrackForDatatype,
+} from './utils';
+
 // Styles
 import '../styles/AddTrackDialog.module.scss';
 
@@ -126,13 +131,20 @@ class AddTrackDialog extends React.Component {
       // to each tileset
       for (const tileset of selectedTilesets) {
         let datatypes = [tileset.datatype];
+        const orientation = this.getOrientation(this.props.position);
 
         if (tileset.filetype === 'cooler') {
           datatypes = [tileset.datatype, 'chromsizes'];
         }
 
-        tileset.type = AVAILABLE_TRACK_TYPES([datatypes],
-          this.getOrientation(this.props.position))[0].type;
+        const availableTrackTypes = AVAILABLE_TRACK_TYPES([datatypes], orientation);
+        const defaultTrackType = getDefaultTrackForDatatype(
+          datatypes[0],
+          this.props.position,
+          availableTrackTypes
+        );
+
+        tileset.type = defaultTrackType.type;
       }
     }
 
@@ -180,6 +192,7 @@ class AddTrackDialog extends React.Component {
               })}
               onPlotTypeSelected={this.handlePlotTypeSelected.bind(this)}
               orientation={orientation}
+              position={this.props.position}
             />
           )
         }

--- a/app/scripts/AddTrackDialog.js
+++ b/app/scripts/AddTrackDialog.js
@@ -20,8 +20,6 @@ class AddTrackDialog extends React.Component {
   constructor(props) {
     super(props);
 
-    this.multiSelect = null;
-
     this.options = {};
 
     this.state = {
@@ -32,6 +30,8 @@ class AddTrackDialog extends React.Component {
 
     this.handleTilesetPickerDoubleClickBound = this.handleTilesetPickerDoubleClick.bind(this);
     this.selectedTilesetsChangedBound = this.selectedTilesetsChanged.bind(this);
+
+    this.allTracksSameDatatype = true; // Do all selected tracks have the same datatype
   }
 
   /**
@@ -106,7 +106,6 @@ class AddTrackDialog extends React.Component {
   }
 
   selectedTilesetsChanged(selectedTilesetsIn) {
-    let allSame = true;
     let selectedTilesets = null;
 
     if (selectedTilesetsIn.length === 0) {
@@ -116,12 +115,13 @@ class AddTrackDialog extends React.Component {
       selectedTilesets = selectedTilesetsIn;
     }
 
+    this.allTracksSameDatatype = true;
     const firstDatatype = selectedTilesets[0].datatype;
     for (const tileset of selectedTilesets) {
-      if (tileset.datatype !== firstDatatype) { allSame = false; }
+      if (tileset.datatype !== firstDatatype) { this.allTracksSameDatatype = false; }
     }
 
-    if (allSame) {
+    if (this.allTracksSameDatatype) {
       // only one datatype is present in the set of selected tilesets
       for (const tileset of selectedTilesets) {
         tileset.type = this.selectedPlotType;
@@ -182,6 +182,7 @@ class AddTrackDialog extends React.Component {
             <PlotTypeChooser
               // Only for testing purposes
               ref={(c) => { this.plotTypeChooser = c; }}
+              allTracksSameDatatype={this.allTracksSameDatatype}
               datatypes={this.state.selectedTilesets.map((x) => {
                 if (x.filetype === 'cooler') {
                   // cooler files can also supply chromsizes

--- a/app/scripts/AddTrackDialog.js
+++ b/app/scripts/AddTrackDialog.js
@@ -178,7 +178,7 @@ class AddTrackDialog extends React.Component {
       >
         { form }
         {
-          !this.props.hidePlotTypeChooser && (
+          (
             <PlotTypeChooser
               // Only for testing purposes
               ref={(c) => { this.plotTypeChooser = c; }}
@@ -203,13 +203,11 @@ class AddTrackDialog extends React.Component {
 }
 
 AddTrackDialog.defaultProps = {
-  hidePlotTypeChooser: false,
   position: 'top',
 };
 
 AddTrackDialog.propTypes = {
   datatype: PropTypes.string.isRequired,
-  hidePlotTypeChooser: PropTypes.bool,
   host: PropTypes.string.isRequired,
   onCancel: PropTypes.func.isRequired,
   onTracksChosen: PropTypes.func.isRequired,

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -715,7 +715,7 @@ class HiGlassComponent extends React.Component {
   /**
    * Add default track options. These can come from two places:
    *
-   * 1. The track definitions (options/tracks-info.js)
+   * 1. The track definitions (configs/tracks-info.js)
    * 2. The default options passed into the component
    *
    * Of these, #2 takes precendence over #1.

--- a/app/scripts/PlotTypeChooser.js
+++ b/app/scripts/PlotTypeChooser.js
@@ -124,6 +124,16 @@ class PlotTypeChooser extends React.Component {
             </div>
           )
         }
+        { (!this.props.allTracksSameDatatype)
+          && (
+            <div
+              className="plot-type-container-empty"
+            >
+              Datasets with multiple datatypes chosen.
+              They will be added with their default track types.
+            </div>
+          )
+        }
       </div>
     );
   }

--- a/app/scripts/PlotTypeChooser.js
+++ b/app/scripts/PlotTypeChooser.js
@@ -7,6 +7,11 @@ import {
   AVAILABLE_TRACK_TYPES,
 } from './configs';
 
+// Utils
+import {
+  getDefaultTrackForDatatype,
+} from './utils';
+
 // Styles
 import '../styles/PlotTypeChooser.css';
 
@@ -32,12 +37,18 @@ class PlotTypeChooser extends React.Component {
 
     if (this.AVAILABLE_TRACK_TYPES.length > 0) {
       if (!this.AVAILABLE_TRACK_TYPES.includes(this.state.selectedPlotType)) {
-        this.handlePlotTypeSelected(this.AVAILABLE_TRACK_TYPES[0]);
+        const defaultTrackType = getDefaultTrackForDatatype(
+          newProps.datatypes[0][0],
+          this.props.position,
+          this.AVAILABLE_TRACK_TYPES
+        );
+        this.handlePlotTypeSelected(defaultTrackType);
       }
     } else {
       // no available track types
       // this could be because the datatype is unknown
       // or because there's multiple different datatypes
+      // that don't have common track types
     }
   }
 
@@ -62,7 +73,9 @@ class PlotTypeChooser extends React.Component {
         .sort((a, b) => a.type < b.type)
         .map((x) => {
           const thumbnail = trackTypeToInfo[x.type].thumbnail;
-          const plotTypeClass = this.state.selectedPlotType.type === x.type ? 'plot-type-selected' : 'unselected';
+          const plotTypeClass = this.state.selectedPlotType.type === x.type
+            ? 'plot-type-item plot-type-selected'
+            : 'plot-type-item';
           const imgTag = trackTypeToInfo[x.type].thumbnail
             ? (
               <div
@@ -71,7 +84,7 @@ class PlotTypeChooser extends React.Component {
               />
             )
             : (
-              <div style={{ display: 'inline-block', marginRight: 10, verticalAlign: 'middle' }}>
+              <div className="track-thumbnail">
                 <svg height={20} width={30} />
               </div>
             );

--- a/app/scripts/PlotTypeChooser.js
+++ b/app/scripts/PlotTypeChooser.js
@@ -35,6 +35,8 @@ class PlotTypeChooser extends React.Component {
 
     if (!this.AVAILABLE_TRACK_TYPES) { return; }
 
+    if (!newProps.allTracksSameDatatype) { return; }
+
     if (this.AVAILABLE_TRACK_TYPES.length > 0) {
       if (!this.AVAILABLE_TRACK_TYPES.includes(this.state.selectedPlotType)) {
         const defaultTrackType = getDefaultTrackForDatatype(
@@ -113,7 +115,7 @@ class PlotTypeChooser extends React.Component {
 
     return (
       <div>
-        { AVAILABLE_TRACK_TYPES_LIST.length > 0
+        { (AVAILABLE_TRACK_TYPES_LIST.length > 0 && this.props.allTracksSameDatatype)
           && (
             <div
               className="plot-type-container"

--- a/app/scripts/TiledPlot.js
+++ b/app/scripts/TiledPlot.js
@@ -300,7 +300,6 @@ class TiledPlot extends React.Component {
       this.props.modal.open(
         <AddTrackDialog
           datatype={TRACKS_INFO_BY_TYPE[series.type].datatype[0]}
-          hidePlotTypeChooser={true}
           host={this.state.addTrackHost}
           onCancel={() => {
             this.setState({ addDivisorDialog: null });

--- a/app/scripts/configs/default-tracks-for-datatype.js
+++ b/app/scripts/configs/default-tracks-for-datatype.js
@@ -22,7 +22,7 @@ export const DEFAULT_TRACKS_FOR_DATATYPE = {
   'geo-json': {
     center: 'geo-json',
   },
-  'gene-annotations': {
+  'gene-annotation': {
     top: 'horizontal-gene-annotations',
     bottom: 'horizontal-gene-annotations',
     left: 'vertical-gene-annotations',

--- a/app/scripts/utils/get-default-track-for-datatype.js
+++ b/app/scripts/utils/get-default-track-for-datatype.js
@@ -18,16 +18,18 @@ const getDefaultTrackForDatatype = (datatype, position, availableTracks) => {
 
   if (availableTracks.length === 1) { return availableTracks[0]; }
 
-  let usedTrackType = availableTracks[0];
+  let usedTrack = availableTracks[0];
   const defaultTrackType = DEFAULT_TRACKS_FOR_DATATYPE[datatype] !== undefined
     ? DEFAULT_TRACKS_FOR_DATATYPE[datatype][position]
     : undefined;
 
   if (defaultTrackType !== undefined) {
-    usedTrackType = availableTracks.find(tt => tt.type === defaultTrackType) || usedTrackType;
+    // If we found a default track type for this datatype,
+    // get the definition of this track from the list of available tracks.
+    usedTrack = availableTracks.find(tt => tt.type === defaultTrackType) || usedTrack;
   }
 
-  return usedTrackType;
+  return usedTrack;
 };
 
 export default getDefaultTrackForDatatype;

--- a/app/scripts/utils/get-default-track-for-datatype.js
+++ b/app/scripts/utils/get-default-track-for-datatype.js
@@ -1,0 +1,33 @@
+
+// Configs
+import {
+  DEFAULT_TRACKS_FOR_DATATYPE,
+} from '../configs';
+
+/**
+ * Gets the default track as defined in utils/default-tracks-for-datatype.js
+ *
+ * @param  {string} datatype The datatype to get the default track for
+ * @param  {string} position   top, bottom, left, right, center
+ * @param  {array} availableTracks   list of tracks to choose from,
+ * typically obtained from AVAILABLE_TRACK_TYPES(...)
+ * @return {object}  an element of availableTracks or undefined
+ */
+const getDefaultTrackForDatatype = (datatype, position, availableTracks) => {
+  if (availableTracks.length === 0) { return undefined; }
+
+  if (availableTracks.length === 1) { return availableTracks[0]; }
+
+  let usedTrackType = availableTracks[0];
+  const defaultTrackType = DEFAULT_TRACKS_FOR_DATATYPE[datatype] !== undefined
+    ? DEFAULT_TRACKS_FOR_DATATYPE[datatype][position]
+    : undefined;
+
+  if (defaultTrackType !== undefined) {
+    usedTrackType = availableTracks.find(tt => tt.type === defaultTrackType) || usedTrackType;
+  }
+
+  return usedTrackType;
+};
+
+export default getDefaultTrackForDatatype;

--- a/app/scripts/utils/index.js
+++ b/app/scripts/utils/index.js
@@ -20,6 +20,7 @@ export { default as flatten } from './flatten';
 export { default as forEach } from './for-each';
 export { default as forwardEvent } from './forward-event';
 export { default as genomeLociToPixels } from './genome-loci-to-pixels';
+export { default as getDefaultTrackForDatatype } from './get-default-track-for-datatype';
 export { default as getElementDim } from './get-element-dim';
 export { default as getTrackByUid } from './get-track-by-uid';
 export { default as getTrackObjById } from './get-track-obj-by-id';

--- a/app/styles/PlotTypeChooser.css
+++ b/app/styles/PlotTypeChooser.css
@@ -11,6 +11,14 @@
     max-height: 15vh;
 }
 
+.plot-type-container-empty {
+  margin: 5px;
+  padding: 3px 8px;
+  border: 1px solid #aaaaaa;
+  background-color: #e8e8e8;
+  border-radius: 5px;
+}
+
 .plot-type-item {
   cursor: pointer;
 }

--- a/app/styles/PlotTypeChooser.css
+++ b/app/styles/PlotTypeChooser.css
@@ -11,6 +11,13 @@
     max-height: 15vh;
 }
 
+.plot-type-item {
+  cursor: pointer;
+}
+  .plot-type-item:not(.plot-type-selected):hover {
+    background-color: rgba(51, 51, 204, 0.1);
+  }
+
 .track-thumbnail {
   width: 30px;
   height: 20px;

--- a/docs/track_types.rst
+++ b/docs/track_types.rst
@@ -85,7 +85,7 @@ Gene Annotations
     :align: right
 
 track-type: ``horizontal-gene-annotations``
-datatype: ``gene-annotations``
+datatype: ``gene-annotation``
 
 Gene annotations display the locations of genes and their exons and introns.
 The tracks displayed on HiGlass show a transcript consisting of the union of

--- a/test/AddTrackTests.js
+++ b/test/AddTrackTests.js
@@ -123,6 +123,32 @@ describe('Add track(s)', () => {
     // console.warn('ptc.AVAILABLE_TRACK_TYPES', ptc.AVAILABLE_TRACK_TYPES);
     // should just have the horizontal-heatmap track type
     expect(ptc.AVAILABLE_TRACK_TYPES.length).to.eql(3);
+
+    tilesetFinder.handleSelectedOptions([
+      // hg19 gene track
+      'http://higlass.io/api/v1/OHJakQICQD6gTD7skx4EWA'
+    ]);
+
+    hgc.update();
+
+    ptc = hgc.instance().modalRef.plotTypeChooser;
+
+    // check that the selected plot type defaults to 'horizontal-gene-annotations'
+    expect(ptc.state.selectedPlotType.type).to.eql('horizontal-gene-annotations');
+
+    tilesetFinder.handleSelectedOptions([
+      // hg19 gene track
+      'http://higlass.io/api/v1/OHJakQICQD6gTD7skx4EWA',
+      // GM12878-E116-H3K27me3.fc.signal track
+      'http://higlass.io/api/v1/PdAaSdibTLK34hCw7ubqKA'
+    ]);
+
+    hgc.update();
+
+    ptc = hgc.instance().modalRef.plotTypeChooser;
+
+    // Make sure the plotTypeChooser is not shown since there are different datatypes
+    expect(hgc.find('.plot-type-container').length).to.eql(0);
   });
 
   it('should add the selected tracks', () => {

--- a/test/AddTrackTests.js
+++ b/test/AddTrackTests.js
@@ -148,7 +148,7 @@ describe('Add track(s)', () => {
     ptc = hgc.instance().modalRef.plotTypeChooser;
 
     // Make sure the plotTypeChooser is not shown since there are different datatypes
-    expect(hgc.find('.plot-type-container').length).to.eql(0);
+    expect(hgc.find('.plot-type-item').length).to.eql(0);
   });
 
   it('should add the selected tracks', () => {


### PR DESCRIPTION
## Description

> What was changed in this pull request?

- Changed the default plot types for the PlotTypeChooser when adding new tracks. The defaults are defined in configs/default-tracks-for-datatype.js
- When adding multiple tracks with different datatype, each track is added with its respective default plot type. The plot type chooser is hidden.
- Slight UI change of the PlotTypeChooser

![PlotTypeChooser](https://user-images.githubusercontent.com/53857412/71687046-dade3380-2d6a-11ea-8e33-0884be8c219e.gif)


> Why is it necessary?

- The configuration in configs/default-tracks-for-datatype.js was not considered.

Fixes #65 

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [x] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [x] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
