### PR TITLE
Correctly configure stacked heatmap tracks when added via the track context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release notes
 
-- Set background of new heatmap tracks in a combined track to `transparent` when added via the track context menu
-- Fixed bug where heatmap lables could not be hidden
+- Set background of new heatmap tracks in a combined track to `transparent` when added via the track context menu.
+- Fixed bug where heatmap labels could not be hidden.
 - The position of labels and colorbars for split heatmaps can now be changed.
 
 ## v1.9.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Release notes
 
+- Set background of new heatmap tracks in a combined track to `transparent` when added via the track context menu
+
 ## v1.9.2
 
 - Fixed divided tracks bug by adding denseDataExtrema

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -2511,6 +2511,11 @@ class HiGlassComponent extends React.Component {
 
     if (hostTrack.type === 'combined') {
       hostTrack.contents.push(newTrack);
+
+      if (newTrack.type === 'heatmap') {
+        // For stacked heatmaps we will adjust some options automatically for convenience
+        this.compatibilityfyStackedHeatmaps(newTrack, hostTrack);
+      }
     } else {
       const newHost = {
         type: 'combined',


### PR DESCRIPTION
## Description

> What was changed in this pull request?

This PR makes sure that stacked heatmap tracks receive the correct configuration when added via the track context menu.

> Why is it necessary?

Fixes #888 
Fixes #803 

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
