### PR TITLE
Properly position the track config menu when clicked twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed bug where heatmap labels could not be hidden.
 - The position of labels and colorbars for split heatmaps can now be changed.
 - Use itemRgb field in bed files as the default coloring for bedlike tracks
+- Fixed bug where the track config menu improperly positioned when clicked twice.
 
 _[Detailed changes since v1.9.2](https://github.com/higlass/higlass/compare/v1.9.2...v.1.9.3)_
 

--- a/app/scripts/TrackControl.js
+++ b/app/scripts/TrackControl.js
@@ -30,9 +30,6 @@ const getButtonClassNames = props => {
   return buttonClassName;
 };
 
-let imgConfig;
-let imgClose;
-
 let oldProps = null;
 let DragHandle = null;
 
@@ -59,6 +56,9 @@ const TrackControl = props => {
       </svg>
     ));
   }
+
+  let imgConfig;
+  let imgClose;
 
   return (
     <div styleName={getClassNames(props)}>


### PR DESCRIPTION
## Description

> What was changed in this pull request?

The track config menu was positioned improperly when the control button is clicked twice. This bug occurred mainly because `imgConfig` and `imgClose`, which are the variables that are used to get the position of the cursor (e.g., `imgConfig.getBoundingClientRect()`), store the lastly rendered `ref`, such as the `ref` of a center track shown in the gif below.

> Why is it necessary?

Before:
![fix-910-before](https://user-images.githubusercontent.com/9922882/81481540-f8327b00-91fe-11ea-82f0-6e0ad771aba3.gif)

After:
![fix-910-after](https://user-images.githubusercontent.com/9922882/81481666-ab02d900-91ff-11ea-8a9e-37bec9dda595.gif)

Fixes #910

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [x] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
