### PR TITLE
API .on('createSVG') callback option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Next release
 
 - Remove Content-Type headers when fetching genbank files
-- Added the fields `xRange` and `yRange` the object returned by the JavaScript API `.getLocation()` method. 
+- Added the fields `xRange` and `yRange` the object returned by the JavaScript API `.getLocation()` method.
+- Added the `.on('createSVG')` listener to the JS API, with the corresponding `.off('createSVG')`, for manipulating exported SVGs before they are returned.
 
 ## v1.8.4
 

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -1290,16 +1290,23 @@ class HiGlassComponent extends React.Component {
         }
       }
     }
-    return svg;
-  }
-
-  createSVGString() {
-    const svg = this.createSVG();
 
     // FF is fussier than Chrome, and requires dimensions on the SVG,
     // if it is to be used as an image src.
     svg.setAttribute('width', this.canvasElement.style.width);
     svg.setAttribute('height', this.canvasElement.style.height);
+
+    if (this.postCreateSVGCallback) {
+      // Allow the callback function to modify the exported SVG string
+      // before it is finalized and returned.
+      const modifiedSvg = this.postCreateSVGCallback(svg);
+      return modifiedSvg;
+    }
+    return svg;
+  }
+
+  createSVGString() {
+    const svg = this.createSVG();
 
     let svgString = vkbeautify.xml(
       new window.XMLSerializer().serializeToString(svg)
@@ -1331,6 +1338,14 @@ class HiGlassComponent extends React.Component {
       'export.svg',
       new Blob([this.createSVGString()], { type: 'image/svg+xml' })
     );
+  }
+
+  offPostCreateSVG() {
+    this.postCreateSVGCallback = null;
+  }
+
+  onPostCreateSVG(callback) {
+    this.postCreateSVGCallback = callback;
   }
 
   createPNGBlobPromise() {

--- a/app/scripts/api.js
+++ b/app/scripts/api.js
@@ -689,6 +689,10 @@ const createApi = function api(context, pubSub) {
             self.offViewChange(listenerId);
             break;
 
+          case 'createSVG':
+            self.offPostCreateSVG();
+            break;
+
           default:
             // nothing
             break;
@@ -861,6 +865,9 @@ const createApi = function api(context, pubSub) {
 
           case 'viewConfig':
             return self.onViewChange(callback);
+
+          case 'createSVG':
+            return self.onPostCreateSVG(callback);
 
           default:
             return undefined;

--- a/app/scripts/api.js
+++ b/app/scripts/api.js
@@ -659,6 +659,7 @@ const createApi = function api(context, pubSub) {
        * hgv.off('rangeSelection', rangeListener);
        * hgv.off('viewConfig', viewConfigListener);
        * hgv.off('mouseMoveZoom', mmz);
+       * hgv.off('createSVG');
        */
       off(event, listenerId, viewId) {
         const callback =
@@ -815,6 +816,9 @@ const createApi = function api(context, pubSub) {
        *    // If `true` `center`, `xRange`, and `yRange` are given in genomic positions
        *    isGenomicCoords
        *  }
+       *
+       * ``createSVG:`` Set a callback to obtain the current exported SVG DOM node,
+       *                and potentially return a manipulated SVG DOM node.
        *
        * @param {string} event One of the events described below
        *

--- a/test/APITests.js
+++ b/test/APITests.js
@@ -1,6 +1,6 @@
 /* eslint-env node, jasmine */
 import { globalPubSub } from 'pub-sub-es';
-import { select } from 'd3-selection';
+import { select, create } from 'd3-selection';
 
 import {
   some,
@@ -837,5 +837,67 @@ describe('API Tests', () => {
     //   // check to make sure that the two components have different
     //   // auth headers
     // });
+  });
+
+  describe('Export SVG API tests', () => {
+    it('listens to create SVG events', done => {
+      [div, api] = createElementAndApi(simple1And2dAnnotations, {
+        editable: false,
+        bounded: true
+      });
+
+      api.on('createSVG', svg => {
+        expect(svg.children.length).toEqual(2);
+        done();
+        return svg;
+      });
+
+      waitForTilesLoaded(api.getComponent(), () => {
+        api.exportAsSvg();
+      });
+    });
+
+    it('listens to create SVG events and enables manipulation of the SVG', done => {
+      [div, api] = createElementAndApi(simple1And2dAnnotations, {
+        editable: false,
+        bounded: true
+      });
+
+      api.on('createSVG', svg => {
+        const svgSelection = select(svg);
+
+        const g = create('svg:g');
+        g.append('circle')
+          .attr('cx', 10)
+          .attr('cy', 10)
+          .attr('r', 5)
+          .attr('fill', 'blue');
+        // Replace the contents of the exported SVG with the blue circle.
+        svgSelection.html(g.node().innerHTML);
+        return svgSelection.node();
+      });
+
+      waitForTilesLoaded(api.getComponent(), () => {
+        const svgStr = api.exportAsSvg();
+
+        const domparser = new DOMParser();
+        const doc = domparser.parseFromString(svgStr, 'image/svg+xml');
+
+        expect(doc.children.length).toEqual(1);
+        expect(doc.children[0].nodeName.toLowerCase()).toEqual('svg');
+        expect(doc.children[0].children.length).toEqual(1);
+        expect(doc.children[0].children[0].nodeName.toLowerCase()).toEqual(
+          'circle'
+        );
+        done();
+      });
+    });
+
+    afterEach(() => {
+      api.destroy();
+      removeDiv(div);
+      api = undefined;
+      div = undefined;
+    });
   });
 });


### PR DESCRIPTION
## Description

> What was changed in this pull request?

This adds the option to set a handler function for manipulating exported SVGs before they are downloaded.

> Why is it necessary?

This will allow us to include the extra visualizations from our cistrome-higlass-wrapper component in the SVGs that are exported from HiGlass using the existing "Export views as..." dropdown menu buttons.

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [x] Unit tests added or updated
- [x] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
