### PR TITLE
Fix heatmap label position bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release notes
 
+- Fixed bug where heatmap lables could not be hidden
+- The position of labels and colorbars for split heatmaps can now be changed.
+
 ## v1.9.2
 
 - Fixed divided tracks bug by adding denseDataExtrema

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -3638,49 +3638,31 @@ class HiGlassComponent extends React.Component {
 
     if (!track) return;
 
-    track.options = Object.assign(
-      track.options,
-      this.adjustNewTrackOptions(track, newOptions)
-    );
+    track.options = Object.assign(track.options, newOptions);
 
     if (this.mounted) {
       this.setState(prevState => ({
         views: prevState.views
       }));
-      this.adjustOtherTrackOptions(track, newOptions, view.tracks, viewUid);
+      this.adjustSplitHeatmapTrackOptions(
+        track,
+        newOptions,
+        view.tracks,
+        viewUid
+      );
     }
   }
 
   /**
-   * For convenience we adjust some options based on other options.
-   * @param   {object}  track  Track whose options have changed
-   * @param   {object}  newOptions  New track options
-   * @return  {object}  Adjusted new track options
-   */
-  adjustNewTrackOptions(track, newOptions) {
-    if (track.type === 'heatmap') {
-      if (newOptions.extent === 'upper-right') {
-        newOptions.labelPosition = 'topRight';
-        newOptions.colorbarPosition = 'topRight';
-      }
-      if (newOptions.extent === 'lower-left') {
-        newOptions.labelPosition = 'bottomLeft';
-        newOptions.colorbarPosition = 'bottomLeft';
-      }
-    }
-
-    return newOptions;
-  }
-
-  /**
-   * For convenience we adjust some options of other tracks based on newly
-   * updated options.
+   * For convenience we adjust some options of split heatmap tracks when they are newly added.
+   * This function has no effect when we get split heatmap tracks that are already correctly configured
+   * (i.e. correctly set "lower-extend"/"upper-extend" options)
    * @param   {object}  track  Track whose options have changed
    * @param   {object}  options  New track options
    * @param   {list}  allTracks  All tracks
    * @param   {string}  viewUid  Related view UID
    */
-  adjustOtherTrackOptions(track, options, allTracks, viewUid) {
+  adjustSplitHeatmapTrackOptions(track, options, allTracks, viewUid) {
     if (track.type === 'heatmap') {
       if (
         options.extent === 'upper-right' &&
@@ -3696,12 +3678,28 @@ class HiGlassComponent extends React.Component {
             // Automatically change the extent of the other track to
             // `lower-left``
             const otherNewOptions = Object.assign({}, otherTrack.options, {
-              extent: 'lower-left'
+              extent: 'lower-left',
+              labelPosition: 'bottomLeft',
+              colorbarPosition: 'bottomLeft'
             });
+
+            // Automatically set positions of label and colorbar of the current track
+            // to the opposite corner. We don't want overlapping labels.
+            const originalNewOptions = Object.assign({}, options, {
+              labelPosition: 'topRight',
+              colorbarPosition: 'topRight'
+            });
+
             this.handleTrackOptionsChanged(
               viewUid,
               otherTrack.uid,
               otherNewOptions
+            );
+
+            this.handleTrackOptionsChanged(
+              viewUid,
+              track.uid,
+              originalNewOptions
             );
             return true;
           }
@@ -3723,12 +3721,28 @@ class HiGlassComponent extends React.Component {
               // Automatically change the extent of the other track to
               // `upper-right``
               const otherNewOptions = Object.assign({}, otherTrack.options, {
-                extent: 'upper-right'
+                extent: 'upper-right',
+                labelPosition: 'topRight',
+                colorbarPosition: 'topRight'
               });
+
+              // Automatically set positions of label and colorbar of the current track
+              // to the opposite corner. We don't want overlapping labels.
+              const originalNewOptions = Object.assign({}, options, {
+                labelPosition: 'bottomLeft',
+                colorbarPosition: 'bottomLeft'
+              });
+
               this.handleTrackOptionsChanged(
                 viewUid,
                 otherTrack.uid,
                 otherNewOptions
+              );
+
+              this.handleTrackOptionsChanged(
+                viewUid,
+                track.uid,
+                originalNewOptions
               );
               return true;
             }

--- a/app/scripts/PixiTrack.js
+++ b/app/scripts/PixiTrack.js
@@ -326,7 +326,7 @@ class PixiTrack extends Track {
       this.options.labelPosition === 'hidden'
     ) {
       // don't display the track label
-      this.labelText.opacity = 0;
+      this.labelText.alpha = 0;
       return;
     }
 

--- a/test/HeatmapTests.js
+++ b/test/HeatmapTests.js
@@ -111,16 +111,11 @@ describe('Heatmaps', () => {
       const views = JSON.parse(JSON.stringify(hgc.instance().state.views));
       const center = views.v.tracks.center[0];
 
-      const newOptions0 = Object.assign({}, center.contents[0].options, {
+      const newOptions = Object.assign({}, center.contents[0].options, {
         extent: 'lower-left'
       });
 
-      const newOptions1 = Object.assign({}, center.contents[1].options, {
-        extent: 'upper-right'
-      });
-
-      hgc.instance().handleTrackOptionsChanged('v', 'heatmap0', newOptions0);
-      hgc.instance().handleTrackOptionsChanged('v', 'heatmap1', newOptions1);
+      hgc.instance().handleTrackOptionsChanged('v', 'heatmap0', newOptions);
       hgc.update();
 
       const newViews = JSON.parse(JSON.stringify(hgc.instance().state.views.v));

--- a/test/LabelTests.js
+++ b/test/LabelTests.js
@@ -15,10 +15,11 @@ import {
 } from '../app/scripts/utils';
 
 import viewconf from './view-configs/label-margin';
+import viewconfSplitHeatmaps from './view-configs/label-split-heatmaps';
 
 configure({ adapter: new Adapter() });
 
-describe('Simple HiGlassComponent', () => {
+describe('Label test', () => {
   describe('Axis texts', () => {
     let hgc = null;
     let div = null;
@@ -107,6 +108,31 @@ describe('Simple HiGlassComponent', () => {
       expect(track5.labelText.text.startsWith('hg19 | ')).to.be.true;
       // eslint-disable-next-line no-unused-expressions
       expect(track6.labelText.text.startsWith('hg19 | ')).to.be.false;
+    });
+
+    afterAll(() => {
+      removeHGComponent(div);
+    });
+  });
+
+  describe('Heatmap label tests', () => {
+    let hgc = null;
+    let div = null;
+    beforeAll(done => {
+      [div, hgc] = mountHGComponent(div, hgc, viewconfSplitHeatmaps, done, {
+        style: 'width:800px; height:400px; background-color: lightgreen',
+        bounded: true
+      });
+    });
+
+    it('Makes sure that hiding the label works', () => {
+      hgc.instance().state.views.aa.tracks.center[0].contents[0].options.labelPosition =
+        'hidden';
+      hgc.setState(hgc.instance().state);
+
+      const trackObj = getTrackObjectFromHGC(hgc.instance(), 'aa', 't1');
+
+      expect(trackObj.labelText.alpha).to.be.eql(0);
     });
 
     afterAll(() => {

--- a/test/view-configs/label-split-heatmaps.json
+++ b/test/view-configs/label-split-heatmaps.json
@@ -1,0 +1,157 @@
+{
+  "zoomFixed": false,
+  "views": [
+    {
+      "layout": {
+        "w": 12,
+        "h": 7,
+        "x": 0,
+        "y": 0
+      },
+      "uid": "aa",
+      "initialYDomain": [2523938059.4057345, 2558484895.406563],
+      "initialXDomain": [2520960005.7587643, 2558627201.1403127],
+      "tracks": {
+        "left": [],
+        "top": [],
+        "right": [],
+        "center": [
+          {
+            "uid": "center",
+            "type": "combined",
+            "contents": [
+              {
+                "server": "http://higlass.io/api/v1",
+                "tilesetUid": "dVBREuC2SvO01uXYMUh2aQ",
+                "type": "heatmap",
+                "uid": "t1",
+                "options": {
+                  "backgroundColor": "#eeeeee",
+                  "labelPosition": "bottomLeft",
+                  "labelTextOpacity": 0.4,
+                  "colorRange": [
+                    "white",
+                    "rgba(245,166,35,1.0)",
+                    "rgba(208,2,27,1.0)",
+                    "black"
+                  ],
+                  "maxZoom": null,
+                  "colorbarPosition": "bottomLeft",
+                  "trackBorderWidth": 0,
+                  "trackBorderColor": "black",
+                  "heatmapValueScaling": "log",
+                  "showMousePosition": true,
+                  "mousePositionColor": "#000000",
+                  "showTooltip": true,
+                  "scaleStartPercent": "0.00000",
+                  "scaleEndPercent": "1.00000",
+                  "showMousePositionGlobally": true,
+                  "labelLeftMargin": 0,
+                  "labelRightMargin": 0,
+                  "labelTopMargin": 0,
+                  "labelBottomMargin": 0,
+                  "labelShowResolution": true,
+                  "labelShowAssembly": true,
+                  "colorbarBackgroundColor": "#ffffff",
+                  "minWidth": 100,
+                  "minHeight": 100,
+                  "extent": "lower-left",
+                  "zeroValueColor": null,
+                  "name": "[hicnorm] Rao et al. (2014) GM12878 MboI Primary"
+                },
+                "transforms": [],
+                "width": 676,
+                "height": 718
+              },
+              {
+                "server": "http://higlass.io/api/v1",
+                "tilesetUid": "A3CXORsOSkyl0nzWNkXK3A",
+                "uid": "t2",
+                "type": "heatmap",
+                "options": {
+                  "backgroundColor": "transparent",
+                  "labelPosition": "topRight",
+                  "labelLeftMargin": 0,
+                  "labelRightMargin": 0,
+                  "labelTopMargin": 0,
+                  "labelBottomMargin": 0,
+                  "labelShowResolution": true,
+                  "labelShowAssembly": true,
+                  "colorRange": [
+                    "white",
+                    "rgba(245,166,35,1.0)",
+                    "rgba(208,2,27,1.0)",
+                    "black"
+                  ],
+                  "colorbarBackgroundColor": "#ffffff",
+                  "maxZoom": null,
+                  "minWidth": 100,
+                  "minHeight": 100,
+                  "colorbarPosition": "topRight",
+                  "trackBorderWidth": 0,
+                  "trackBorderColor": "black",
+                  "heatmapValueScaling": "log",
+                  "showMousePosition": true,
+                  "mousePositionColor": "#000000",
+                  "showTooltip": true,
+                  "extent": "upper-right",
+                  "zeroValueColor": null,
+                  "name": "LD correlation - 1000 Genomes Phase 3 (hg19)",
+                  "scaleStartPercent": "0.00000",
+                  "scaleEndPercent": "1.00000"
+                },
+                "width": 100,
+                "height": 100,
+                "transforms": []
+              }
+            ],
+            "options": {},
+            "width": 676,
+            "height": 718
+          }
+        ],
+        "bottom": [],
+        "whole": [],
+        "gallery": []
+      },
+      "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
+      "genomePositionSearchBox": {
+        "visible": true,
+        "chromInfoServer": "http://higlass.io/api/v1",
+        "chromInfoId": "hg19",
+        "autocompleteServer": "http://higlass.io/api/v1",
+        "autocompleteId": "OHJakQICQD6gTD7skx4EWA"
+      }
+    }
+  ],
+  "editable": true,
+  "viewEditable": true,
+  "tracksEditable": true,
+  "exportViewUrl": "/api/v1/viewconfs",
+  "zoomLocks": {
+    "locksByViewUid": {},
+    "locksDict": {}
+  },
+  "trackSourceServers": ["http://higlass.io/api/v1"],
+  "locationLocks": {
+    "locksByViewUid": {
+      "aa": "PkNgAl3mSIqttnSsCewngw",
+      "ewZvJwlDSei_dbpIAkGMlg": "PkNgAl3mSIqttnSsCewngw"
+    },
+    "locksDict": {
+      "PkNgAl3mSIqttnSsCewngw": {
+        "aa": [1550000000, 1550000000, 3380588.876772046],
+        "ewZvJwlDSei_dbpIAkGMlg": [
+          1550000000.0000002,
+          1549999999.9999993,
+          3380588.876772046
+        ],
+        "uid": "PkNgAl3mSIqttnSsCewngw"
+      }
+    }
+  },
+  "valueScaleLocks": {
+    "locksByViewUid": {},
+    "locksDict": {}
+  }
+}

--- a/test/view-configs/label-split-heatmaps.json
+++ b/test/view-configs/label-split-heatmaps.json
@@ -59,7 +59,6 @@
                   "zeroValueColor": null,
                   "name": "[hicnorm] Rao et al. (2014) GM12878 MboI Primary"
                 },
-                "transforms": [],
                 "width": 676,
                 "height": 718
               },
@@ -101,8 +100,7 @@
                   "scaleEndPercent": "1.00000"
                 },
                 "width": 100,
-                "height": 100,
-                "transforms": []
+                "height": 100
               }
             ],
             "options": {},


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Heatmap labels can now be hidden.

Split heatmaps now allow different label and colorbar positions (they were fixed before). However, when creating a new split heatmap by setting`extend` of one track to `upper-right` / `lower-left`, labels and colorbars will be still automatically positioned in opposite corners.


> Why is it necessary?

Labels couldn't be hidden, split heatmap labels were always fixed.

Fixes #884 
Fixes #812 

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [x] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
