### PR TITLE
Ignore filler annotations when rendering gene annotation names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release notes
 
 - Fix registration of plugin tracks
+- Don't try to render names of filler annotations
 
 ## v1.11.1
 

--- a/app/scripts/HorizontalGeneAnnotationsTrack.js
+++ b/app/scripts/HorizontalGeneAnnotationsTrack.js
@@ -132,6 +132,10 @@ function externalInitTile(track, tile, options) {
   tile.tileData = geneEntries.concat(fillerEntries);
 
   tile.tileData.forEach((td, i) => {
+    if (td.type === 'filler') {
+      return;
+    }
+
     const geneInfo = td.fields;
     const geneName = geneInfo[3];
     const geneId = track.geneId(geneInfo, td.type);
@@ -736,9 +740,11 @@ class HorizontalGeneAnnotationsTrack extends HorizontalTiled1DPixiTrack {
         tile.tileData.forEach(td => {
           // tile probably hasn't been initialized yet
           if (!tile.texts) return;
+          if (td.type === 'filler') return;
 
           const geneInfo = td.fields;
           const geneName = geneInfo[3];
+
           const geneId = this.geneId(geneInfo, td.type);
 
           const text = tile.texts[geneId];
@@ -891,13 +897,11 @@ class HorizontalGeneAnnotationsTrack extends HorizontalTiled1DPixiTrack {
 
     for (const tile of this.visibleAndFetchedTiles()) {
       for (let i = 0; i < tile.allRects.length; i++) {
-        // console.log('tile.allRects:', tile.allRects);
         // copy the visible rects array
         if (tile.allRects[i][2].type === 'filler') {
           continue;
         }
         const rect = tile.allRects[i][0].slice(0);
-        // console.log('rect:', rect);
 
         const newArr = [];
         while (rect.length) {
@@ -915,7 +919,6 @@ class HorizontalGeneAnnotationsTrack extends HorizontalTiled1DPixiTrack {
         const pc = classifyPoint(newArr, point);
 
         if (pc === -1) {
-          // console.log('ar:', tile.allRects[i]);
           const gene = tile.allRects[i][2];
 
           return `


### PR DESCRIPTION
## Description

> What was changed in this pull request?

- It ignores filler annotations when rendering gene annotations

> Why is it necessary?

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
