### PR TITLE
Remove content-type header from genbank requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## Next release
+
+- Remove Content-Type headers when fetching genbank files
+
 ## v1.8.4
 
 - Corrupted lock bug fix

--- a/app/scripts/data-fetchers/genbank-fetcher.js
+++ b/app/scripts/data-fetchers/genbank-fetcher.js
@@ -128,9 +128,7 @@ class GBKDataFetcher {
       redirect: 'follow',
       method: 'GET'
     })
-      .then(response => {
-        return gzipped ? response.arrayBuffer() : response.text();
-      })
+      .then(response => (gzipped ? response.arrayBuffer() : response.text()))
       .then(buffer => {
         const gffText = gzipped
           ? pako.inflate(buffer, { to: 'string' })

--- a/app/scripts/data-fetchers/genbank-fetcher.js
+++ b/app/scripts/data-fetchers/genbank-fetcher.js
@@ -124,12 +124,13 @@ class GBKDataFetcher {
     this.errorTxt = '';
 
     this.dataPromise = fetch(dataConfig.url, {
-      headers: {
-        'Content-Encoding': gzipped ? 'gzip' : 'text/plain'
-      },
-      mode: 'cors'
+      mode: 'cors',
+      redirect: 'follow',
+      method: 'GET'
     })
-      .then(response => (gzipped ? response.arrayBuffer() : response.text()))
+      .then(response => {
+        return gzipped ? response.arrayBuffer() : response.text();
+      })
       .then(buffer => {
         const gffText = gzipped
           ? pako.inflate(buffer, { to: 'string' })

--- a/package-lock.json
+++ b/package-lock.json
@@ -3930,7 +3930,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -4297,7 +4297,7 @@
       }
     },
     "css-element-queries": {
-      "version": "github:marcj/css-element-queries#8f127c7c96cb8c21253cbe07cf2f1a826ac0b575",
+      "version": "github:marcj/css-element-queries#31cabb56fb2af08470159251f6e535e2c3577758",
       "from": "github:marcj/css-element-queries"
     },
     "css-loader": {
@@ -5874,7 +5874,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -12274,7 +12274,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mississippi": {
@@ -17148,7 +17148,7 @@
     },
     "readable-stream": {
       "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
       "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -21082,7 +21082,7 @@
     },
     "yargs": {
       "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "requires": {
         "camelcase": "^1.0.2",


### PR DESCRIPTION
## Description

> What was changed in this pull request?

For some reason, having these headers leads to errors on CORS requests with redirects. Removing them fixes it. Also added `redirect: follow` header which is helpful because lots of services redirect their URLs to S3 buckets.

> Why is it necessary?

Fix genbank fetching.

Fixes #___

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
