### PR TITLE
Properly initialize the style of 1D brushes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 
 - Show visual clue when tileset info is not available ("Tileset info not found. ...").
+- Properly initialize the style of 1D brushes (`viewport-projection-horizontal` and `viewport-projection-vertical`).
 
 _[Detailed changes since v1.11.5](https://github.com/higlass/higlass/compare/v1.11.6...develop)_
 

--- a/app/scripts/ViewportTracker2D.js
+++ b/app/scripts/ViewportTracker2D.js
@@ -54,10 +54,10 @@ class ViewportTracker2D extends SVGTrack {
 
     this.gBrush.selectAll('.handle--e').style('pointer-events', 'none');
 
-    registerViewportChanged(uid, this.viewportChanged.bind(this));
-
     // the viewport will call this.viewportChanged immediately upon
     // hearing registerViewportChanged
+    registerViewportChanged(uid, this.viewportChanged.bind(this));
+
     this.rerender();
     this.draw();
   }

--- a/app/scripts/ViewportTrackerHorizontal.js
+++ b/app/scripts/ViewportTrackerHorizontal.js
@@ -50,10 +50,11 @@ class ViewportTrackerHorizontal extends SVGTrack {
 
     this.gBrush.selectAll('.handle--s').style('pointer-events', 'none');
 
-    registerViewportChanged(uid, this.viewportChanged.bind(this));
-
     // the viewport will call this.viewportChanged immediately upon
     // hearing registerViewportChanged
+    registerViewportChanged(uid, this.viewportChanged.bind(this));
+
+    this.rerender();
     this.draw();
   }
 

--- a/app/scripts/ViewportTrackerVertical.js
+++ b/app/scripts/ViewportTrackerVertical.js
@@ -49,10 +49,11 @@ class ViewportTrackerVertical extends SVGTrack {
 
     this.gBrush.selectAll('.handle--w').style('pointer-events', 'none');
 
-    registerViewportChanged(uid, this.viewportChanged.bind(this));
-
     // the viewport will call this.viewportChanged immediately upon
     // hearing registerViewportChanged
+    registerViewportChanged(uid, this.viewportChanged.bind(this));
+
+    this.rerender();
     this.draw();
   }
 


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Fix to properly initialize the style of 1D brushes (`viewport-projection-horizontal` and `viewport-projection-vertical`) by calling `rerender()`.

> Why is it necessary?

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
