### PR TITLE
Show visual clue when failed to fetch tileset info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- Show visual clue when tileset info is not available ("Tileset info not found. ...").
+
 _[Detailed changes since v1.11.5](https://github.com/higlass/higlass/compare/v1.11.6...develop)_
 
 ## v1.11.6

--- a/app/scripts/DataFetcher.js
+++ b/app/scripts/DataFetcher.js
@@ -130,6 +130,7 @@ export default class DataFetcher {
             );
           },
           (error) => {
+            this.tilesetInfoLoading = false;
             finished({
               error,
             });

--- a/app/scripts/TiledPixiTrack.js
+++ b/app/scripts/TiledPixiTrack.js
@@ -166,6 +166,9 @@ class TiledPixiTrack extends PixiTrack {
         this.dataFetcher.dataConfig.tilesetUid = tilesetUid;
       }
 
+      this.tilesetUid = this.dataFetcher.dataConfig.tilesetUid;
+      this.server = this.dataFetcher.dataConfig.server || 'unknown';
+
       if (this.tilesetInfo.chromsizes) {
         this.chromInfo = parseChromsizesRows(this.tilesetInfo.chromsizes);
       }


### PR DESCRIPTION
## Description

> What was changed in this pull request?

<img width="660" alt="Screen Shot 2021-01-28 at 11 15 11 AM" src="https://user-images.githubusercontent.com/9922882/106166970-b82f7180-615a-11eb-8d21-01b51e5fa23c.png">

> Why is it necessary?

Fixes #1002 

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [x] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
