### PR TITLE
Publish viewUid and trackUid with wheel events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release notes
 
-- Fix: Add missing initializer value to `utils.reduce`
+## Next release
+
+- Add missing initializer value to `utils.reduce`
+- Added `trackUid` and `viewUid` as properties in the object published to wheel event callback functions.
 
 ## v1.13.5
 

--- a/app/scripts/HeatmapTiledPixiTrack.js
+++ b/app/scripts/HeatmapTiledPixiTrack.js
@@ -76,7 +76,7 @@ class HeatmapTiledPixiTrack extends TiledPixiTrack {
     this.pubSub = pubSub;
     this.is2d = true;
     this.animate = animate;
-    this.uid = slugid.nice();
+    this.uid = context.trackUid ?? slugid.nice();
     this.scaleBrush = brushY();
 
     this.onTrackOptionsChanged = onTrackOptionsChanged;

--- a/app/scripts/HiGlassComponent.jsx
+++ b/app/scripts/HiGlassComponent.jsx
@@ -130,7 +130,6 @@ class HiGlassComponent extends React.Component {
     this.yScales = {};
     this.projectionXDomains = {};
     this.projectionYDomains = {};
-    this.topDiv = null;
     this.zoomToDataExtentOnInit = new Set();
 
     // a reference of view / track combinations
@@ -4901,7 +4900,7 @@ class HiGlassComponent extends React.Component {
 
     // Find the tracks at the wheel position
     if (this.apiStack.wheel && this.apiStack.wheel.length > 0) {
-      const relPos = pointer(nativeEvent, this.topDiv);
+      const relPos = pointer(nativeEvent, this.topDivRef.current);
       // We need to add the scrollTop
       relPos[1] += this.scrollTop;
       const hoveredTracks = hoveredTiledPlot
@@ -4923,7 +4922,7 @@ class HiGlassComponent extends React.Component {
       const viewUid = hoveredTiledPlot?.props
         ? hoveredTiledPlot.props.uid
         : undefined;
-      const trackUid = hoveredTrack ? hoveredTrack.id : undefined;
+      const trackUid = hoveredTrack ? hoveredTrack.uid : undefined;
 
       const evtToPublish = {
         x: relPos[0],

--- a/app/scripts/HiGlassComponent.jsx
+++ b/app/scripts/HiGlassComponent.jsx
@@ -375,11 +375,11 @@ class HiGlassComponent extends React.Component {
 
     this.setBroadcastMousePositionGlobally(
       this.props.options.broadcastMousePositionGlobally ||
-      this.props.options.globalMousePosition,
+        this.props.options.globalMousePosition,
     );
     this.setShowGlobalMousePosition(
       this.props.options.showGlobalMousePosition ||
-      this.props.options.globalMousePosition,
+        this.props.options.globalMousePosition,
     );
   }
 
@@ -1316,11 +1316,11 @@ class HiGlassComponent extends React.Component {
           typeof sourceTrack.options.scaleEndPercent !== 'undefined' &&
           (Math.abs(
             lockedTrack.options.scaleStartPercent -
-            sourceTrack.options.scaleStartPercent,
+              sourceTrack.options.scaleStartPercent,
           ) > epsilon ||
             Math.abs(
               lockedTrack.options.scaleEndPercent -
-              sourceTrack.options.scaleEndPercent,
+                sourceTrack.options.scaleEndPercent,
             ) > epsilon);
 
         // If we do view based scaling we want to minimize the number of rerenders
@@ -3324,7 +3324,7 @@ class HiGlassComponent extends React.Component {
         ) {
           this.locationLocks[viewUid] =
             viewConfig.locationLocks.locksDict[
-            viewConfig.locationLocks.locksByViewUid[viewUid]
+              viewConfig.locationLocks.locksByViewUid[viewUid]
             ];
         } else {
           // This means we need to link x and y axes separately.
@@ -3333,7 +3333,7 @@ class HiGlassComponent extends React.Component {
           if ('x' in viewConfig.locationLocks.locksByViewUid[viewUid]) {
             const lockInfo =
               viewConfig.locationLocks.locksDict[
-              viewConfig.locationLocks.locksByViewUid[viewUid].x.lock
+                viewConfig.locationLocks.locksByViewUid[viewUid].x.lock
               ];
             this.locationLocksAxisWise.x[viewUid] = {
               lock: lockInfo,
@@ -3345,7 +3345,7 @@ class HiGlassComponent extends React.Component {
           if ('y' in viewConfig.locationLocks.locksByViewUid[viewUid]) {
             const lockInfo =
               viewConfig.locationLocks.locksDict[
-              viewConfig.locationLocks.locksByViewUid[viewUid].y.lock
+                viewConfig.locationLocks.locksByViewUid[viewUid].y.lock
               ];
             this.locationLocksAxisWise.y[viewUid] = {
               lock: lockInfo,
@@ -3367,7 +3367,7 @@ class HiGlassComponent extends React.Component {
       for (const viewUid of dictKeys(viewConfig.zoomLocks.locksByViewUid)) {
         this.zoomLocks[viewUid] =
           viewConfig.zoomLocks.locksDict[
-          viewConfig.zoomLocks.locksByViewUid[viewUid]
+            viewConfig.zoomLocks.locksByViewUid[viewUid]
           ];
       }
     }
@@ -3384,7 +3384,7 @@ class HiGlassComponent extends React.Component {
       )) {
         this.valueScaleLocks[viewUid] =
           viewConfig.valueScaleLocks.locksDict[
-          viewConfig.valueScaleLocks.locksByViewUid[viewUid]
+            viewConfig.valueScaleLocks.locksByViewUid[viewUid]
           ];
       }
     }
@@ -4449,8 +4449,8 @@ class HiGlassComponent extends React.Component {
 
     const hoveredTracks = hoveredTiledPlot
       ? hoveredTiledPlot
-        .listTracksAtPosition(relPos[0], relPos[1], true)
-        .map((track) => track.originalTrack || track)
+          .listTracksAtPosition(relPos[0], relPos[1], true)
+          .map((track) => track.originalTrack || track)
       : [];
 
     const hoveredTrack = hoveredTracks.find(
@@ -4459,9 +4459,9 @@ class HiGlassComponent extends React.Component {
 
     const relTrackPos = hoveredTrack
       ? [
-        relPos[0] - hoveredTrack.position[0],
-        relPos[1] - hoveredTrack.position[1],
-      ]
+          relPos[0] - hoveredTrack.position[0],
+          relPos[1] - hoveredTrack.position[1],
+        ]
       : relPos;
 
     let dataX = -1;
@@ -4671,8 +4671,8 @@ class HiGlassComponent extends React.Component {
 
     const hoveredTracks = hoveredTiledPlot
       ? hoveredTiledPlot
-        .listTracksAtPosition(relPos[0], relPos[1], true)
-        .map((track) => track.originalTrack || track)
+          .listTracksAtPosition(relPos[0], relPos[1], true)
+          .map((track) => track.originalTrack || track)
       : [];
 
     const hoveredTrack = hoveredTracks.find(
@@ -4685,9 +4685,9 @@ class HiGlassComponent extends React.Component {
     // any additional information (i.e. annotations under the cursor)
     const relTrackPos = hoveredTrack
       ? [
-        relPos[0] - hoveredTrack.position[0],
-        relPos[1] - hoveredTrack.position[1],
-      ]
+          relPos[0] - hoveredTrack.position[0],
+          relPos[1] - hoveredTrack.position[1],
+        ]
       : relPos;
 
     const relTrackX = hoveredTrack?.flipText ? relTrackPos[1] : relTrackPos[0];
@@ -4787,7 +4787,7 @@ class HiGlassComponent extends React.Component {
   /**
    * Handle mousedown events/
    */
-  mouseDownHandler(evt) { }
+  mouseDownHandler(evt) {}
 
   onScrollHandler() {
     if (this.sizeMode !== SIZE_MODE_SCROLL) return;
@@ -4906,8 +4906,8 @@ class HiGlassComponent extends React.Component {
       relPos[1] += this.scrollTop;
       const hoveredTracks = hoveredTiledPlot
         ? hoveredTiledPlot
-          .listTracksAtPosition(relPos[0], relPos[1], true)
-          .map((track) => track.originalTrack || track)
+            .listTracksAtPosition(relPos[0], relPos[1], true)
+            .map((track) => track.originalTrack || track)
         : [];
       const hoveredTrack = hoveredTracks.find(
         (track) => !track.isAugmentationTrack,
@@ -4915,9 +4915,9 @@ class HiGlassComponent extends React.Component {
 
       const relTrackPos = hoveredTrack
         ? [
-          relPos[0] - hoveredTrack.position[0],
-          relPos[1] - hoveredTrack.position[1],
-        ]
+            relPos[0] - hoveredTrack.position[0],
+            relPos[1] - hoveredTrack.position[1],
+          ]
         : relPos;
 
       const viewUid = hoveredTiledPlot?.props
@@ -5042,7 +5042,7 @@ class HiGlassComponent extends React.Component {
             chooseTrackHandler={
               this.state.chooseTrackHandler
                 ? (trackId, evt) =>
-                  this.state.chooseTrackHandler(view.uid, trackId, evt)
+                    this.state.chooseTrackHandler(view.uid, trackId, evt)
                 : null
             }
             customDialog={this.state.customDialog}
@@ -5202,8 +5202,8 @@ class HiGlassComponent extends React.Component {
         );
         const multiTrackHeader =
           this.isEditable() &&
-            !this.isViewHeaderDisabled() &&
-            !this.state.viewConfig.hideHeader ? (
+          !this.isViewHeaderDisabled() &&
+          !this.state.viewConfig.hideHeader ? (
             <ViewHeader
               ref={(c) => {
                 this.viewHeaders[view.uid] = c;
@@ -5301,8 +5301,8 @@ class HiGlassComponent extends React.Component {
 
     let layouts = this.mounted
       ? Object.values(this.state.views)
-        .filter((view) => view.layout)
-        .map((view) => view.layout)
+          .filter((view) => view.layout)
+          .map((view) => view.layout)
       : [];
 
     layouts = JSON.parse(JSON.stringify(layouts)); // make sure to copy the layouts

--- a/app/scripts/HiGlassComponent.jsx
+++ b/app/scripts/HiGlassComponent.jsx
@@ -375,11 +375,11 @@ class HiGlassComponent extends React.Component {
 
     this.setBroadcastMousePositionGlobally(
       this.props.options.broadcastMousePositionGlobally ||
-        this.props.options.globalMousePosition,
+      this.props.options.globalMousePosition,
     );
     this.setShowGlobalMousePosition(
       this.props.options.showGlobalMousePosition ||
-        this.props.options.globalMousePosition,
+      this.props.options.globalMousePosition,
     );
   }
 
@@ -1316,11 +1316,11 @@ class HiGlassComponent extends React.Component {
           typeof sourceTrack.options.scaleEndPercent !== 'undefined' &&
           (Math.abs(
             lockedTrack.options.scaleStartPercent -
-              sourceTrack.options.scaleStartPercent,
+            sourceTrack.options.scaleStartPercent,
           ) > epsilon ||
             Math.abs(
               lockedTrack.options.scaleEndPercent -
-                sourceTrack.options.scaleEndPercent,
+              sourceTrack.options.scaleEndPercent,
             ) > epsilon);
 
         // If we do view based scaling we want to minimize the number of rerenders
@@ -3324,7 +3324,7 @@ class HiGlassComponent extends React.Component {
         ) {
           this.locationLocks[viewUid] =
             viewConfig.locationLocks.locksDict[
-              viewConfig.locationLocks.locksByViewUid[viewUid]
+            viewConfig.locationLocks.locksByViewUid[viewUid]
             ];
         } else {
           // This means we need to link x and y axes separately.
@@ -3333,7 +3333,7 @@ class HiGlassComponent extends React.Component {
           if ('x' in viewConfig.locationLocks.locksByViewUid[viewUid]) {
             const lockInfo =
               viewConfig.locationLocks.locksDict[
-                viewConfig.locationLocks.locksByViewUid[viewUid].x.lock
+              viewConfig.locationLocks.locksByViewUid[viewUid].x.lock
               ];
             this.locationLocksAxisWise.x[viewUid] = {
               lock: lockInfo,
@@ -3345,7 +3345,7 @@ class HiGlassComponent extends React.Component {
           if ('y' in viewConfig.locationLocks.locksByViewUid[viewUid]) {
             const lockInfo =
               viewConfig.locationLocks.locksDict[
-                viewConfig.locationLocks.locksByViewUid[viewUid].y.lock
+              viewConfig.locationLocks.locksByViewUid[viewUid].y.lock
               ];
             this.locationLocksAxisWise.y[viewUid] = {
               lock: lockInfo,
@@ -3367,7 +3367,7 @@ class HiGlassComponent extends React.Component {
       for (const viewUid of dictKeys(viewConfig.zoomLocks.locksByViewUid)) {
         this.zoomLocks[viewUid] =
           viewConfig.zoomLocks.locksDict[
-            viewConfig.zoomLocks.locksByViewUid[viewUid]
+          viewConfig.zoomLocks.locksByViewUid[viewUid]
           ];
       }
     }
@@ -3384,7 +3384,7 @@ class HiGlassComponent extends React.Component {
       )) {
         this.valueScaleLocks[viewUid] =
           viewConfig.valueScaleLocks.locksDict[
-            viewConfig.valueScaleLocks.locksByViewUid[viewUid]
+          viewConfig.valueScaleLocks.locksByViewUid[viewUid]
           ];
       }
     }
@@ -4449,8 +4449,8 @@ class HiGlassComponent extends React.Component {
 
     const hoveredTracks = hoveredTiledPlot
       ? hoveredTiledPlot
-          .listTracksAtPosition(relPos[0], relPos[1], true)
-          .map((track) => track.originalTrack || track)
+        .listTracksAtPosition(relPos[0], relPos[1], true)
+        .map((track) => track.originalTrack || track)
       : [];
 
     const hoveredTrack = hoveredTracks.find(
@@ -4459,9 +4459,9 @@ class HiGlassComponent extends React.Component {
 
     const relTrackPos = hoveredTrack
       ? [
-          relPos[0] - hoveredTrack.position[0],
-          relPos[1] - hoveredTrack.position[1],
-        ]
+        relPos[0] - hoveredTrack.position[0],
+        relPos[1] - hoveredTrack.position[1],
+      ]
       : relPos;
 
     let dataX = -1;
@@ -4671,8 +4671,8 @@ class HiGlassComponent extends React.Component {
 
     const hoveredTracks = hoveredTiledPlot
       ? hoveredTiledPlot
-          .listTracksAtPosition(relPos[0], relPos[1], true)
-          .map((track) => track.originalTrack || track)
+        .listTracksAtPosition(relPos[0], relPos[1], true)
+        .map((track) => track.originalTrack || track)
       : [];
 
     const hoveredTrack = hoveredTracks.find(
@@ -4685,9 +4685,9 @@ class HiGlassComponent extends React.Component {
     // any additional information (i.e. annotations under the cursor)
     const relTrackPos = hoveredTrack
       ? [
-          relPos[0] - hoveredTrack.position[0],
-          relPos[1] - hoveredTrack.position[1],
-        ]
+        relPos[0] - hoveredTrack.position[0],
+        relPos[1] - hoveredTrack.position[1],
+      ]
       : relPos;
 
     const relTrackX = hoveredTrack?.flipText ? relTrackPos[1] : relTrackPos[0];
@@ -4787,7 +4787,7 @@ class HiGlassComponent extends React.Component {
   /**
    * Handle mousedown events/
    */
-  mouseDownHandler(evt) {}
+  mouseDownHandler(evt) { }
 
   onScrollHandler() {
     if (this.sizeMode !== SIZE_MODE_SCROLL) return;
@@ -4906,8 +4906,8 @@ class HiGlassComponent extends React.Component {
       relPos[1] += this.scrollTop;
       const hoveredTracks = hoveredTiledPlot
         ? hoveredTiledPlot
-            .listTracksAtPosition(relPos[0], relPos[1], true)
-            .map((track) => track.originalTrack || track)
+          .listTracksAtPosition(relPos[0], relPos[1], true)
+          .map((track) => track.originalTrack || track)
         : [];
       const hoveredTrack = hoveredTracks.find(
         (track) => !track.isAugmentationTrack,
@@ -4915,16 +4915,23 @@ class HiGlassComponent extends React.Component {
 
       const relTrackPos = hoveredTrack
         ? [
-            relPos[0] - hoveredTrack.position[0],
-            relPos[1] - hoveredTrack.position[1],
-          ]
+          relPos[0] - hoveredTrack.position[0],
+          relPos[1] - hoveredTrack.position[1],
+        ]
         : relPos;
+
+      const viewUid = hoveredTiledPlot?.props
+        ? hoveredTiledPlot.props.uid
+        : undefined;
+      const trackUid = hoveredTrack ? hoveredTrack.id : undefined;
 
       const evtToPublish = {
         x: relPos[0],
         y: relPos[1],
         relTrackX: hoveredTrack?.flipText ? relTrackPos[1] : relTrackPos[0],
         relTrackY: hoveredTrack?.flipText ? relTrackPos[0] : relTrackPos[1],
+        viewUid,
+        trackUid,
         track: hoveredTrack,
         origEvt: nativeEvent,
         sourceUid: this.uid,
@@ -5035,7 +5042,7 @@ class HiGlassComponent extends React.Component {
             chooseTrackHandler={
               this.state.chooseTrackHandler
                 ? (trackId, evt) =>
-                    this.state.chooseTrackHandler(view.uid, trackId, evt)
+                  this.state.chooseTrackHandler(view.uid, trackId, evt)
                 : null
             }
             customDialog={this.state.customDialog}
@@ -5195,8 +5202,8 @@ class HiGlassComponent extends React.Component {
         );
         const multiTrackHeader =
           this.isEditable() &&
-          !this.isViewHeaderDisabled() &&
-          !this.state.viewConfig.hideHeader ? (
+            !this.isViewHeaderDisabled() &&
+            !this.state.viewConfig.hideHeader ? (
             <ViewHeader
               ref={(c) => {
                 this.viewHeaders[view.uid] = c;
@@ -5294,8 +5301,8 @@ class HiGlassComponent extends React.Component {
 
     let layouts = this.mounted
       ? Object.values(this.state.views)
-          .filter((view) => view.layout)
-          .map((view) => view.layout)
+        .filter((view) => view.layout)
+        .map((view) => view.layout)
       : [];
 
     layouts = JSON.parse(JSON.stringify(layouts)); // make sure to copy the layouts

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -75,20 +75,20 @@ describe('API Tests', () => {
       );
       expect(tiledPlotBBox.height).to.equal(
         totalViewHeight +
-          options.viewPaddingTop +
-          options.viewPaddingBottom +
-          options.viewMarginTop +
-          options.viewMarginBottom,
+        options.viewPaddingTop +
+        options.viewPaddingBottom +
+        options.viewMarginTop +
+        options.viewMarginBottom,
       );
       expect(trackRendererBBox.width).to.equal(
         topTrackBBox.width + options.viewPaddingLeft + options.viewPaddingRight,
       );
       expect(tiledPlotBBox.width).to.equal(
         topTrackBBox.width +
-          options.viewPaddingLeft +
-          options.viewPaddingRight +
-          options.viewMarginLeft +
-          options.viewMarginRight,
+        options.viewPaddingLeft +
+        options.viewPaddingRight +
+        options.viewMarginLeft +
+        options.viewMarginRight,
       );
     });
 
@@ -519,22 +519,23 @@ describe('API Tests', () => {
 
       const promise = new Promise((done) => {
         api.on('wheel', (e) => {
-          expect(e.origEvt.clientX).to.equal(30);
-          expect(e.origEvt.clientY).to.equal(40);
-          done(null);
+          expect(e.origEvt.clientX).toEqual(150);
+          expect(e.origEvt.clientY).toEqual(250);
+          expect(e.viewUid).toEqual('a');
+          expect(e.trackUid).toEqual('heatmap');
         });
       });
 
       const canvas = div.querySelector('canvas');
       // The wheel event that we expect to catch.
       const wheelEvent = {
-        clientX: 30,
-        clientY: 40,
+        clientX: 150,
+        clientY: 250,
         forwarded: true,
         target: canvas,
         nativeEvent: undefined,
-        stopPropagation: () => {},
-        preventDefault: () => {},
+        stopPropagation: () => { },
+        preventDefault: () => { },
       };
       // Simulate the wheel and keyboard events.
       hgc.wheelHandler(wheelEvent);

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -75,20 +75,20 @@ describe('API Tests', () => {
       );
       expect(tiledPlotBBox.height).to.equal(
         totalViewHeight +
-        options.viewPaddingTop +
-        options.viewPaddingBottom +
-        options.viewMarginTop +
-        options.viewMarginBottom,
+          options.viewPaddingTop +
+          options.viewPaddingBottom +
+          options.viewMarginTop +
+          options.viewMarginBottom,
       );
       expect(trackRendererBBox.width).to.equal(
         topTrackBBox.width + options.viewPaddingLeft + options.viewPaddingRight,
       );
       expect(tiledPlotBBox.width).to.equal(
         topTrackBBox.width +
-        options.viewPaddingLeft +
-        options.viewPaddingRight +
-        options.viewMarginLeft +
-        options.viewMarginRight,
+          options.viewPaddingLeft +
+          options.viewPaddingRight +
+          options.viewMarginLeft +
+          options.viewMarginRight,
       );
     });
 
@@ -534,8 +534,8 @@ describe('API Tests', () => {
         forwarded: true,
         target: canvas,
         nativeEvent: undefined,
-        stopPropagation: () => { },
-        preventDefault: () => { },
+        stopPropagation: () => {},
+        preventDefault: () => {},
       };
       // Simulate the wheel and keyboard events.
       hgc.wheelHandler(wheelEvent);

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -526,20 +526,17 @@ describe('API Tests', () => {
         });
       });
 
-      const canvas = div.querySelector('canvas');
+      // dispatch a real event
+      div.querySelector('canvas').dispatchEvent(
+        new WheelEvent('wheel', {
+          clientX: 300,
+          clientY: 150,
+          deltaY: 10,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
 
-      // The wheel event that we expect to catch.
-      const wheelEvent = {
-        clientX: 300,
-        clientY: 150,
-        forwarded: true,
-        target: canvas,
-        nativeEvent: undefined,
-        stopPropagation: () => {},
-        preventDefault: () => {},
-      };
-      // Simulate the wheel and keyboard events.
-      hgc.wheelHandler(wheelEvent);
       await promise;
     });
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -21,7 +21,6 @@ import simpleHeatmapViewConf from './view-configs/simple-heatmap.json';
 
 import createElementAndApi from './utils/create-element-and-api';
 import removeDiv from './utils/remove-div';
-// import drag from './utils/drag';
 
 import { version as VERSION } from '../package.json';
 
@@ -519,18 +518,20 @@ describe('API Tests', () => {
 
       const promise = new Promise((done) => {
         api.on('wheel', (e) => {
-          expect(e.origEvt.clientX).toEqual(150);
-          expect(e.origEvt.clientY).toEqual(250);
+          expect(e.origEvt.clientX).toEqual(300);
+          expect(e.origEvt.clientY).toEqual(150);
           expect(e.viewUid).toEqual('a');
           expect(e.trackUid).toEqual('heatmap');
+          done(null);
         });
       });
 
       const canvas = div.querySelector('canvas');
+
       // The wheel event that we expect to catch.
       const wheelEvent = {
-        clientX: 150,
-        clientY: 250,
+        clientX: 300,
+        clientY: 150,
         forwarded: true,
         target: canvas,
         nativeEvent: undefined,


### PR DESCRIPTION
## Description

> What was changed in this pull request?

This pull request adds the properties `trackUid` and `viewUid` to the object that is published on wheel events (that have been registered via `.on('wheel', callback)` using the JS API).

> Why is it necessary?

Currently, wheel events only publish the track with which they are associated. However, this could be ambiguous if one wants to identify the track since there is no information about the parent view. To be more precise about which track a wheel event is associated with, we can also include the view UID in the event object.


Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [x] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
