### PR TITLE
Use alt key for value scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Use alt key for value scaling rather than the shift key
+
 _[Detailed changes since v1.11.2](https://github.com/higlass/higlass/compare/v1.11.3...develop)_
 
 ## v1.11.3

--- a/app/scripts/TrackRenderer.js
+++ b/app/scripts/TrackRenderer.js
@@ -1169,7 +1169,7 @@ class TrackRenderer extends React.Component {
     if (trackOrientation && event.sourceEvent) {
       // if somebody is holding down the shift key and is zooming over
       // a 1d track, try to apply value scale zooming
-      if (event.shiftKey || this.valueScaleZooming) {
+      if (event.altKey || this.valueScaleZooming) {
         if (event.sourceEvent.deltaY !== undefined) {
           this.valueScaleZoom(trackOrientation);
           return;
@@ -1275,7 +1275,7 @@ class TrackRenderer extends React.Component {
         event.sourceEvent,
       );
 
-      if (event.sourceEvent.shiftKey) {
+      if (event.sourceEvent.altKey) {
         this.valueScaleZooming = true;
       }
     }


### PR DESCRIPTION
## Description

> What was changed in this pull request?

- Use the alt key for value scaling rather than the shift key

> Why is it necessary?

- So that we can reserve the shift key for enabling brushing behavio

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
