### PR TITLE
Make sure setViewConfig promise resolves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Release notes
 
+- Added the `resolveImmediately` parameter to the setViewConfig API call.
 - Zooming can now be restricted by specifying `zoomLimits` in the viewconf.
 - Fixed bug where the track config menu improperly positioned when clicked twice.
 - Update the heatmap option interface to allow seeing the preview when a color picker is opened.

--- a/app/scripts/api.js
+++ b/app/scripts/api.js
@@ -176,6 +176,8 @@ const createApi = function api(context, pubSub) {
        *
        * @param {obj} newViewConfig A JSON object that defines
        *    the state of the HiGlassComponent
+       * @param {boolean} resolveImmediately If true, the returned promise resolves immediately
+       *    even if not all data has loaded. This should be set to true, if the new viewconf does not request new data. Default: false.
        * @example
        *
        * const p = hgv.setViewConfig(newViewConfig);
@@ -184,9 +186,10 @@ const createApi = function api(context, pubSub) {
        * });
        *
        * @return {Promise} dataLoaded A promise that resolves when
-       *   all of the data for this viewconfig is loaded
+       *   all of the data for this viewconfig is loaded. If `resolveImmediately` is set to true,
+       * the promise resolves without waiting for the data to be loaded.
        */
-      setViewConfig(newViewConfig) {
+      setViewConfig(newViewConfig, resolveImmediately = false) {
         const validate = new Ajv().compile(schema);
         const valid = validate(newViewConfig);
         if (validate.errors) {
@@ -222,7 +225,11 @@ const createApi = function api(context, pubSub) {
               viewConfig: newViewConfig,
               views: viewsByUid
             },
-            () => {}
+            () => {
+              if (resolveImmediately) {
+                resolve();
+              }
+            }
           );
         });
 

--- a/test/APITests.js
+++ b/test/APITests.js
@@ -858,6 +858,28 @@ describe('API Tests', () => {
       });
     });
 
+    it('can modify and set the viewconf', done => {
+      [div, api] = createElementAndApi(simpleHeatmapViewConf, {
+        editable: true
+      });
+
+      const hgc = api.getComponent();
+
+      waitForTilesLoaded(hgc, () => {
+        const newConfig = JSON.parse(JSON.stringify(simpleCenterViewConfig));
+        newConfig.views[0].tracks.center[0].options.name = 'Modified name';
+
+        // Ckeck that the promise resolves
+        api.setViewConfig(newConfig, true).then(() => {
+          const retrievedViewConf = api.getViewConfig();
+          const newName =
+            retrievedViewConf.views[0].tracks.center[0].options.name;
+          expect(newName).toEqual('Modified name');
+          done();
+        });
+      });
+    });
+
     afterEach(() => {
       api.destroy();
       removeDiv(div);


### PR DESCRIPTION
## Description

> What was changed in this pull request?

This PR adds the parameter `resolveImmediately` to the `setViewConfig` API function. If set to true, it makes sure that the resulting promise resolves. Currently, when a new viewconfig is set and no new data needs to be loaded, the promise returned by `setViewConfig` does not resolve.


> Why is it necessary?

Promise returned by `setViewConfig` does not always resolve.

Fixes #___

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [x] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
