### PR TITLE
Fix state bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added the JS API `.on('geneSearch', callback)` option for subscribing to gene search events.
 - Simplify plugin track registry
 - Implemented plugin data fetchers.
+- Fixed a bug in which `HiGlassComponent.getTrackInfo` was trying to access `this.state` prior to it being initialized.
 
 _[Detailed changes since v1.10.2](https://github.com/higlass/higlass/compare/v1.10.2...develop)_
 

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -2172,8 +2172,8 @@ class HiGlassComponent extends React.Component {
       return TRACKS_INFO_BY_TYPE[trackType];
     }
 
-    if (this.state.pluginTracks && this.state.pluginTracks[trackType]) {
-      return this.state.pluginTracks[trackType].config;
+    if (window.higlassTracksByType && window.higlassTracksByType[trackType]) {
+      return window.higlassTracksByType[trackType].config;
     }
 
     console.warn(


### PR DESCRIPTION
## Description

> What was changed in this pull request?

This reverts two lines changed in #965 . @pkerpedjiev was there a reason those lines were updated in that PR? Sorry for not clarifying when reviewing #965.

> Why is it necessary?

It appears that the `getTrackInfo` function may be called in the constructor of HiGlassComponent, before the state has been set up, which causes an error:

![Screen Shot 2020-08-07 at 4 56 41 PM](https://user-images.githubusercontent.com/7525285/89688008-44a95780-d8cf-11ea-9f69-19fd706c1e44.png)


Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
