### PR TITLE
SVG export for Rule tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Updated default plot types when adding tracks
 - When adding multiple tracks at once that have different datatype, each track is added with its default plot type. The plot type chooser is hidden.
 - In `HorizontalLine1DPixiTrack`, make sure that `this.valueScale` is set when `getMouseOverHtml()` is called.
+- VerticalRule, HorizontalRule, and CrossRule tracks included in SVG and PNG exports.
 
 _[Detailed changes since v1.7.2](https://github.com/higlass/higlass/compare/v1.7.2...v1.7.3)_
 

--- a/app/scripts/CrossRule.js
+++ b/app/scripts/CrossRule.js
@@ -12,6 +12,11 @@ class CrossRule extends mix(PixiTrack).with(RuleMixin, VerticalRuleMixin) {
 
     this.xPosition = x;
     this.yPosition = y;
+
+    this.strokeWidth = 2;
+    this.strokeOpacity = 1;
+    this.dashLength = 5;
+    this.dashGap = 3;
   }
 
   draw() {
@@ -35,34 +40,83 @@ class CrossRule extends mix(PixiTrack).with(RuleMixin, VerticalRuleMixin) {
   }
 
   drawHorizontalRule(graphics) {
-    const strokeWidth = 2;
-
     let stroke = colorToHex('black');
 
     if (this.highlighted) {
       stroke = colorToHex('red');
     }
 
-    graphics.lineStyle(strokeWidth, stroke, 1);
+    graphics.lineStyle(this.strokeWidth, stroke, this.strokeOpacity);
 
     let pos = 0;
-
-    const dashLength = 5;
-    const dashGap = 3;
 
     // console.log('this._yScale.range()', this._yScale.range());
 
     while (pos < this.dimensions[0]) {
       graphics.moveTo(pos, this._yScale(this.yPosition));
-      graphics.lineTo(pos + dashLength, this._yScale(this.yPosition));
+      graphics.lineTo(pos + this.dashLength, this._yScale(this.yPosition));
 
-      pos += dashLength + dashGap;
+      pos += this.dashLength + this.dashGap;
     }
   }
 
   isMouseOverHorizontalLine(mousePos) {
     return Math.abs(mousePos.y - this.position[1] - this._yScale(this.yPosition))
       < this.MOUSEOVER_RADIUS;
+  }
+
+  /**
+   * Export an SVG representation of this track
+   *
+   * @returns {Array} The two returned DOM nodes are both SVG
+   * elements [base,track]. Base is a parent which contains track as a
+   * child. Track is clipped with a clipping rectangle contained in base.
+   *
+   */
+  exportSVG() {
+    let track = null;
+    let base = null;
+
+    if (super.exportSVG) {
+      [base, track] = super.exportSVG();
+    } else {
+      base = document.createElement('g');
+      track = base;
+    }
+    const output = document.createElement('g');
+    output.setAttribute('class', 'cross-rule');
+    output.setAttribute('transform',
+      `translate(${this.position[0]},${this.position[1]})`);
+
+    track.appendChild(output);
+
+    let stroke = 'black';
+    if (this.highlighted) {
+      stroke = 'red';
+    }
+
+    const verticalLine = document.createElement('line');
+    verticalLine.setAttribute('stroke', stroke);
+    verticalLine.setAttribute('stroke-width', this.strokeWidth);
+    verticalLine.setAttribute('stroke-dasharray', `${this.dashLength} ${this.dashGap}`);
+    verticalLine.setAttribute('x1', this._xScale(this.xPosition));
+    verticalLine.setAttribute('y1', 0);
+    verticalLine.setAttribute('x2', this._xScale(this.xPosition));
+    verticalLine.setAttribute('y2', this.dimensions[1]);
+
+    const horizontalLine = document.createElement('line');
+    horizontalLine.setAttribute('stroke', stroke);
+    horizontalLine.setAttribute('stroke-width', this.strokeWidth);
+    horizontalLine.setAttribute('stroke-dasharray', `${this.dashLength} ${this.dashGap}`);
+    horizontalLine.setAttribute('x1', 0);
+    horizontalLine.setAttribute('y1', this._yScale(this.yPosition));
+    horizontalLine.setAttribute('x2', this.dimensions[0]);
+    horizontalLine.setAttribute('y2', this._yScale(this.yPosition));
+
+    output.appendChild(verticalLine);
+    output.appendChild(horizontalLine);
+
+    return [base, track];
   }
 }
 

--- a/app/scripts/HorizontalRule.js
+++ b/app/scripts/HorizontalRule.js
@@ -7,27 +7,21 @@ import { colorToHex } from './utils';
 
 export const HorizontalRuleMixin = Mixin(superclass => class extends superclass {
   drawHorizontalRule(graphics) {
-    const strokeWidth = 2;
-    const strokeOpacity = 1;
-
     let stroke = colorToHex('black');
 
     if (this.highlighted) {
       stroke = colorToHex('red');
     }
 
-    graphics.lineStyle(strokeWidth, stroke, strokeOpacity);
+    graphics.lineStyle(this.strokeWidth, stroke, this.strokeOpacity);
 
     let pos = 0;
 
-    const dashLength = 5;
-    const dashGap = 3;
-
     while (pos < this.dimensions[0]) {
       graphics.moveTo(pos, this._yScale(this.yPosition));
-      graphics.lineTo(pos + dashLength, this._yScale(this.yPosition));
+      graphics.lineTo(pos + this.dashLength, this._yScale(this.yPosition));
 
-      pos += dashLength + dashGap;
+      pos += this.dashLength + this.dashGap;
     }
   }
 
@@ -46,6 +40,11 @@ class HorizontalRule extends mix(PixiTrack).with(RuleMixin, HorizontalRuleMixin)
     super(context, options);
 
     this.yPosition = context.yPosition;
+
+    this.strokeWidth = 2;
+    this.strokeOpacity = 1;
+    this.dashLength = 5;
+    this.dashGap = 3;
   }
 
 
@@ -67,6 +66,50 @@ class HorizontalRule extends mix(PixiTrack).with(RuleMixin, HorizontalRuleMixin)
 
     this.drawHorizontalRule(graphics);
     this.animate();
+  }
+
+  /**
+   * Export an SVG representation of this track
+   *
+   * @returns {Array} The two returned DOM nodes are both SVG
+   * elements [base,track]. Base is a parent which contains track as a
+   * child. Track is clipped with a clipping rectangle contained in base.
+   *
+   */
+  exportSVG() {
+    let track = null;
+    let base = null;
+
+    if (super.exportSVG) {
+      [base, track] = super.exportSVG();
+    } else {
+      base = document.createElement('g');
+      track = base;
+    }
+    const output = document.createElement('g');
+    output.setAttribute('class', 'horizontal-rule');
+    output.setAttribute('transform',
+      `translate(${this.position[0]},${this.position[1]})`);
+
+    track.appendChild(output);
+
+    let stroke = 'black';
+    if (this.highlighted) {
+      stroke = 'red';
+    }
+
+    const line = document.createElement('line');
+    line.setAttribute('stroke', stroke);
+    line.setAttribute('stroke-width', this.strokeWidth);
+    line.setAttribute('stroke-dasharray', `${this.dashLength} ${this.dashGap}`);
+    line.setAttribute('x1', 0);
+    line.setAttribute('y1', this._yScale(this.yPosition));
+    line.setAttribute('x2', this.dimensions[0]);
+    line.setAttribute('y2', this._yScale(this.yPosition));
+
+    output.appendChild(line);
+
+    return [base, track];
   }
 }
 

--- a/app/scripts/VerticalRule.js
+++ b/app/scripts/VerticalRule.js
@@ -53,6 +53,41 @@ export default class VerticalRule extends mix(PixiTrack).with(RuleMixin, Vertica
     this.animate();
   }
 
+  exportSVG() {
+    let track = null;
+    let base = null;
+
+    if (super.exportSVG) {
+      [base, track] = super.exportSVG();
+    } else {
+      base = document.createElement('g');
+      track = base;
+    }
+    const output = document.createElement('g');
+    output.setAttribute('transform',
+      `translate(${this.position[0]},${this.position[1]})`);
+
+    track.appendChild(output);
+
+    let stroke = 'black';
+    if (this.highlighted) {
+      stroke = 'red';
+    }
+
+    const line = document.createElement('line');
+    line.setAttribute('stroke', stroke);
+    line.setAttribute('stroke-width', '2');
+    line.setAttribute('stroke-dasharray', '5 3');
+    line.setAttribute('x1', this._xScale(this.xPosition));
+    line.setAttribute('y1', 0);
+    line.setAttribute('x2', this._xScale(this.xPosition));
+    line.setAttribute('y2', this.dimensions[1]);
+
+    output.appendChild(line);
+
+    return [base, track];
+  }
+
   mouseMoveHandler(mousePos) {
     this.highlighted = (
       this.isWithin(mousePos.x, mousePos.y)

--- a/app/scripts/VerticalRule.js
+++ b/app/scripts/VerticalRule.js
@@ -13,21 +13,18 @@ export const VerticalRuleMixin = Mixin(superclass => class extends superclass {
       stroke = colorToHex('red');
     }
 
-    graphics.lineStyle(2, stroke, 1);
+    graphics.lineStyle(this.strokeWidth, stroke, this.strokeOpacity);
 
     let pos = 0;
-
-    const dashLength = 5;
-    const dashGap = 3;
 
     // console.log('this.position', this.position);
     // console.log('this._xScale.range()', this._xScale.range());
 
     while (pos < this.dimensions[1]) {
       graphics.moveTo(this._xScale(this.xPosition), pos);
-      graphics.lineTo(this._xScale(this.xPosition), pos + dashLength);
+      graphics.lineTo(this._xScale(this.xPosition), pos + this.dashLength);
 
-      pos += dashLength + dashGap;
+      pos += this.dashLength + this.dashGap;
     }
   }
 
@@ -43,6 +40,11 @@ export default class VerticalRule extends mix(PixiTrack).with(RuleMixin, Vertica
     super(context, options);
 
     this.xPosition = context.xPosition;
+
+    this.strokeWidth = 2;
+    this.strokeOpacity = 1;
+    this.dashLength = 5;
+    this.dashGap = 3;
   }
 
   draw() {
@@ -53,6 +55,14 @@ export default class VerticalRule extends mix(PixiTrack).with(RuleMixin, Vertica
     this.animate();
   }
 
+  /**
+   * Export an SVG representation of this track
+   *
+   * @returns {Array} The two returned DOM nodes are both SVG
+   * elements [base,track]. Base is a parent which contains track as a
+   * child. Track is clipped with a clipping rectangle contained in base.
+   *
+   */
   exportSVG() {
     let track = null;
     let base = null;
@@ -64,6 +74,7 @@ export default class VerticalRule extends mix(PixiTrack).with(RuleMixin, Vertica
       track = base;
     }
     const output = document.createElement('g');
+    output.setAttribute('class', 'vertical-rule');
     output.setAttribute('transform',
       `translate(${this.position[0]},${this.position[1]})`);
 
@@ -76,8 +87,8 @@ export default class VerticalRule extends mix(PixiTrack).with(RuleMixin, Vertica
 
     const line = document.createElement('line');
     line.setAttribute('stroke', stroke);
-    line.setAttribute('stroke-width', '2');
-    line.setAttribute('stroke-dasharray', '5 3');
+    line.setAttribute('stroke-width', this.strokeWidth);
+    line.setAttribute('stroke-dasharray', `${this.dashLength} ${this.dashGap}`);
     line.setAttribute('x1', this._xScale(this.xPosition));
     line.setAttribute('y1', 0);
     line.setAttribute('x2', this._xScale(this.xPosition));

--- a/test/SvgExportTest.js
+++ b/test/SvgExportTest.js
@@ -98,4 +98,110 @@ describe('SVG Export', () => {
       removeHGComponent(div);
     });
   });
+
+  describe('horizontal, vertical, and cross rules', () => {
+    let hgc = null;
+    let div = null;
+
+    const addedRulesConf = {
+      views: [
+        {
+          tracks: {
+            center: [
+              {
+                type: 'combined',
+                contents: [
+                  {
+                    server: '//higlass.io/api/v1',
+                    tilesetUid: 'CQMd6V_cRw6iCI_-Unl3PQ',
+                    type: 'heatmap',
+                    options: {
+                      colorRange: [
+                        'white',
+                        'black'
+                      ]
+                    }
+                  },
+                ]
+              }
+            ],
+            whole: [
+              {
+                type: 'vertical-rule',
+                x: 2544051862.4804587,
+                options: {},
+                uid: 'LoWaxFMuRAmSLFJzhiYmKQ',
+                width: 20,
+                height: 20
+              },
+              {
+                type: 'horizontal-rule',
+                y: 2537291938.292442,
+                options: {},
+                uid: 'V0qsdww3SO2pIHUhIWZaSQ',
+                width: 20,
+                height: 20
+              },
+              {
+                type: 'cross-rule',
+                x: 2543805011.140535,
+                y: 2536118340.322387,
+                options: {},
+                uid: 'dw5LQpd9Srm2uxBsfpCv0g',
+                width: 20,
+                height: 20
+              }
+            ],
+          }
+        }
+      ]
+    };
+
+    beforeAll((done) => {
+      const viewConf = JSON.parse(JSON.stringify(addedRulesConf));
+      const options = viewConf.views[0].tracks.center[0].contents[0].options;
+      options.scaleStartPercent = 0;
+      options.scaleEndPercent = 1;
+      options.heatmapValueScaling = 'log';
+      ([div, hgc] = mountHGComponent(div, hgc, viewConf,
+        done));
+    });
+
+    it('includes line for added vertical rule', () => {
+      const svg = hgc.instance().createSVG();
+      const group = svg.getElementsByClassName('vertical-rule')[0];
+      const line = group.getElementsByTagName('line');
+      expect(line.length).to.equal(1);
+      expect(Number(line[0].getAttribute('y1'))).to.equal(0);
+      expect(Number(line[0].getAttribute('y2'))).to.be.greaterThan(0);
+      expect(Number(line[0].getAttribute('x1'))).to.equal(649.2246915865658);
+    });
+
+    it('includes line for added horizontal rule', () => {
+      const svg = hgc.instance().createSVG();
+      const group = svg.getElementsByClassName('horizontal-rule')[0];
+      const line = group.getElementsByTagName('line');
+      expect(line.length).to.equal(1);
+      expect(Number(line[0].getAttribute('x1'))).to.equal(0);
+      expect(Number(line[0].getAttribute('x2'))).to.be.greaterThan(0);
+      expect(Number(line[0].getAttribute('y1'))).to.equal(307.4996050186234);
+    });
+
+    it('includes lines for added cross rule', () => {
+      const svg = hgc.instance().createSVG();
+      const group = svg.getElementsByClassName('cross-rule')[0];
+      const line = group.getElementsByTagName('line');
+      expect(line.length).to.equal(2);
+      expect(Number(line[0].getAttribute('y1'))).to.equal(0);
+      expect(Number(line[0].getAttribute('y2'))).to.be.greaterThan(0);
+      expect(Number(line[0].getAttribute('x1'))).to.equal(649.1616968074917);
+      expect(Number(line[1].getAttribute('x1'))).to.equal(0);
+      expect(Number(line[1].getAttribute('x2'))).to.be.greaterThan(0);
+      expect(Number(line[1].getAttribute('y1'))).to.equal(307.2001108175058);
+    });
+
+    afterAll(() => {
+      removeHGComponent(div);
+    });
+  });
 });


### PR DESCRIPTION
## Description

> What was changed in this pull request?

`exportSVG` functions were added for VerticalRule, HorizontalRule, and CrossRule track components.



> Why is it necessary?

Horizontal, vertical, and cross rule lines are currently not included when exporting to SVG. Users may expect that these tracks will appear in exported files.

Fixes part of #516

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [x] Unit tests added or updated
- [x] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
