### PR TITLE
Fix colorbar error when valueScale is degenerate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Next
 
-_[Detailed changes since v1.11.2](https://github.com/higlass/higlass/compare/v1.11.3...develop)_
+- Fix colorbar error on degenerate colorscale
+
+_[Detailed changes since v1.11.3](https://github.com/higlass/higlass/compare/v1.11.3...develop)_
 
 ## v1.11.3
 

--- a/app/scripts/HeatmapTiledPixiTrack.js
+++ b/app/scripts/HeatmapTiledPixiTrack.js
@@ -617,6 +617,12 @@ class HeatmapTiledPixiTrack extends TiledPixiTrack {
       return;
     }
 
+    if (this.valueScale.domain()[1] === this.valueScale.domain()[0]) {
+      // degenerate color bar
+      this.removeColorbar();
+      return;
+    }
+
     const axisValueScale = this.valueScale
       .copy()
       .range([this.colorbarHeight, 0]);


### PR DESCRIPTION
## Description

> What was changed in this pull request?

- Check for a one-value valueScale and don't try to draw a colorbar in it

> Why is it necessary?

- The colorbar code errors out otherwise

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
