### PR TITLE
Add an option to disable compact layout of RGL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Add a top-level option, `compactLayout`, that controls to allow adding vertical gaps between views.
+
 _[Detailed changes since v1.11.4](https://github.com/higlass/higlass/compare/v1.11.4...develop)_
 
 ## v1.11.4

--- a/app/schema.json
+++ b/app/schema.json
@@ -19,6 +19,7 @@
       "default": true
     },
     "zoomFixed": { "type": "boolean" },
+    "compactLayout": { "type": "boolean" },
     "exportViewUrl": { "type": "string" },
     "trackSourceServers": {
       "type": "array",

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -4908,6 +4908,7 @@ class HiGlassComponent extends React.Component {
         // `useCSSTransforms` (it's default `true`)
         // and set `measureBeforeMount={true}`.
         useCSSTransforms={this.mounted}
+        verticalCompact={this.state.viewConfig.compactLayout}
         width={this.state.width}
       >
         {this.tiledAreas}
@@ -5001,6 +5002,7 @@ class HiGlassComponent extends React.Component {
 HiGlassComponent.defaultProps = {
   options: {},
   zoomFixed: false,
+  compactLayout: true,
 };
 
 HiGlassComponent.propTypes = {
@@ -5009,6 +5011,7 @@ HiGlassComponent.propTypes = {
   viewConfig: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
     .isRequired,
   zoomFixed: PropTypes.bool,
+  compactLayout: PropTypes.bool,
 };
 
 export default HiGlassComponent;


### PR DESCRIPTION
## Description

> What was changed in this pull request?

This PR adds a root-level option of viewConfig, `compactLayout` (default: `true`), that allows to use or disable compact layout of HiGlass views ([verticalCompact in ReactGridLayout](https://github.com/STRML/react-grid-layout/blob/master/test/examples/11-no-vertical-compact.jsx)). This way, vertical gaps can be placed between views w/o using arbitrary `empty` tracks.

```js
{ ...,
  compactLayout: false,
  views: [
    { ..., layout: { w: 12, h: 3, x: 0, y: 0 } },
    { ..., layout: { w: 12, h: 3, x: 0, y: 6 } }
  ]
}
```

![Screen Shot 2020-12-02 at 10 25 17 AM](https://user-images.githubusercontent.com/9922882/100894242-47394980-348a-11eb-9831-63bce572e697.png)

> Why is it necessary?

Vertical gaps between views can be useful for some use cases.

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [x] Update schema.json if there are changes to the viewconf JSON structure format
- [x] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
