### PR TITLE
Prevent crash when clicking "Configure Series"

### DIFF
--- a/app/scripts/SeriesListMenu.js
+++ b/app/scripts/SeriesListMenu.js
@@ -326,7 +326,7 @@ export default class SeriesListMenu extends ContextMenuContainer {
         styleName={styleNames}
       >
         <ContextMenuItem
-          onClick={this.props.onConfigureTrack}
+          onClick={() => {}}
           onMouseEnter={e =>
             this.handleItemMouseEnter(e, {
               option: 'configure-series',


### PR DESCRIPTION
## Description

> What was changed in this pull request?

This PR prevents Higlass from crashing when clicking on "Configure Series" in the track context menu. See #661.

> Why is it necessary?

Fixes #661 

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
