### PR TITLE
Empty selectRows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Show a more comprehensive list of track types in the track config menu
 - Show only integar ticks in `HorizontalChromosomeLabels` tracks because it is misleading to have decimal values in genomic coordinates.
 - Add a `reverseOrientation` option in `HorizontalChromosomeLabels` tracks to allow aligning tick labels and lines on the top or left.
+- Fix a bug that led to the app crash when `selectRows` is set to an empty array `[]`
 
 ## v1.11.2
 

--- a/app/scripts/HorizontalMultivecTrack.js
+++ b/app/scripts/HorizontalMultivecTrack.js
@@ -97,7 +97,10 @@ export default class HorizontalMultivecTrack extends HeatmapTiledPixiTrack {
     ctx.fillStyle = 'transparent';
     ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-    if (pixData.length === 4 * canvas.width * canvas.height) {
+    if (
+      pixData.length !== 0 &&
+      pixData.length === 4 * canvas.width * canvas.height
+    ) {
       const pix = new ImageData(pixData, canvas.width, canvas.height);
       ctx.putImageData(pix, 0, 0);
     } else {


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Prevent from app crash when `[]` is set to the `selectRows` option in multivec heatmaps

> Why is it necessary?

Fixes #989 

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [X] Updated CHANGELOG.md
