### PR TITLE
Add ChromosomeInfo and SearchField to AVAILABLE_FOR_PLUGINS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Next
 
+- Added `ChromosomeInfo` and `SearchField` classes to `AVAILABLE_TO_PLUGINS`.
+
+_[Detailed changes since v1.10.2](https://github.com/higlass/higlass/compare/v1.11.0...develop)_
+
+## v1.11.0
+
 - Make gene annotations rotatable so that they can be added on the left
 - Tracks can now modify their own dimensions by publishing `trackDimensionsModified`.
 - Fixed a bug preventing usage of `data.url` and HorizontalMultivecTrack server-side aggregation simultaneously.
@@ -9,9 +15,8 @@
 - Added the JS API `.on('geneSearch', callback)` option for subscribing to gene search events.
 - Simplify plugin track registry
 - Implemented plugin data fetchers.
-- Added `ChromosomeInfo` and `SearchField` classes to `AVAILABLE_TO_PLUGINS`.
 
-_[Detailed changes since v1.10.2](https://github.com/higlass/higlass/compare/v1.10.2...develop)_
+_[Detailed changes since v1.10.2](https://github.com/higlass/higlass/compare/v1.10.2...v1.11.0)_
 
 ## v1.10.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added the JS API `.on('geneSearch', callback)` option for subscribing to gene search events.
 - Simplify plugin track registry
 - Implemented plugin data fetchers.
+- Added `ChromosomeInfo` and `SearchField` classes to `AVAILABLE_TO_PLUGINS`.
 
 _[Detailed changes since v1.10.2](https://github.com/higlass/higlass/compare/v1.10.2...develop)_
 

--- a/app/scripts/configs/available-for-plugins.js
+++ b/app/scripts/configs/available-for-plugins.js
@@ -71,6 +71,10 @@ import LruCache from '../factories';
 // Services
 import * as services from '../services';
 
+// Chromosomes
+import ChromosomeInfo from '../ChromosomeInfo';
+import SearchField from '../SearchField';
+
 const libraries = {
   d3Array,
   d3Axis,
@@ -88,7 +92,7 @@ const libraries = {
   d3Zoom,
   PIXI: configs.GLOBALS.PIXI,
   mix,
-  slugid
+  slugid,
 };
 
 const tracks = {
@@ -125,16 +129,22 @@ const tracks = {
   Track,
   ValueIntervalTrack,
   VerticalTiled1DPixiTrack,
-  VerticalTrack
+  VerticalTrack,
 };
 
 const factories = {
   ContextMenuItem,
   DataFetcher,
-  LruCache
+  LruCache,
+};
+
+const chromosomes = {
+  ChromosomeInfo,
+  SearchField,
 };
 
 export default {
+  chromosomes,
   libraries,
   tracks,
   factories,
@@ -142,5 +152,5 @@ export default {
   utils,
   configs,
   // Defined globally by webpack.
-  VERSION
+  VERSION,
 };

--- a/docs/available_to_plugins.rst
+++ b/docs/available_to_plugins.rst
@@ -205,6 +205,14 @@ Configs
 - POSITIONS_BY_DATATYPE
 - DEFAULT_TRACKS_FOR_DATATYPE
 
+Chromosomes
+-------
+
+**Prefix:** ``chromosomes`` (e.g., ``HGC.chromosomes.ChromosomeInfo``)
+
+- ChromosomeInfo
+- SearchField
+
 Other
 -----
 


### PR DESCRIPTION
## Description

> What was changed in this pull request?

This makes `ChromosomeInfo` and `SearchField` classes available to plugins under a new `HGC.chromosomes` object.

> Why is it necessary?

I realized that these classes are required to build a plugin track for serverless chromsizes datasets.

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [x] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
