### PR TITLE
Update hgc.api.getLocation return value object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next release
 
 - Remove Content-Type headers when fetching genbank files
+- Added the fields `xRange` and `yRange` the object returned by the JavaScript API `.getLocation()` method. 
 
 ## v1.8.4
 

--- a/app/scripts/api.js
+++ b/app/scripts/api.js
@@ -580,11 +580,11 @@ const createApi = function api(context, pubSub) {
        * Get the current location for a view.
        *
        * @param {string} [viewId=null] The id of the view to get the location for
-       * @returns {obj} A an object containing two Arrays representing the domains of
-       *  the x andy scales of the view.
+       * @returns {obj} A an object containing four arrays representing the domains and ranges of
+       *  the x and y scales of the view.
        * @example
        *
-       * const {xScale, yScale} = hgv.getLocation('viewId');
+       * const {xDomain, yDomain, xRange, yRange} = hgv.getLocation('viewId');
        */
       getLocation(viewId) {
         const wurstId = viewId
@@ -598,7 +598,9 @@ const createApi = function api(context, pubSub) {
 
         return {
           xDomain: self.xScales[wurstId].domain(),
-          yDomain: self.yScales[wurstId].domain()
+          yDomain: self.yScales[wurstId].domain(),
+          xRange: self.xScales[wurstId].range(),
+          yRange: self.yScales[wurstId].range()
         };
       },
 

--- a/test/APITests.js
+++ b/test/APITests.js
@@ -782,6 +782,33 @@ describe('API Tests', () => {
       });
     });
 
+    it('has location getter', done => {
+      [div, api] = createElementAndApi(simpleHeatmapViewConf, {
+        editable: false
+      });
+
+      const hgc = api.getComponent();
+
+      waitForTilesLoaded(hgc, () => {
+        const newXDomain = [1000000000, 2000000000];
+        api.zoomTo('a', ...newXDomain, null, null, 100);
+
+        waitForTransitionsFinished(hgc, () => {
+          const location = api.getLocation();
+          expect(Math.round(location.xDomain[0])).toEqual(1000000000);
+          expect(Math.round(location.xDomain[1])).toEqual(2000000000);
+          expect(Math.round(location.yDomain[0])).toEqual(1406779661);
+          expect(Math.round(location.yDomain[1])).toEqual(1593220339);
+          expect(Math.round(location.xRange[0])).toEqual(0);
+          expect(Math.round(location.xRange[1])).toEqual(590);
+          expect(Math.round(location.yRange[0])).toEqual(0);
+          expect(Math.round(location.yRange[1])).toEqual(110);
+
+          done();
+        });
+      });
+    });
+
     afterEach(() => {
       api.destroy();
       removeDiv(div);


### PR DESCRIPTION
## Description

> What was changed in this pull request?

This pull request adds the values `xRange` and `yRange` to the return value of the JS API `.getLocation()` function.

> Why is it necessary?

This will enable us to obtain the dimensions of a particular view via the API, which will be used to position things relative to the view in the `cistrome-higlass-wrapper` app.

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [x] Unit tests added or updated
- [x] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
