### PR TITLE
Add troubleshooting section to docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -183,3 +183,4 @@ crucial are listed below.
     higlass_docker
     view_config
     developer
+    troubleshooting

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -6,6 +6,7 @@ Troubleshooting
 
 Empty Page
 ==========
+
 HiGlass showing as an empty page in Firefox on Linux
 ----------------------------------------------------
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -1,0 +1,13 @@
+.. _troubleshooting:
+
+===========
+Troubleshooting
+===========
+
+HiGlass showing as an empty page in Firefox on Linux
+====================
+
+Due to a bug in Mesa video drivers that has since been fixed, Firefox introduced a workaround which prevents HiGlass to load.
+To disable this workaround, set ``gfx.work-around-driver-bugs=false`` in ``about:config``, and restart the browser.
+
+Source: https://bugzilla.mozilla.org/show_bug.cgi?id=1601682

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -4,8 +4,10 @@
 Troubleshooting
 ===========
 
+Empty Page
+==========
 HiGlass showing as an empty page in Firefox on Linux
-====================
+----------------------------------------------------
 
 Due to a bug in Mesa video drivers that has since been fixed, Firefox introduced a workaround which prevents HiGlass to load.
 To disable this workaround, set ``gfx.work-around-driver-bugs=false`` in ``about:config``, and restart the browser.


### PR DESCRIPTION
Created `troubleshooting.rst` in docs.

Added there how to fix empty page on FF on Linux.

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [x] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
