### PR TITLE
Add data fetchers to AVAILABLE_FOR_PLUGINS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Make vertical chromosome labels as well as loading status labels readable in vertical tracks
 - Added an option menu item for rectangle domain fill opacity
+- Add data fetchers to `AVAILABLE_FOR_PLUGINS`
 
 _[Detailed changes since v1.11.5](https://github.com/higlass/higlass/compare/v1.11.7...develop)_
 

--- a/app/scripts/configs/available-for-plugins.js
+++ b/app/scripts/configs/available-for-plugins.js
@@ -75,6 +75,12 @@ import * as services from '../services';
 import ChromosomeInfo from '../ChromosomeInfo';
 import SearchField from '../SearchField';
 
+// Data Fetchers
+import GBKDataFetcher from '../data-fetchers/genbank-fetcher';
+import LocalDataFetcher from '../data-fetchers/local-tile-fetcher';
+import getDataFetcher from '../data-fetchers/get-data-fetcher';
+
+
 const libraries = {
   d3Array,
   d3Axis,
@@ -143,10 +149,18 @@ const chromosomes = {
   SearchField,
 };
 
+const dataFetchers = {
+  DataFetcher,
+  GBKDataFetcher,
+  LocalDataFetcher,
+  getDataFetcher,
+};
+
 export default {
   chromosomes,
   libraries,
   tracks,
+  dataFetchers,
   factories,
   services,
   utils,

--- a/docs/available_to_plugins.rst
+++ b/docs/available_to_plugins.rst
@@ -213,6 +213,16 @@ Chromosomes
 - ChromosomeInfo
 - SearchField
 
+Data Fetchers
+-------
+
+**Prefix:** ``dataFetchers`` (e.g., ``HGC.dataFetchers.DataFetcher``)
+
+- DataFetcher
+- GBKDataFetcher
+- LocalDataFetcher
+- getDataFetcher
+
 Other
 -----
 

--- a/docs/plugin_datafetcher.rst
+++ b/docs/plugin_datafetcher.rst
@@ -24,8 +24,16 @@ In the follow you can see a bare minimum example of this structure.
         );
       }
 
+
       // You can extend the base DataFetcher class with your plugin.
-      const { DataFetcher } = HGC.factories;
+      const { DataFetcher } = HGC.dataFetchers;
+      
+      // You also have access to other built-in data fetchers and getDataFetcher
+      const {
+        GBKDataFetcher,
+        LocalDataFetcher,
+        getDataFetcher
+      } = HGC.dataFetchers;
 
       // Other libraries, utils, etc. that are provided by HiGlass (HGC)
       const { ... } = HGC.libraries;
@@ -33,11 +41,13 @@ In the follow you can see a bare minimum example of this structure.
       const { ... } = HGC.services;
       const { ... } = HGC.utils;
       const { ... } = HGC.configs;
+      // The base DataFetcher class is also exposed from HGC.factories.
+      const { ... } = HGC.factories;
 
       // The version of HiGlass. Can be used to check for compatibility.
       const hgVersion = HGC.VERSION;
 
-      class MyDataFetcherClass extends HGC.factories.DataFetcher {
+      class MyDataFetcherClass extends HGC.dataFetchers.DataFetcher {
         constructor(dataConfig, pubSub) {
             super(dataConfig, pubSub);
             this.hgc = HGC;

--- a/docs/plugin_track.rst
+++ b/docs/plugin_track.rst
@@ -34,6 +34,7 @@ other track. In the follow you can see a bare minimum example of this structure.
       const { ... } = HGC.services;
       const { ... } = HGC.utils;
       const { ... } = HGC.configs;
+      const { ... } = HGC.dataFetchers;
 
       // The version of HiGlass. Can be used to check for compatibility.
       const hgVersion = HGC.VERSION;


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Added the built-in data fetcher classes and the `getDataFetcher` function to a new `dataFetchers` property in `AVAILABLE_FOR_PLUGINS`.

> Why is it necessary?

This is helpful for developing plugins that use advanced data fetching logic. I'm personally trying to implement a multi-tileset data fetcher, which could be made much simpler with access to `getDataFetcher`.

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] <strike>Unit tests added or updated</strike> N/A (I think?)
- [x] Documentation added or updated
- [ ] <strike>Example(s) added or updated</strike> N/A
- [ ] <strike>Update schema.json if there are changes to the viewconf JSON structure format</strike> N/A
- [ ] <strike>Screenshot for visual changes (e.g. new tracks or UI changes)</strike> N/A
- [x] Updated CHANGELOG.md

P.S. I don't have write access to HiGlass so I can't add any labels.
