### PR TITLE
Show all available track types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## Next
+
+- Show a more comprehensive list of track types in the track config menu
+
 ## v1.11.2
 
 - Fix registration of plugin tracks

--- a/app/scripts/SeriesListMenu.js
+++ b/app/scripts/SeriesListMenu.js
@@ -5,12 +5,7 @@ import ContextMenuItem from './ContextMenuItem';
 import NestedContextMenu from './NestedContextMenu';
 
 // Configs
-import {
-  OPTIONS_INFO,
-  THEME_DARK,
-  TRACKS_INFO,
-  TRACKS_INFO_BY_TYPE,
-} from './configs';
+import { OPTIONS_INFO, THEME_DARK, TRACKS_INFO_BY_TYPE } from './configs';
 
 // Styles
 import '../styles/ContextMenu.module.scss';
@@ -187,13 +182,12 @@ export default class SeriesListMenu extends ContextMenuContainer {
     }
 
     // see which other tracks can display a similar datatype
-    const availableTrackTypes = TRACKS_INFO.filter(x => x.datatype)
+    const availableTrackTypes = Object.values(TRACKS_INFO_BY_TYPE)
+      .filter(x => x.datatype)
       .filter(x => x.orientation)
       .filter(x => x.datatype.includes(datatype))
       .filter(x => x.orientation === orientation)
       .map(x => x.type);
-
-    // console.log('availableTrackTypes:', availableTrackTypes);
 
     const menuItems = {};
     for (let i = 0; i < availableTrackTypes.length; i++) {


### PR DESCRIPTION
## Description

> What was changed in this pull request?

- When changing the track type for a track, the `TRACKS_INFO_BY_TYPE` includes plugin track types so we should use that.

![image](https://user-images.githubusercontent.com/2143629/91177569-e98aa980-e6b1-11ea-925d-113e8a5f564c.png)


> Why is it necessary?

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [x] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
