### PR TITLE
Allow specifying padding around a gene in the `zoomToGene` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 
 - Added an option menu item for rectangle domain fill opacity
+- Added a parameter in `zoomToGene` to specify padding around gene to navigate
 
 _[Detailed changes since v1.11.5](https://github.com/higlass/higlass/compare/v1.11.7...develop)_
 

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -4055,7 +4055,7 @@ class HiGlassComponent extends React.Component {
     this.setCenters[viewUid](centerX, centerY, k, false, animateTime);
   }
 
-  zoomToGene(viewUid, geneName, animateTime) {
+  zoomToGene(viewUid, geneName, padding, animateTime) {
     if (!(viewUid in this.setCenters)) {
       throw Error(
         `Invalid viewUid. Current uuids: ${Object.keys(this.setCenters).join(
@@ -4091,8 +4091,9 @@ class HiGlassComponent extends React.Component {
             this.state.views[viewUid].chromInfoPath,
             (loadedChromInfo) => {
               // using the absolution positions, zoom to the position near a gene
-              const startAbs = loadedChromInfo.chrToAbs([chr, txStart]);
-              const endAbs = loadedChromInfo.chrToAbs([chr, txEnd]);
+              const startAbs =
+                loadedChromInfo.chrToAbs([chr, txStart]) - padding;
+              const endAbs = loadedChromInfo.chrToAbs([chr, txEnd]) + padding;
 
               const [centerX, centerY, k] = scalesCenterAndK(
                 this.xScales[viewUid].copy().domain([startAbs, endAbs]),

--- a/app/scripts/api.js
+++ b/app/scripts/api.js
@@ -473,13 +473,14 @@ const createApi = function api(context, pubSub) {
        *
        * @param {string} viewUid The identifier of the view to zoom
        * @param {string} geneName The name of gene symbol to search
+       * @param {string} padding The padding (BP) around the gene to see
        * @param {Number} animateTime The time to spend zooming to the specified location
        * @example
        * // Zoom to the location near 'MYC'
-       * hgApi.zoomToGene('view1', 'MYC', 2000);
+       * hgApi.zoomToGene('view1', 'MYC', 100, 2000);
        */
-      zoomToGene(viewUid, geneName, animateTime = 0) {
-        self.zoomToGene(viewUid, geneName, animateTime);
+      zoomToGene(viewUid, geneName, padding = 0, animateTime = 0) {
+        self.zoomToGene(viewUid, geneName, padding, animateTime);
       },
 
       /**

--- a/test/APITests.js
+++ b/test/APITests.js
@@ -247,7 +247,7 @@ describe('API Tests', () => {
         editable: false,
       });
 
-      api.zoomToGene('a', 'MYC', 100);
+      api.zoomToGene('a', 'MYC', 100, 1000);
 
       waitForTransitionsFinished(api.getComponent(), () => {
         expect(api.getComponent().xScales.a.domain()[0]).toBeCloseTo(


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Currently, the `zoomToGene` API shows the exact genomic interval of a given gene. This PR adds a parameter to specify `padding` in the `zoomToGene()`:

```js
hg.current.api.zoomToGene(
   "view-1", 
   "MYC", 
   10000 , // show +- 10,000 bp regions
   0, // transition duration (default: 0bp)
); 
```

<img width="1512" alt="Screen Shot 2021-06-17 at 4 39 06 PM" src="https://user-images.githubusercontent.com/9922882/122469529-0f5ba480-cf8b-11eb-8870-332c8e413a3b.png">


> Why is it necessary?

Sometimes, it is useful to show padding around the given gene.

Fixes #1023 

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [x] Unit tests added or updated
- [x] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [x] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
