### PR TITLE
Support zero-height tracks

### DIFF
--- a/app/scripts/utils/fill-in-min-widths.js
+++ b/app/scripts/utils/fill-in-min-widths.js
@@ -32,18 +32,16 @@ const fillInMinWidths = tracks => {
         const trackInfo = TRACKS_INFO_BY_TYPE[track.type];
         const defaultOptions = (trackInfo && trackInfo.defaultOptions) || {};
         const options = track.options
-          ? { ...track.options, ...defaultOptions }
+          ? { ...defaultOptions, ...track.options } // values in track.options take precedence
           : defaultOptions;
 
-        if (!options.minHeight && track.height < options.minHeight) {
-          track.height = options.minHeight || MIN_HORIZONTAL_HEIGHT;
+        if (options.minHeight !== undefined && track.height === undefined) {
+          track.height = options.minHeight;
         }
 
-        if (!track.height) {
+        if (track.height === undefined) {
           track.height =
-            (trackInfo && trackInfo.defaultHeight) ||
-            options.minHeight ||
-            MIN_HORIZONTAL_HEIGHT;
+            (trackInfo && trackInfo.defaultHeight) || MIN_HORIZONTAL_HEIGHT;
         }
       })
     );
@@ -56,18 +54,16 @@ const fillInMinWidths = tracks => {
         const defaultOptions = (trackInfo && trackInfo.defaultOptions) || {};
 
         const options = track.options
-          ? { ...track.options, ...defaultOptions }
+          ? { ...defaultOptions, ...track.options } // values in track.options take precedence
           : defaultOptions;
 
-        if (!options.minWidth && track.width < options.minWidth) {
-          track.width = options.minWidth || MIN_VERTICAL_WIDTH;
+        if (options.minWidth !== undefined && track.width === undefined) {
+          track.width = options.minWidth;
         }
 
-        if (!track.width) {
+        if (track.width === undefined) {
           track.width =
-            (trackInfo && trackInfo.defaultWidth) ||
-            options.minWidth ||
-            MIN_VERTICAL_WIDTH;
+            (trackInfo && trackInfo.defaultWidth) || MIN_VERTICAL_WIDTH;
         }
       })
     );

--- a/test/HiGlassComponentTest.js
+++ b/test/HiGlassComponentTest.js
@@ -2579,9 +2579,11 @@ describe('Simple HiGlassComponent', () => {
       waitForTilesLoaded(hgc.instance(), done);
     });
 
-    it('should have a bottom track of height 0', () => {
+    it('should have a bottom track of height 0', done => {
       const height = hgc.instance().state.views.aa.tracks.bottom[0].height;
       expect(height).toEqual(0);
+
+      waitForTilesLoaded(hgc.instance(), done);
     });
   });
 

--- a/test/HiGlassComponentTest.js
+++ b/test/HiGlassComponentTest.js
@@ -2578,6 +2578,11 @@ describe('Simple HiGlassComponent', () => {
 
       waitForTilesLoaded(hgc.instance(), done);
     });
+
+    it('should have a bottom track of height 0', () => {
+      const height = hgc.instance().state.views.aa.tracks.bottom[0].height;
+      expect(height).toEqual(0);
+    });
   });
 
   describe('Value interval track tests', () => {

--- a/test/UtilsTests.js
+++ b/test/UtilsTests.js
@@ -23,7 +23,7 @@ describe('Utils tests', () => {
     });
 
     expect(found).to.eql(true);
-    expect(visited).to.eql(5);
+    expect(visited).to.eql(6);
   });
 
   it('should compute size based on an array of selected item indices', () => {

--- a/test/view-configs-more/oneViewConfig.json
+++ b/test/view-configs-more/oneViewConfig.json
@@ -88,7 +88,36 @@
           }
         ],
         "right": [],
-        "bottom": []
+        "bottom": [
+          {
+            "server": "http://higlass.io/api/v1",
+            "tilesetUid": "E36VpigUTAaHI-_pm1hGsA",
+            "uid": "WTZUPcoeRUG977hjurAWow",
+            "type": "horizontal-bar",
+            "options": {
+              "align": "bottom",
+              "labelColor": "[glyph-color]",
+              "labelPosition": "topLeft",
+              "labelLeftMargin": 0,
+              "labelRightMargin": 0,
+              "labelTopMargin": 0,
+              "labelBottomMargin": 0,
+              "labelShowResolution": false,
+              "labelShowAssembly": true,
+              "axisLabelFormatting": "scientific",
+              "axisPositionHorizontal": "right",
+              "barFillColor": "darkgreen",
+              "valueScaling": "linear",
+              "trackBorderWidth": 0,
+              "trackBorderColor": "black",
+              "labelTextOpacity": 0.4,
+              "barOpacity": 1,
+              "name": "Ballinger et al. 2019 - MCF7 BLISS 50Kb"
+            },
+            "width": 20,
+            "height": 0
+          }
+        ]
       },
       "layout": {
         "w": 5,


### PR DESCRIPTION
## Description

> What was changed in this pull request?

This PR adds support for zero-height/zero-width 1D tracks. If the `height`/`width` property of a track is set to `0`, it will be correctly rendered with zero height/width. Note that if `height` or `width` is set, the `minHeight`, `minWidth` options are ignored.


> Why is it necessary?

Fixes #887 

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [x] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
