### PR TITLE
Check for dark theme preference

### DIFF
--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -671,17 +671,24 @@ class HiGlassComponent extends React.Component {
       );
       this.theme = isDarkTheme ? 'dark' : 'light';
     } else {
+      const prefersDark =
+        window.matchMedia &&
+        window.matchMedia('(prefers-color-scheme: dark)').matches;
       switch (newTheme) {
         case 'dark':
           this.theme = THEME_DARK;
           break;
         case 'light':
-        case undefined:
           this.theme = THEME_LIGHT;
           break;
+        case undefined:
+          this.theme = prefersDark ? THEME_DARK : THEME_LIGHT;
+          break;
         default:
-          console.warn(`Unknown theme "${newTheme}". Using light theme.`);
-          this.theme = THEME_LIGHT;
+          this.theme = prefersDark ? THEME_DARK : THEME_LIGHT;
+          console.warn(
+            `Unknown theme "${newTheme}". Using ${this.theme.toString()} theme.`
+          );
           break;
       }
     }


### PR DESCRIPTION
## Description

> What was changed in this pull request?

This pull request updates the `setTheme()` function to check for `prefers-color-theme: dark` if no theme (or invalid theme) has been passed.

> Why is it necessary?

More of an enhancement. Setting this as a draft PR since it should probably wait until theming is no longer in the beta stage.

Fixes #804 

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
