### PR TITLE
Flekschas/simplify plugin track registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a bug preventing usage of `data.url` and HorizontalMultivecTrack server-side aggregation simultaneously.
 - Fixed a bug preventing an updated value of `track.options.selectRows` from triggering a HorizontalMultivecTrack track update when using server-side aggregation (`track.options.selectRowsAggregationMethod === 'server'`).
+- Simplify plugin track registry
 
 _[Detailed changes since v1.10.2](https://github.com/higlass/higlass/compare/v1.10.2...develop)_
 

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -245,10 +245,12 @@ class HiGlassComponent extends React.Component {
 
     const pluginTracks = {};
     try {
-      if (window.higlassTracks) {
-        Object.values(window.higlassTracks).forEach(trackDef => {
-          pluginTracks[trackDef.config.type] = trackDef;
-        });
+      if (window.higlassTracksByType) {
+        Object.entries(window.higlassTracksByType).forEach(
+          ([trackType, trackDef]) => {
+            pluginTracks[trackType] = trackDef;
+          },
+        );
       }
     } catch (e) {
       console.warn(

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,7 +8,7 @@ module.exports = config => {
     browserDisconnectTolerance: 2,
     /** * How long will Karma wait for a message from a browser before
      * disconnecting from it (in ms). */
-    browserNoActivityTimeout: 50000,
+    browserNoActivityTimeout: 90000,
     basePath: '',
     frameworks: ['jasmine'],
 


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Simplify plugin track registry to only rely on `window. higlassTracksByType`

> Why is it necessary?

Remove unnecessary reliance on `window.higlassTracks`

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
