### PR TITLE
Trigger the on viewConfig callback on track resize events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Enabled view-based scaling
 - Left and right tracks can now be value scale locked
 - Added the attributes `projectionXDomain` and `projectionYDomain` to the `viewport-projection-horizontal` and `viewport-projection-vertical`, respectively, and both to the `viewport-projection-center`, to support the case in which the `fromViewUid` attribute is undefined.
+- Track resizing events now trigger the `.on('viewConfig')` JS API callback.
 
 _[Detailed changes since v1.8.4](https://github.com/higlass/higlass/compare/v1.8.3...develop)_
 

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -4390,6 +4390,7 @@ class HiGlassComponent extends React.Component {
             }
             onNoTrackAdded={this.handleNoTrackAdded.bind(this)}
             onRangeSelection={this.rangeSelectionHandler.bind(this)}
+            onResizeTrack={this.triggerViewChangeDb}
             onScalesChanged={(x, y) => this.handleScalesChanged(view.uid, x, y)}
             onTrackOptionsChanged={(trackId, options) =>
               this.handleTrackOptionsChanged(view.uid, trackId, options)

--- a/app/scripts/TiledPlot.js
+++ b/app/scripts/TiledPlot.js
@@ -626,6 +626,8 @@ class TiledPlot extends React.Component {
       tracks,
       forceUpdate: Math.random()
     });
+
+    this.props.onResizeTrack();
   }
 
   closeMenus() {
@@ -2388,6 +2390,7 @@ TiledPlot.propTypes = {
   onTracksAdded: PropTypes.func,
   onUnlockValueScale: PropTypes.func,
   onValueScaleChanged: PropTypes.func,
+  onResizeTrack: PropTypes.func,
   overlays: PropTypes.array,
   openModal: PropTypes.func,
   pixiRenderer: PropTypes.object,

--- a/test/APITests.js
+++ b/test/APITests.js
@@ -809,6 +809,27 @@ describe('API Tests', () => {
       });
     });
 
+    it('triggers on viewConfig events from track resize interactions', done => {
+      [div, api] = createElementAndApi(
+        simple1dHorizontalVerticalAnd2dDataTrack
+      );
+      const hgc = api.getComponent();
+      waitForTilesLoaded(hgc, () => {
+        const topTrackHeight = api.getViewConfig().views[0].tracks.top[0]
+          .height;
+        expect(topTrackHeight).toEqual(60);
+
+        hgc.tiledPlots.a.handleResizeTrack('h-line', 500, 100);
+
+        api.on('viewConfig', newViewConfigString => {
+          const newViewConfig = JSON.parse(newViewConfigString);
+          const newTopTrackHeight = newViewConfig.views[0].tracks.top[0].height;
+          expect(newTopTrackHeight).toEqual(100);
+          done();
+        });
+      });
+    });
+
     afterEach(() => {
       api.destroy();
       removeDiv(div);


### PR DESCRIPTION
## Description

> What was changed in this pull request?

This pull request adds code to trigger the `.on('viewConfig', callback)` callback function upon track resizing events, including from dragging the <DraggableDiv /> components

> Why is it necessary?

There is currently no way to detect track resize events from outside HiGlass.

Fixes #867 

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [x] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
