### PR TITLE
Fixed adding position to track defs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## Next release
+
+- Fixed horizontal track not rendering properly in vertical position bug
+
 ## v1.8.1
 
 - Prettified JS code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Release notes
 
-## Next
+## v1.8.1
 
 - Prettified JS code
-- Added `labelShowAssembly` as an option to allow hiding the assembly in track options `hg19 | ` text
+- Added `labelShowAssembly` as an option to allow hiding the assembly in track label (e.g. `hg19 | ` text)
 - Added `tickFormat` and `tickPosition` options to the chromosome labels track
 - Enabled the colorbar slider by adding the options `colorbarPosition` and `colorbarBackgroundColor` for the `horizontal-multivec`
 - Added release notes to docs.

--- a/app/scripts/TiledPlot.js
+++ b/app/scripts/TiledPlot.js
@@ -796,11 +796,11 @@ class TiledPlot extends React.Component {
       if (tracks[location]) {
         tracks[location].forEach(track => {
           if (track.contents) {
-            for (let i = 0; i < track.contents.length; i++) {
-              track.contents[i].position = location;
-            }
+            track.contents.forEach(content => {
+              content.position = location;
+            });
           }
-          // track.position in is used in TrackRenderer to determine
+          // track.position is used in TrackRenderer to determine
           // whether to use LeftTrackModifier
           track.position = location;
           tracksAndLocations.push({ track, location });

--- a/app/scripts/TiledPlot.js
+++ b/app/scripts/TiledPlot.js
@@ -795,6 +795,14 @@ class TiledPlot extends React.Component {
     TRACK_LOCATIONS.forEach(location => {
       if (tracks[location]) {
         tracks[location].forEach(track => {
+          if (track.contents) {
+            for (let i = 0; i < track.contents.length; i++) {
+              track.contents[i].position = location;
+            }
+          }
+          // track.position in is used in TrackRenderer to determine
+          // whether to use LeftTrackModifier
+          track.position = location;
           tracksAndLocations.push({ track, location });
         });
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "higlass",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "higlass",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "HiGlass Hi-C / genomic / large data viewer",
   "author": "Peter Kerpedjiev <pkerpedjiev@gmail.com>",
   "main": "dist/hglib.js",

--- a/test/ChromosomeLabelsTests.js
+++ b/test/ChromosomeLabelsTests.js
@@ -12,12 +12,13 @@ import { expect } from 'chai';
 import {
   mountHGComponent,
   removeHGComponent,
-  getTrackObjectFromHGC
+  getTrackObjectFromHGC,
+  getTrackRenderer
 } from '../app/scripts/utils';
 
 configure({ adapter: new Adapter() });
 
-describe('Horizontal heatmaps', () => {
+describe('Horizontal chromosome labels', () => {
   let hgc = null;
   let div = null;
 
@@ -32,6 +33,11 @@ describe('Horizontal heatmaps', () => {
     // add your tests here
 
     const trackObj = getTrackObjectFromHGC(hgc.instance(), 'v1', 't1');
+    const trackRenderer = getTrackRenderer(hgc.instance(), 'v1');
+
+    expect(trackRenderer.trackDefObjects.t1.trackDef.track).to.have.property(
+      'position'
+    );
 
     expect(trackObj.tickTexts).not.to.have.property('chr17');
     expect(trackObj.tickTexts.all.length).to.eql(2);
@@ -43,7 +49,6 @@ describe('Horizontal heatmaps', () => {
     hgc.update();
 
     const trackObj = getTrackObjectFromHGC(hgc.instance(), 'v1', 't1');
-
     expect(trackObj.tickTexts).to.have.property('chr17');
   });
 


### PR DESCRIPTION
## Description

> What was changed in this pull request?

This PR fixes functionality in TiledPlot which adds a `position` field to track definitions before they are passed on to TrackRenderer.

> Why is it necessary?

If a horizontal track is placed in a vertical position, we can automatically render it as a vertical track by wrapping it in LeftTrackModifier. In order to do this `TrackRenderer` needs to know the position of the track. This PR adds that information.

Fixes #___

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [x] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
