### PR TITLE
Prevent from zooming in too far by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Change the default value of `zoomLimits` to `[1, null]`, which means highest zoom resolution is 1bp.
+
 _[Detailed changes since v1.11.5](https://github.com/higlass/higlass/compare/v1.11.5...develop)_
 
 ## v1.11.5

--- a/app/schema.json
+++ b/app/schema.json
@@ -153,7 +153,8 @@
         "zoomLimits": {
           "type": "array",
           "minLength": 2,
-          "maxLength": 2
+          "maxLength": 2,
+          "default": [1, null]
         }
       }
     },

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -2409,28 +2409,27 @@ class HiGlassComponent extends React.Component {
   calculateZoomLimits(view, initialXDomain) {
     const limits = [0, Infinity];
 
-    if ('zoomLimits' in view) {
-      const diffX = initialXDomain[1] - initialXDomain[0];
-      const viewConfLimit = view.zoomLimits;
+    // By default, highest zoom resolution is 1bp
+    const viewConfLimit = view.zoomLimits || [1, null];
+    const diffX = initialXDomain[1] - initialXDomain[0];
 
-      if (viewConfLimit.length !== 2) {
-        return limits;
+    if (viewConfLimit.length !== 2) {
+      return limits;
+    }
+
+    if (viewConfLimit[0] !== null && viewConfLimit[0] > 0) {
+      const upperLimit = diffX / viewConfLimit[0];
+      limits[1] = Math.max(upperLimit, 1);
+      if (upperLimit < 1) {
+        console.warn(`Invalid zoom limits. Lower limit set to ${diffX}`);
       }
+    }
 
-      if (viewConfLimit[0] !== null && viewConfLimit[0] > 0) {
-        const upperLimit = diffX / viewConfLimit[0];
-        limits[1] = Math.max(upperLimit, 1);
-        if (upperLimit < 1) {
-          console.warn(`Invalid zoom limits. Lower limit set to ${diffX}`);
-        }
-      }
-
-      if (viewConfLimit[1] !== null && viewConfLimit[1] > viewConfLimit[0]) {
-        const lowerLimit = diffX / viewConfLimit[1];
-        limits[0] = Math.min(lowerLimit, 1);
-        if (lowerLimit > 1) {
-          console.warn(`Invalid zoom limits. Upper limit set to ${diffX}`);
-        }
+    if (viewConfLimit[1] !== null && viewConfLimit[1] > viewConfLimit[0]) {
+      const lowerLimit = diffX / viewConfLimit[1];
+      limits[0] = Math.min(lowerLimit, 1);
+      if (lowerLimit > 1) {
+        console.warn(`Invalid zoom limits. Upper limit set to ${diffX}`);
       }
     }
     return limits;

--- a/docs/view_config.rst
+++ b/docs/view_config.rst
@@ -231,7 +231,7 @@ assigned values of ``[0,1]]``.
 zoomLimits
 ^^^^^^^^^^
 
-The field contains limits that controll the extend to which zooming is possible within a view. In the example below, zooming in is not possible beyond 200bp. If one of the items in the array is `null`, zooming is unrestricted in the corresponding direction. If the field is not present in the viewconf, it defaults to unrestricted zooming.
+The field contains limits that controll the extend to which zooming is possible within a view. In the example below, zooming in is not possible beyond 200bp. If one of the items in the array is `null`, zooming is unrestricted in the corresponding direction. If the field is not present in the viewconf, it defaults to `[1, null]`.
 
 .. code-block:: javascript
 


### PR DESCRIPTION
## Description

> What was changed in this pull request?

If `zoomLimits` is not set, highest zoom resolution is 1bp.

> Why is it necessary?

Fixes #996

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [x] Documentation added or updated
- [ ] Example(s) added or updated
- [x] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
