### PR TITLE
Add a zoomToGene API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Add a zoomToGene API that allows to zoom a HiGlass view to a location near a certain gene.
+
 _[Detailed changes since v1.11.4](https://github.com/higlass/higlass/compare/v1.11.4...develop)_
 
 ## v1.11.4

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -4063,18 +4063,23 @@ class HiGlassComponent extends React.Component {
       );
     }
 
-    const autocompleteServer = this.state.views[viewUid].genomePositionSearchBox
-      .autocompleteServer;
-    const autocompleteId = this.state.views[viewUid].genomePositionSearchBox
-      .autocompleteId;
-    const chromInfoPath = this.state.views[viewUid].chromInfoPath;
-
-    if (!autocompleteServer || !autocompleteId || !chromInfoPath) {
+    if (
+      !this.state.views[viewUid].genomePositionSearchBox ||
+      !this.state.views[viewUid].genomePositionSearchBox.autocompleteServer ||
+      !this.state.views[viewUid].genomePositionSearchBox.autocompleteId ||
+      !this.state.views[viewUid].chromInfoPath
+    ) {
       console.warn(
         'Please set chromInfoPath, autocompleteServer, and autocompleteId to use the zoomToGene API',
       );
       return;
     }
+
+    const autocompleteServer = this.state.views[viewUid].genomePositionSearchBox
+      .autocompleteServer;
+    const autocompleteId = this.state.views[viewUid].genomePositionSearchBox
+      .autocompleteId;
+    const chromInfoPath = this.state.views[viewUid].chromInfoPath;
 
     const url = `${autocompleteServer}/suggest/?d=${autocompleteId}&ac=${geneSymbol.toLowerCase()}`;
 

--- a/app/scripts/api.js
+++ b/app/scripts/api.js
@@ -468,6 +468,21 @@ const createApi = function api(context, pubSub) {
       },
 
       /**
+       * Change the current view port to a location near the gene of interest.
+       * When ``animateTime`` is greater than 0, animate the transition.
+       *
+       * @param {string} viewUid The identifier of the view to zoom
+       * @param {string} geneSymbol The name of gene symbol to search
+       * @param {Number} animateTime The time to spend zooming to the specified location
+       * @example
+       * // Zoom to the location near 'MYC'
+       * hgApi.zoomToGene('view1', 'MYC', 2000);
+       */
+      zoomToGene(viewUid, geneSymbol, animateTime = 0) {
+        self.zoomToGene(viewUid, geneSymbol, animateTime);
+      },
+
+      /**
        * Zoom so that the entirety of all the datasets in a view
        * are visible.
        * The passed in ``viewUid`` should refer to a view which is present. If it

--- a/test/APITests.js
+++ b/test/APITests.js
@@ -242,6 +242,22 @@ describe('API Tests', () => {
       });
     });
 
+    it('zooms to the location near a MYC gene', (done) => {
+      [div, api] = createElementAndApi(simpleCenterViewConfig, {
+        editable: false,
+      });
+
+      api.zoomToGene('a', 'MYC', 100);
+
+      waitForTransitionsFinished(api.getComponent(), () => {
+        expect(api.getComponent().xScales.a.domain()[0]).toBeCloseTo(
+          1521544004,
+          -6,
+        );
+        done();
+      });
+    });
+
     it('reset viewport after zoom', (done) => {
       [div, api] = createElementAndApi(simpleHeatmapViewConf, {
         editable: false,

--- a/test/APITests.js
+++ b/test/APITests.js
@@ -251,7 +251,7 @@ describe('API Tests', () => {
 
       waitForTransitionsFinished(api.getComponent(), () => {
         expect(api.getComponent().xScales.a.domain()[0]).toBeCloseTo(
-          1521544004,
+          1480820463,
           -6,
         );
         done();

--- a/test/view-configs-more/simpleCenterViewConfig.json
+++ b/test/view-configs-more/simpleCenterViewConfig.json
@@ -4,6 +4,14 @@
   "trackSourceServers": ["http://higlass.io/api/v1"],
   "views": [
     {
+      "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
+      "genomePositionSearchBox": {
+        "visible": true,
+        "chromInfoServer": "http://higlass.io/api/v1",
+        "chromInfoId": "hg19",
+        "autocompleteServer": "http://higlass.io/api/v1",
+        "autocompleteId": "OHJakQICQD6gTD7skx4EWA"
+      },
       "uid": "a",
       "initialXDomain": [1480820463.833503, 2550144059.1286707],
       "initialYDomain": [1569819845.1080737, 2433776657.2008576],


### PR DESCRIPTION
## Description

> What was changed in this pull request?

This PR adds a `zoomToGene` API that allows zooming a HiGlass view to a location near a certain gene. The location of gene is searched based on view specs: `autocompleteServer` and `autocompleteId`.

```js
hgApi.zoomToGene(
  'view-1', // view id
  'MYC',    // gene name
  2000      // duration of animated transition
);
```

> Why is it necessary?

This allows to reposition the center of a HiGlass view using a gene name, similar to a `zoomTo` API that instead uses absolute positions.

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [x] Unit tests added or updated
- [x] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
