### PR TITLE
Flelschas/small options fix

### DIFF
--- a/app/scripts/HeatmapTiledPixiTrack.js
+++ b/app/scripts/HeatmapTiledPixiTrack.js
@@ -659,7 +659,7 @@ class HeatmapTiledPixiTrack extends TiledPixiTrack {
     this.pColorbarArea.clear();
     this.pColorbarArea.beginFill(
       colorToHex(this.options.colorbarBackgroundColor || 'white'),
-      +this.options.colorbarBackgroundOpacity || 0.6
+      +this.options.colorbarBackgroundOpacity >= 0 ? +this.options.colorbarBackgroundOpacity : 0.6
     );
     this.pColorbarArea.drawRect(0, 0, COLORBAR_AREA_WIDTH, colorbarAreaHeight);
 

--- a/app/scripts/PixiTrack.js
+++ b/app/scripts/PixiTrack.js
@@ -329,7 +329,9 @@ class PixiTrack extends Track {
 
     graphics.beginFill(
       colorToHex(this.options.labelBackgroundColor || 'white'),
-      +this.options.labelBackgroundOpacity || 0.5
+      +this.options.labelBackgroundOpacity >= 0
+        ? +this.options.labelBackgroundOpacity
+        : 0.5
     );
 
     const fontColor = colorToHex(this.getLabelColor());


### PR DESCRIPTION
## Description

> What was changed in this pull request?

The following options can now be set to zero:
- colorbarBackgroundOpacity
- labelBackgroundOpacity

> Why is it necessary?

The current behavior is weird. If you had set `labelBackgroundOpacity` to zero the background opacity was `0.5` because `0` was treated as a falsy value.

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
