### PR TITLE
Add a suggestGene API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Next
 
-- Add a zoomToGene API that allows to zoom a HiGlass view to a location near a certain gene.
+- Add a `zoomToGene` API that allows to zoom a HiGlass view to a location near a certain gene.
+- Add a `suggestGene` API that returns a list of genes of top match for a given keyword based on `autocompleteServer`.
 
 _[Detailed changes since v1.11.4](https://github.com/higlass/higlass/compare/v1.11.4...develop)_
 

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -4054,7 +4054,7 @@ class HiGlassComponent extends React.Component {
     this.setCenters[viewUid](centerX, centerY, k, false, animateTime);
   }
 
-  zoomToGene(viewUid, gene, animateTime) {
+  zoomToGene(viewUid, geneName, animateTime) {
     if (!(viewUid in this.setCenters)) {
       throw Error(
         `Invalid viewUid. Current uuids: ${Object.keys(this.setCenters).join(
@@ -4075,23 +4075,23 @@ class HiGlassComponent extends React.Component {
       return;
     }
 
-    this.suggestGene(viewUid, gene, (suggestions) => {
+    this.suggestGene(viewUid, geneName, (suggestions) => {
       if (suggestions) {
         // extract the position of exact match
         const exactMatch = suggestions.find(
-          (d) => d.gene.toLowerCase() === gene.toLowerCase(),
+          (d) => d.geneName.toLowerCase() === geneName.toLowerCase(),
         );
 
         if (exactMatch) {
-          const { chr, start, end } = exactMatch;
+          const { chr, txStart, txEnd } = exactMatch;
 
           // extract absolute positions
           ChromosomeInfo(
             this.state.views[viewUid].chromInfoPath,
             (loadedChromInfo) => {
               // using the absolution positions, zoom to the position near a gene
-              const startAbs = loadedChromInfo.chrToAbs([chr, start]);
-              const endAbs = loadedChromInfo.chrToAbs([chr, end]);
+              const startAbs = loadedChromInfo.chrToAbs([chr, txStart]);
+              const endAbs = loadedChromInfo.chrToAbs([chr, txEnd]);
 
               const [centerX, centerY, k] = scalesCenterAndK(
                 this.xScales[viewUid].copy().domain([startAbs, endAbs]),
@@ -4103,7 +4103,7 @@ class HiGlassComponent extends React.Component {
             this.pubSub,
           );
         } else {
-          console.warn(`Couldn't find the gene symbol: ${gene}`);
+          console.warn(`Couldn't find the gene symbol: ${geneName}`);
         }
       }
     });
@@ -4139,18 +4139,7 @@ class HiGlassComponent extends React.Component {
     tileProxy
       .json(url, toVoid, this.pubSub)
       .then((suggestions) => {
-        callback(
-          suggestions.map((d) => {
-            // change to use simpler key names just to make it easier to use
-            return {
-              chr: d.chr,
-              start: d.txStart,
-              end: d.txEnd,
-              score: d.score,
-              gene: d.geneName,
-            };
-          }),
-        );
+        callback(suggestions);
       })
       .catch((error) => console.error(error));
   }

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -4054,7 +4054,7 @@ class HiGlassComponent extends React.Component {
     this.setCenters[viewUid](centerX, centerY, k, false, animateTime);
   }
 
-  zoomToGene(viewUid, geneSymbol, animateTime) {
+  zoomToGene(viewUid, gene, animateTime) {
     if (!(viewUid in this.setCenters)) {
       throw Error(
         `Invalid viewUid. Current uuids: ${Object.keys(this.setCenters).join(
@@ -4075,53 +4075,82 @@ class HiGlassComponent extends React.Component {
       return;
     }
 
+    this.suggestGene(viewUid, gene, (suggestions) => {
+      if (suggestions) {
+        // extract the position of exact match
+        const exactMatch = suggestions.find(
+          (d) => d.gene.toLowerCase() === gene.toLowerCase(),
+        );
+
+        if (exactMatch) {
+          const { chr, start, end } = exactMatch;
+
+          // extract absolute positions
+          ChromosomeInfo(
+            this.state.views[viewUid].chromInfoPath,
+            (loadedChromInfo) => {
+              // using the absolution positions, zoom to the position near a gene
+              const startAbs = loadedChromInfo.chrToAbs([chr, start]);
+              const endAbs = loadedChromInfo.chrToAbs([chr, end]);
+
+              const [centerX, centerY, k] = scalesCenterAndK(
+                this.xScales[viewUid].copy().domain([startAbs, endAbs]),
+                this.yScales[viewUid].copy().domain([startAbs, endAbs]),
+              );
+
+              this.setCenters[viewUid](centerX, centerY, k, false, animateTime);
+            },
+            this.pubSub,
+          );
+        } else {
+          console.warn(`Couldn't find the gene symbol: ${gene}`);
+        }
+      }
+    });
+  }
+
+  suggestGene(viewUid, keyword, callback) {
+    if (!(viewUid in this.setCenters)) {
+      throw Error(
+        `Invalid viewUid. Current uuids: ${Object.keys(this.setCenters).join(
+          ',',
+        )}`,
+      );
+    }
+
+    if (
+      !this.state.views[viewUid].genomePositionSearchBox ||
+      !this.state.views[viewUid].genomePositionSearchBox.autocompleteServer ||
+      !this.state.views[viewUid].genomePositionSearchBox.autocompleteId
+    ) {
+      console.warn(
+        'Please set autocompleteServer and autocompleteId to use the suggestGene API',
+      );
+      return;
+    }
+
     const autocompleteServer = this.state.views[viewUid].genomePositionSearchBox
       .autocompleteServer;
     const autocompleteId = this.state.views[viewUid].genomePositionSearchBox
       .autocompleteId;
-    const chromInfoPath = this.state.views[viewUid].chromInfoPath;
 
-    const url = `${autocompleteServer}/suggest/?d=${autocompleteId}&ac=${geneSymbol.toLowerCase()}`;
+    const url = `${autocompleteServer}/suggest/?d=${autocompleteId}&ac=${keyword.toLowerCase()}`;
 
     tileProxy
       .json(url, toVoid, this.pubSub)
-      .then((positions) => {
-        if (positions) {
-          // extract the position of exact match
-          const genePosition = positions.find(
-            (d) => d.geneName.toLowerCase() === geneSymbol.toLowerCase(),
-          );
-
-          if (genePosition) {
-            const { chr, txStart: start, txEnd: end } = genePosition;
-
-            // extract absolute positions
-            ChromosomeInfo(
-              chromInfoPath,
-              (loadedChromInfo) => {
-                // using the absolution positions, zoom to the position near a gene
-                const startAbs = loadedChromInfo.chrToAbs([chr, start]);
-                const endAbs = loadedChromInfo.chrToAbs([chr, end]);
-
-                const [centerX, centerY, k] = scalesCenterAndK(
-                  this.xScales[viewUid].copy().domain([startAbs, endAbs]),
-                  this.yScales[viewUid].copy().domain([startAbs, endAbs]),
-                );
-
-                this.setCenters[viewUid](
-                  centerX,
-                  centerY,
-                  k,
-                  false,
-                  animateTime,
-                );
-              },
-              this.pubSub,
-            );
-          } else {
-            console.warn(`Couldn't find the gene symbol: ${geneSymbol}`);
-          }
-        }
+      .then((suggestions) => {
+        callback(
+          suggestions.map((d) => {
+            // change to use simpler key names just to make it easier to use
+            return {
+              chr: d.chr,
+              start: d.txStart,
+              end: d.txEnd,
+              score: d.score,
+              gene: d.geneName,
+            };
+          }),
+        );
       })
       .catch((error) => console.error(error));
   }

--- a/app/scripts/api.js
+++ b/app/scripts/api.js
@@ -472,14 +472,14 @@ const createApi = function api(context, pubSub) {
        * When ``animateTime`` is greater than 0, animate the transition.
        *
        * @param {string} viewUid The identifier of the view to zoom
-       * @param {string} gene The name of gene symbol to search
+       * @param {string} geneName The name of gene symbol to search
        * @param {Number} animateTime The time to spend zooming to the specified location
        * @example
        * // Zoom to the location near 'MYC'
        * hgApi.zoomToGene('view1', 'MYC', 2000);
        */
-      zoomToGene(viewUid, gene, animateTime = 0) {
-        self.zoomToGene(viewUid, gene, animateTime);
+      zoomToGene(viewUid, geneName, animateTime = 0) {
+        self.zoomToGene(viewUid, geneName, animateTime);
       },
 
       /**
@@ -491,10 +491,10 @@ const createApi = function api(context, pubSub) {
        * @example
        * hgv.suggestGene('view1', 'MY', (suggestions) => {
        *    if(suggestions && suggestions.length > 0) {
-       *      console.log('Gene suggested', suggestions[0].gene);
+       *      console.log('Gene suggested', suggestions[0].geneName);
        *      console.log('Chromosome', suggestions[0].chr);
-       *      console.log('Start position', suggestions[0].start);
-       *      console.log('End position', suggestions[0].end);
+       *      console.log('Start position', suggestions[0].txStart);
+       *      console.log('End position', suggestions[0].txEnd);
        *    }
        * });
        */

--- a/app/scripts/api.js
+++ b/app/scripts/api.js
@@ -472,14 +472,34 @@ const createApi = function api(context, pubSub) {
        * When ``animateTime`` is greater than 0, animate the transition.
        *
        * @param {string} viewUid The identifier of the view to zoom
-       * @param {string} geneSymbol The name of gene symbol to search
+       * @param {string} gene The name of gene symbol to search
        * @param {Number} animateTime The time to spend zooming to the specified location
        * @example
        * // Zoom to the location near 'MYC'
        * hgApi.zoomToGene('view1', 'MYC', 2000);
        */
-      zoomToGene(viewUid, geneSymbol, animateTime = 0) {
-        self.zoomToGene(viewUid, geneSymbol, animateTime);
+      zoomToGene(viewUid, gene, animateTime = 0) {
+        self.zoomToGene(viewUid, gene, animateTime);
+      },
+
+      /**
+       * Get the list of genes of top match for a given keyword.
+       *
+       * @param {string} viewUid The id of the view containing the track.
+       * @param {string} keyword The substring of gene name to search.
+       * @param {function} callback A function to be called upon gene list search.
+       * @example
+       * hgv.suggestGene('view1', 'MY', (suggestions) => {
+       *    if(suggestions && suggestions.length > 0) {
+       *      console.log('Gene suggested', suggestions[0].gene);
+       *      console.log('Chromosome', suggestions[0].chr);
+       *      console.log('Start position', suggestions[0].start);
+       *      console.log('End position', suggestions[0].end);
+       *    }
+       * });
+       */
+      suggestGene(viewUid, keyword, callback) {
+        return self.suggestGene(viewUid, keyword, callback);
       },
 
       /**

--- a/test/APITests.js
+++ b/test/APITests.js
@@ -265,7 +265,9 @@ describe('API Tests', () => {
 
       api.suggestGene('a', 'MY', (suggestions) => {
         expect(
-          suggestions.find((d) => d.gene.toLowerCase() === 'MYC'.toLowerCase()),
+          suggestions.find(
+            (d) => d.geneName.toLowerCase() === 'MYC'.toLowerCase(),
+          ),
         ).not.toBeUndefined();
         done();
       });

--- a/test/APITests.js
+++ b/test/APITests.js
@@ -258,6 +258,19 @@ describe('API Tests', () => {
       });
     });
 
+    it('suggest a list of genes that top match with the given keyword', (done) => {
+      [div, api] = createElementAndApi(simpleCenterViewConfig, {
+        editable: false,
+      });
+
+      api.suggestGene('a', 'MY', (suggestions) => {
+        expect(
+          suggestions.find((d) => d.gene.toLowerCase() === 'MYC'.toLowerCase()),
+        ).not.toBeUndefined();
+        done();
+      });
+    });
+
     it('reset viewport after zoom', (done) => {
       [div, api] = createElementAndApi(simpleHeatmapViewConf, {
         editable: false,


### PR DESCRIPTION
## Description

> What was changed in this pull request?

This PR adds an API, `suggestGene`, that returns the list of top matching genes for a given keyword (e.g., 'MY'). The suggestions are based on view specs: `autocompleteServer` and `autocompleteId`.

```js
hgApi.suggestGene('aa', 'MY', (suggestions) => {
  if(suggestions && suggestions.length > 0) {
    console.log('Gene suggested', suggestions[0].geneName);
    console.log('Chromosome', suggestions[0].chr);
    console.log('Start position', suggestions[0].txStart);
    console.log('End position', suggestions[0].txEnd);
  }
});
```

> Why is it necessary?

Together with the `zoomToGene` API (#997), this can be useful when we want to support searching for genes on the interface that are placed outside of HiGlass views.

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [x] Unit tests added or updated
- [x] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
