### PR TITLE
Make vertical labels readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+- Make vertical chromosome labels as well as loading status labels readable in vertical tracks
 - Added an option menu item for rectangle domain fill opacity
 
 _[Detailed changes since v1.11.5](https://github.com/higlass/higlass/compare/v1.11.7...develop)_

--- a/app/scripts/HorizontalChromosomeLabels.js
+++ b/app/scripts/HorizontalChromosomeLabels.js
@@ -266,6 +266,14 @@ class HorizontalChromosomeLabels extends PixiTrack {
 
     this.rightBoundTick.anchor.x = 1;
 
+    if (this.flipText) {
+      // this means this track is displayed vertically, so update the anchor and scale of labels to make them readable!
+      this.leftBoundTick.scale.x = -1;
+      this.leftBoundTick.anchor.x = 1;
+      this.rightBoundTick.scale.x = -1;
+      this.rightBoundTick.anchor.x = 0;
+    }
+
     // line is offset by one because it's right on the edge of the
     // visible region and we want to get the full width
     this.leftBoundTick.tickLine = [

--- a/app/scripts/TiledPixiTrack.js
+++ b/app/scripts/TiledPixiTrack.js
@@ -735,10 +735,11 @@ class TiledPixiTrack extends PixiTrack {
       }
 
       [this.trackNotFoundText.x, this.trackNotFoundText.y] = this.position;
-      /*
-      if (this.flipText)
-          this.trackNotFoundText.scale.x = -1;
-      */
+
+      if (this.flipText) {
+        this.trackNotFoundText.anchor.x = 1;
+        this.trackNotFoundText.scale.x = -1;
+      }
 
       this.trackNotFoundText.visible = true;
     } else {


### PR DESCRIPTION
## Description

> What was changed in this pull request?

This PR makes vertical labels, such as chromosome labels and "Loading..." labels, readable by flipping properly.

### Before
<img width="841" alt="Screen Shot 2021-06-17 at 5 19 17 PM" src="https://user-images.githubusercontent.com/9922882/122474294-079efe80-cf91-11eb-8b1e-9fad3e36ab3e.png">

### After
<img width="841" alt="Screen Shot 2021-06-17 at 5 19 35 PM" src="https://user-images.githubusercontent.com/9922882/122474312-0bcb1c00-cf91-11eb-9d64-a0dd04702902.png">

> Why is it necessary?

Some labels are unreadable in vertical tracks.

Fixes #1006
Fixes #1003  
Fixes #1010 

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [x] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
