### PR TITLE
Add denseDataExtreme to divided tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## Next release
+
+- Fixed divided tracks bug by adding denseDataExtrema
+
+_[Detailed changes since v1.9.1](https://github.com/higlass/higlass/compare/v1.9.1...develop)_
+
 ## v1.9.1
 
 - Used stretchRects to ensure that there are no rendering artifacts when zooming in too far

--- a/app/scripts/DataFetcher.js
+++ b/app/scripts/DataFetcher.js
@@ -2,6 +2,9 @@ import slugid from 'slugid';
 import { scaleLinear } from 'd3-scale';
 import { trimTrailingSlash as tts, dictValues } from './utils';
 
+import DenseDataExtrema1D from './utils/DenseDataExtrema1D';
+import DenseDataExtrema2D from './utils/DenseDataExtrema2D';
+
 // Services
 import { tileProxy } from './services';
 import { minNonZero, maxNonZero } from './worker';
@@ -496,8 +499,14 @@ export default class DataFetcher {
           returnedTiles[1][tileIds[i]].dense
         );
 
+        const dde =
+          tilePos.length === 2
+            ? new DenseDataExtrema2D(newData)
+            : new DenseDataExtrema1D(newData);
+
         newTile = {
           dense: newData,
+          denseDataExtrema: dde,
           minNonZero: minNonZero(newData),
           maxNonZero: maxNonZero(newData),
           zoomLevel,

--- a/app/scripts/utils/test-helpers.js
+++ b/app/scripts/utils/test-helpers.js
@@ -101,9 +101,16 @@ export const isWaitingOnTiles = hgc => {
   for (const track of hgc.iterateOverTracks()) {
     let trackObj = getTrackObjectFromHGC(hgc, track.viewId, track.trackId);
 
-    if (!track.track.server && !track.track.tilesetUid) {
+    if (
+      !track.track.server &&
+      !track.track.tilesetUid &&
+      !(track.track.data && track.track.data.type === 'divided')
+    ) {
       continue;
-    } else if (track.track.server && track.track.tilesetUid) {
+    } else if (
+      (track.track.data && track.track.data.type === 'divided') ||
+      (track.track.server && track.track.tilesetUid)
+    ) {
       if (trackObj.originalTrack) {
         trackObj = trackObj.originalTrack;
       }

--- a/test/HiGlassComponentTest.js
+++ b/test/HiGlassComponentTest.js
@@ -67,6 +67,48 @@ describe('Simple HiGlassComponent', () => {
 
   jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
 
+  describe('Division track', () => {
+    it('Cleans up previously created instances and mounts a new component', done => {
+      if (hgc) {
+        hgc.unmount();
+        hgc.detach();
+      }
+
+      if (div) {
+        global.document.body.removeChild(div);
+      }
+
+      div = global.document.createElement('div');
+      global.document.body.appendChild(div);
+
+      div.setAttribute('style', 'width:800px;background-color: lightgreen');
+      div.setAttribute('id', 'simple-hg-component');
+
+      hgc = mount(
+        <HiGlassComponent
+          options={{ bounded: false }}
+          viewConfig={divisionViewConfig}
+        />,
+        { attachTo: div }
+      );
+
+      hgc.update();
+      waitForTilesLoaded(hgc.instance(), () => {
+        const svgText = hgc.instance().createSVGString();
+
+        expect(svgText.indexOf('image')).toBeGreaterThan(0);
+        done();
+      });
+
+      // visual check that the heatmap track config menu is moved
+      // to the left
+    });
+
+    it('clones itself', () => {
+      hgc.instance().handleAddView(hgc.instance().state.views.aa);
+    });
+  });
+
   describe('Track positioning', () => {
     it('Cleans up previously created instances and mounts a new component', done => {
       if (hgc) {
@@ -2714,43 +2756,6 @@ describe('Simple HiGlassComponent', () => {
 
       // visual check that the heatmap track config menu is moved
       // to the left
-    });
-  });
-
-  describe('Division track', () => {
-    it('Cleans up previously created instances and mounts a new component', done => {
-      if (hgc) {
-        hgc.unmount();
-        hgc.detach();
-      }
-
-      if (div) {
-        global.document.body.removeChild(div);
-      }
-
-      div = global.document.createElement('div');
-      global.document.body.appendChild(div);
-
-      div.setAttribute('style', 'width:800px;background-color: lightgreen');
-      div.setAttribute('id', 'simple-hg-component');
-
-      hgc = mount(
-        <HiGlassComponent
-          options={{ bounded: false }}
-          viewConfig={divisionViewConfig}
-        />,
-        { attachTo: div }
-      );
-
-      hgc.update();
-      waitForTilesLoaded(hgc.instance(), done);
-
-      // visual check that the heatmap track config menu is moved
-      // to the left
-    });
-
-    it('clones itself', () => {
-      hgc.instance().handleAddView(hgc.instance().state.views.aa);
     });
   });
 


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Adds denseDataExtrema to divided tiles so that they don't blow up.

> Why is it necessary?

Fixes #___

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [x] Unit tests added or updated
- [o] Documentation added or updated
- [o] Example(s) added or updated
- [o] Update schema.json if there are changes to the viewconf JSON structure format
- [o] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
