### PR TITLE
Fixed the track displacement issue when saving view configs

### DIFF
--- a/app/scripts/TilesetFinder.js
+++ b/app/scripts/TilesetFinder.js
@@ -355,7 +355,7 @@ class TilesetFinder extends React.Component {
                   <use xlinkHref="#check_square_o" />
                 </svg>
               ),
-              halfcheck: (
+              halfCheck: (
                 <svg style={halfSvgStyle}>
                   <use xlinkHref="#check_square_o" />
                 </svg>

--- a/app/scripts/TrackRenderer.js
+++ b/app/scripts/TrackRenderer.js
@@ -381,6 +381,18 @@ class TrackRenderer extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
+    // If the initial domain changed, a new view config
+    // probably has loaded. Reset the zoom in this case.
+    if (
+      this.props.initialXDomain[0] !== prevProps.initialXDomain[0] ||
+      this.props.initialXDomain[1] !== prevProps.initialXDomain[1] ||
+      this.props.initialYDomain[0] !== prevProps.initialYDomain[0] ||
+      this.props.initialYDomain[1] !== prevProps.initialYDomain[1]
+    ) {
+      this.removeZoom();
+      this.addZoom();
+    }
+
     if (prevProps.isRangeSelection !== this.props.isRangeSelection) {
       if (this.props.isRangeSelection) {
         this.removeZoom();
@@ -573,6 +585,10 @@ class TrackRenderer extends React.Component {
     this.xDomainLimits = xDomainLimits;
     this.yDomainLimits = yDomainLimits;
     this.zoomLimits = zoomLimits;
+
+    // Reset the zoomTransform, if the initial domain changed
+    this.zoomTransform = zoomIdentity;
+    this.prevZoomTransform = zoomIdentity;
 
     this.cumCenterYOffset = 0;
     this.cumCenterXOffset = 0;

--- a/app/scripts/TrackRenderer.js
+++ b/app/scripts/TrackRenderer.js
@@ -383,6 +383,7 @@ class TrackRenderer extends React.Component {
   componentDidUpdate(prevProps) {
     // If the initial domain changed, a new view config
     // probably has loaded. Reset the element's zoomTransform in this case.
+    // In D3, an element’s transform is stored internally as element.__zoom
     if (
       this.props.initialXDomain[0] !== prevProps.initialXDomain[0] ||
       this.props.initialXDomain[1] !== prevProps.initialXDomain[1] ||
@@ -585,7 +586,8 @@ class TrackRenderer extends React.Component {
     this.yDomainLimits = yDomainLimits;
     this.zoomLimits = zoomLimits;
 
-    // Reset the zoomTransform, if the initial domain changed
+    // Reset the local record of the zoom transform to avoid
+    // pan & zoom jumps when saving the viewconfig
     this.zoomTransform = zoomIdentity;
     this.prevZoomTransform = zoomIdentity;
 

--- a/app/scripts/TrackRenderer.js
+++ b/app/scripts/TrackRenderer.js
@@ -382,15 +382,14 @@ class TrackRenderer extends React.Component {
 
   componentDidUpdate(prevProps) {
     // If the initial domain changed, a new view config
-    // probably has loaded. Reset the zoom in this case.
+    // probably has loaded. Reset the element's zoomTransform in this case.
     if (
       this.props.initialXDomain[0] !== prevProps.initialXDomain[0] ||
       this.props.initialXDomain[1] !== prevProps.initialXDomain[1] ||
       this.props.initialYDomain[0] !== prevProps.initialYDomain[0] ||
       this.props.initialYDomain[1] !== prevProps.initialYDomain[1]
     ) {
-      this.removeZoom();
-      this.addZoom();
+      this.element.__zoom = zoomIdentity;
     }
 
     if (prevProps.isRangeSelection !== this.props.isRangeSelection) {


### PR DESCRIPTION
## Description

> What was changed in this pull request?

This PR resets the zoomTransform in the TrackRenderer when a new viewConfig is loaded, e.g., via the view config editor.

> Why is it necessary?

When the zoomTransform is not reset, saving a modified or unmodified view config via the editor can lead to an unexpected displacement of the existing tracks (since the zoomTransform is applied again).

Fixes #855 

![viewconf-editor-fixed](https://user-images.githubusercontent.com/53857412/74274066-773b1480-4cdf-11ea-841f-6a8feaafe121.gif)


## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [x] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [x] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
