### PR TITLE
Fix plugin track registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Release notes
 
+- Fix registration of plugin tracks
+
 ## v1.11.1
 
 - Fix multivec SVG export

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -2177,6 +2177,10 @@ class HiGlassComponent extends React.Component {
       return this.pluginTracks[trackType].config;
     }
 
+    if (window.higlassTracksByType && window.higlassTracksByType[trackType]) {
+      return window.higlassTracksByType[trackType].config;
+    }
+
     console.warn(
       'Track type not found:',
       trackType,


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Plugin track infos are pulled from `window.higlassTracksByType` instead of `this.pluginTracks` (if available)


> Why is it necessary?

Options that are defined within plugin tracks are currently not correctly passed into the plugin track constructor.

Fixes #___

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
