### PR TITLE
Fix gene annotation mouseover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ _[Detailed changes since v1.11.2](https://github.com/higlass/higlass/compare/v1.
 - Make overlays SVG exportable
 - Fix a bug that led to the app crash when `selectRows` is set to an empty array `[]`
 - Break up and turn off some tests
+- Fix gene annotation mouseover
 
 _[Detailed changes since v1.11.2](https://github.com/higlass/higlass/compare/v1.11.2...v1.11.3)_
 

--- a/app/scripts/HorizontalGeneAnnotationsTrack.js
+++ b/app/scripts/HorizontalGeneAnnotationsTrack.js
@@ -925,8 +925,9 @@ class HorizontalGeneAnnotationsTrack extends HorizontalTiled1DPixiTrack {
 
           return `
             <div>
-              <p><b>${gene.fields[3]}</b></p>
-              <p>${gene.fields[0]}:${gene.fields[1]}-${gene.fields[2]} Strand: ${gene.strand}</p>
+              <b>${gene.fields[3]}</b><br>
+              <b>Position:</b> ${gene.fields[0]}:${gene.fields[1]}-${gene.fields[2]}<br>
+              <b>Strand:</b> ${gene.fields[5]}
             </div>
           `;
         }


### PR DESCRIPTION
This is a copy of https://github.com/higlass/higlass/pull/983 (already approved)
Had to start over due to some weird merge issues.

## Description

> What was changed in this pull request?

Fixes the mouseover for the gene annotation track


> Why is it necessary?

Currently the mouseover shows "Strand: undefined"

Fixes #___

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
