### PR TITLE
Update styles of exported heatmp svg:image tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Next release
 
 - Remove Content-Type headers when fetching genbank files
-- Added the fields `xRange` and `yRange` the object returned by the JavaScript API `.getLocation()` method. 
+- Added the fields `xRange` and `yRange` the object returned by the JavaScript API `.getLocation()` method.
+- Fixed blurry exported heatmap SVG graphics issue using the `image-rendering` CSS property.
 
 ## v1.8.4
 

--- a/app/scripts/HeatmapTiledPixiTrack.js
+++ b/app/scripts/HeatmapTiledPixiTrack.js
@@ -1258,7 +1258,8 @@ class HeatmapTiledPixiTrack extends TiledPixiTrack {
         tile.canvas.toDataURL()
       );
       image.setAttribute('width', 256);
-      image.setAttribute('height', 256);
+      image.setAttribute('height', tile.canvas.height);
+      image.setAttribute('style', 'image-rendering: pixelated');
 
       g.appendChild(image);
       output.appendChild(g);


### PR DESCRIPTION
## Description

> What was changed in this pull request?

This adds the `image-rendering: pixelated` css to the `<image/>` tag of exported heatmap SVGs. This css property is explained in this blog post: https://css-tricks.com/almanac/properties/i/image-rendering/#article-header-id-0 Also, I updated the height attribute to use the canvas height property rather than a static value of 256, since now with the `selectRows` option of the `horizontal-multivec` track, the canvas height may not always be 256.

> Why is it necessary?

Fixes #862

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [x] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md

## Screenshots

- Browser
![Screen Shot 2020-02-24 at 11 29 31 AM](https://user-images.githubusercontent.com/7525285/75172005-8d42cf00-56fa-11ea-834f-d7edfbbce9e4.png)


- Exported SVG before these changes
![Screen Shot 2020-02-24 at 11 30 49 AM](https://user-images.githubusercontent.com/7525285/75172027-97fd6400-56fa-11ea-98cf-77e1bc085f20.png)

- Exported SVG after these changes
![Screen Shot 2020-02-24 at 11 30 52 AM](https://user-images.githubusercontent.com/7525285/75172057-a9467080-56fa-11ea-9a0c-8c328be8804c.png)
