### PR TITLE
Flekschas/export overlays as svg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Show a more comprehensive list of track types in the track config menu
 - Show only integar ticks in `HorizontalChromosomeLabels` tracks because it is misleading to have decimal values in genomic coordinates.
 - Add a `reverseOrientation` option in `HorizontalChromosomeLabels` tracks to allow aligning tick labels and lines on the top or left.
+- Make overlays SVG exportable
 
 ## v1.11.2
 

--- a/app/scripts/OverlayTrack.js
+++ b/app/scripts/OverlayTrack.js
@@ -86,7 +86,7 @@ const drawRectWithPositionedBorder = (
     colors.strokeOpacity = 0;
     colors.strokeWidth = 1;
 
-    outline.positions.forEach(pos => {
+    outline.positions.forEach((pos) => {
       if ((pos === 'top' && !isVertical) || (pos === 'left' && isVertical)) {
         drawRect(
           xPos - outlineWidth,
@@ -168,7 +168,7 @@ const drawRectWithPositionedBorder = (
     colors.strokeOpacity = 0;
     colors.strokeWidth = 1;
 
-    stroke.positions.forEach(pos => {
+    stroke.positions.forEach((pos) => {
       if ((pos === 'top' && !isVertical) || (pos === 'left' && isVertical)) {
         drawRect(xPos, yPos, width, strokeHeight, target, colors);
         finalYPos += strokeHeight;
@@ -378,9 +378,9 @@ class OverlayTrack extends PixiTrack {
     const minHeight = Math.max(0, +this.options.minHeight || 0);
 
     if (Array.isArray(this.options.extent)) {
-      this.options.orientationsAndPositions.forEach(op => {
+      this.options.orientationsAndPositions.forEach((op) => {
         if (op.orientation === '1d-horizontal' || op.orientation === '2d') {
-          this.options.extent.forEach(extent =>
+          this.options.extent.forEach((extent) =>
             this.drawHorizontalOverlay(
               graphics,
               op.position,
@@ -395,7 +395,7 @@ class OverlayTrack extends PixiTrack {
         }
 
         if (op.orientation === '1d-vertical' || op.orientation === '2d') {
-          this.options.extent.forEach(extent =>
+          this.options.extent.forEach((extent) =>
             this.drawVerticalOverlay(
               graphics,
               op.position,

--- a/app/scripts/utils/dec-to-hex-str.js
+++ b/app/scripts/utils/dec-to-hex-str.js
@@ -1,0 +1,3 @@
+const decToHexStr = dec => (dec + 16 ** 6).toString(16).substr(-6);
+
+export default decToHexStr;

--- a/app/scripts/utils/index.js
+++ b/app/scripts/utils/index.js
@@ -11,6 +11,7 @@ export { default as colorToHex } from './color-to-hex';
 export { default as colorToRgba } from './color-to-rgba';
 export { default as dataToGenomicLoci } from './data-to-genomic-loci';
 export { default as debounce } from './debounce';
+export { default as decToHexStr } from './dec-to-hex-str';
 export { default as dictFromTuples } from './dict-from-tuples';
 export { default as dictItems } from './dict-items';
 export { default as dictKeys } from './dict-keys';

--- a/docs/examples/apis/svg.html
+++ b/docs/examples/apis/svg.html
@@ -9,10 +9,10 @@
 <style type="text/css">
 #demo {
   position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  right: 0;
+  left: 1rem;
+  top: 1rem;
+  bottom: 1rem;
+  right: 1rem;
   overflow: hidden;
   height: 50%;
 }

--- a/docs/examples/viewconfs/overlay-tracks.json
+++ b/docs/examples/viewconfs/overlay-tracks.json
@@ -245,53 +245,6 @@
             "extent": [
               [1000000000, 1100000000],
               [1200000000, 1300000000, 1400000000, 1500000000]
-            ],
-            "orientationsAndPositions": [
-              {
-                "orientation": "1d-horizontal",
-                "position": {
-                  "left": 95,
-                  "top": 60,
-                  "width": 1057,
-                  "height": 35
-                }
-              },
-              {
-                "orientation": "1d-vertical",
-                "position": {
-                  "left": 60,
-                  "top": 95,
-                  "width": 35,
-                  "height": 1240
-                }
-              },
-              {
-                "orientation": "1d-horizontal",
-                "position": {
-                  "left": 95,
-                  "top": 5,
-                  "width": 1057,
-                  "height": 55
-                }
-              },
-              {
-                "orientation": "1d-vertical",
-                "position": {
-                  "left": 5,
-                  "top": 95,
-                  "width": 55,
-                  "height": 1240
-                }
-              },
-              {
-                "orientation": "2d",
-                "position": {
-                  "left": 95,
-                  "top": 95,
-                  "width": 1057,
-                  "height": 1240
-                }
-              }
             ]
           }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4144,7 +4144,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -4534,7 +4534,7 @@
       }
     },
     "css-element-queries": {
-      "version": "github:marcj/css-element-queries#31cabb56fb2af08470159251f6e535e2c3577758",
+      "version": "github:marcj/css-element-queries#8f127c7c96cb8c21253cbe07cf2f1a826ac0b575",
       "from": "github:marcj/css-element-queries"
     },
     "css-loader": {
@@ -6126,7 +6126,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -6514,7 +6514,7 @@
     },
     "es6-promise-polyfill": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.zymergen.net:443/api/npm/zymergen-npm/es6-promise-polyfill/-/es6-promise-polyfill-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promise-polyfill/-/es6-promise-polyfill-1.2.0.tgz",
       "integrity": "sha1-84kl8jyz4+jObNqP93T867sJDN4=",
       "dev": true
     },
@@ -12537,7 +12537,7 @@
     },
     "mini-signals": {
       "version": "1.2.0",
-      "resolved": "https://artifactory.zymergen.net:443/api/npm/zymergen-npm/mini-signals/-/mini-signals-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/mini-signals/-/mini-signals-1.2.0.tgz",
       "integrity": "sha1-RbCAE8X65RokqhqTXNMXye1yHXQ=",
       "dev": true
     },
@@ -12563,7 +12563,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mississippi": {
@@ -14008,7 +14008,7 @@
     },
     "parse-uri": {
       "version": "1.0.0",
-      "resolved": "https://artifactory.zymergen.net:443/api/npm/zymergen-npm/parse-uri/-/parse-uri-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-uri/-/parse-uri-1.0.0.tgz",
       "integrity": "sha1-KHLcwi8aeXrN4Vg9igrClVLdrCA=",
       "dev": true
     },
@@ -17519,7 +17519,7 @@
     },
     "readable-stream": {
       "version": "1.0.34",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
       "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -21531,7 +21531,7 @@
     },
     "yargs": {
       "version": "3.10.0",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "requires": {
         "camelcase": "^1.0.2",


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Implement SVG export of overlays.

Example screenshot from http://localhost:8080/apis/svg.html?/viewconfs/overlay-tracks.json:

<img width="969" alt="Screen Shot 2020-10-23 at 10 03 23 AM" src="https://user-images.githubusercontent.com/932103/97013788-78cc0600-1517-11eb-9636-728d53461871.png">

> Why is it necessary?

To see overlays in the exported SVG

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [x] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [x] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
