### PR TITLE
Fix gene annotation mouseover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 
 - Show a more comprehensive list of track types in the track config menu
+- Fix gene annotation mouseover
 
 ## v1.11.2
 

--- a/app/scripts/HorizontalGeneAnnotationsTrack.js
+++ b/app/scripts/HorizontalGeneAnnotationsTrack.js
@@ -925,8 +925,9 @@ class HorizontalGeneAnnotationsTrack extends HorizontalTiled1DPixiTrack {
 
           return `
             <div>
-              <p><b>${gene.fields[3]}</b></p>
-              <p>${gene.fields[0]}:${gene.fields[1]}-${gene.fields[2]} Strand: ${gene.strand}</p>
+              <b>${gene.fields[3]}</b><br>
+              <b>Position:</b> ${gene.fields[0]}:${gene.fields[1]}-${gene.fields[2]}<br>
+              <b>Strand:</b> ${gene.fields[5]}
             </div>
           `;
         }


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Fixes the mouseover for the gene annotation track


> Why is it necessary?

Currently the mouseover shows "Strand: undefined"

Fixes #___

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
