### PR TITLE
Fix tracks available in AVAILABLE_FOR_PLUGINS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Make vertical chromosome labels as well as loading status labels readable in vertical tracks
 - Added an option menu item for rectangle domain fill opacity
 - Add data fetchers to `AVAILABLE_FOR_PLUGINS`
+- Update track list in `AVAILABLE_FOR_PLUGINS`
 
 _[Detailed changes since v1.11.5](https://github.com/higlass/higlass/compare/v1.11.7...develop)_
 

--- a/app/scripts/configs/available-for-plugins.js
+++ b/app/scripts/configs/available-for-plugins.js
@@ -28,14 +28,20 @@ import * as configs from '.';
 import * as utils from '../utils';
 
 // Tracks
+import Annotations1dTrack from '../Annotations1dTrack';
 import Annotations2dTrack from '../Annotations2dTrack';
 import ArrowheadDomainsTrack from '../ArrowheadDomainsTrack';
 import BarTrack from '../BarTrack';
 import BedLikeTrack from '../BedLikeTrack';
 import CNVIntervalTrack from '../CNVIntervalTrack';
+import Chromosome2DAnnotations from '../Chromosome2DAnnotations';
+import Chromosome2DLabels from '../Chromosome2DLabels';
+import ChromosomeGrid from '../ChromosomeGrid';
 import CombinedTrack from '../CombinedTrack';
+import CrossRule from '../CrossRule';
 import DivergentBarTrack from '../DivergentBarTrack';
 import HeatmapTiledPixiTrack from '../HeatmapTiledPixiTrack';
+import Horizontal1dHeatmapTrack from '../Horizontal1dHeatmapTrack';
 import Horizontal2DDomainsTrack from '../Horizontal2DDomainsTrack';
 import HorizontalChromosomeLabels from '../HorizontalChromosomeLabels';
 import HorizontalGeneAnnotationsTrack from '../HorizontalGeneAnnotationsTrack';
@@ -43,6 +49,8 @@ import HorizontalHeatmapTrack from '../HorizontalHeatmapTrack';
 import HorizontalLine1DPixiTrack from '../HorizontalLine1DPixiTrack';
 import HorizontalMultivecTrack from '../HorizontalMultivecTrack';
 import HorizontalPoint1DPixiTrack from '../HorizontalPoint1DPixiTrack';
+import HorizontalRule from '../HorizontalRule';
+import HorizontalTiled1DPixiTrack from '../HorizontalTiled1DPixiTrack';
 import HorizontalTiledPlot from '../HorizontalTiledPlot';
 import HorizontalTrack from '../HorizontalTrack';
 import Id2DTiledPixiTrack from '../Id2DTiledPixiTrack';
@@ -51,8 +59,11 @@ import IdVertical1DTiledPixiTrack from '../IdVertical1DTiledPixiTrack';
 import LeftAxisTrack from '../LeftAxisTrack';
 import MapboxTilesTrack from '../MapboxTilesTrack';
 import MoveableTrack from '../MoveableTrack';
+import OSMTileIdsTrack from '../OSMTileIdsTrack';
 import OSMTilesTrack from '../OSMTilesTrack';
+import OverlayTrack from '../OverlayTrack';
 import PixiTrack from '../PixiTrack';
+import RasterTilesTrack from '../RasterTilesTrack';
 import SVGTrack from '../SVGTrack';
 import SquareMarkersTrack from '../SquareMarkersTrack';
 import Tiled1DPixiTrack from '../Tiled1DPixiTrack';
@@ -60,8 +71,13 @@ import TiledPixiTrack from '../TiledPixiTrack';
 import TopAxisTrack from '../TopAxisTrack';
 import Track from '../Track';
 import ValueIntervalTrack from '../ValueIntervalTrack';
+import VerticalRule from '../VerticalRule';
 import VerticalTiled1DPixiTrack from '../VerticalTiled1DPixiTrack';
 import VerticalTrack from '../VerticalTrack';
+import ViewportTracker2D from '../ViewportTracker2D';
+import ViewportTracker2DPixi from '../ViewportTracker2DPixi';
+import ViewportTrackerHorizontal from '../ViewportTrackerHorizontal';
+import ViewportTrackerVertical from '../ViewportTrackerVertical';
 
 // Factories
 import ContextMenuItem from '../ContextMenuItem';
@@ -79,7 +95,6 @@ import SearchField from '../SearchField';
 import GBKDataFetcher from '../data-fetchers/genbank-fetcher';
 import LocalDataFetcher from '../data-fetchers/local-tile-fetcher';
 import getDataFetcher from '../data-fetchers/get-data-fetcher';
-
 
 const libraries = {
   d3Array,
@@ -102,14 +117,20 @@ const libraries = {
 };
 
 const tracks = {
+  Annotations1dTrack,
   Annotations2dTrack,
   ArrowheadDomainsTrack,
   BarTrack,
   BedLikeTrack,
   CNVIntervalTrack,
+  Chromosome2DAnnotations,
+  Chromosome2DLabels,
+  ChromosomeGrid,
   CombinedTrack,
+  CrossRule,
   DivergentBarTrack,
   HeatmapTiledPixiTrack,
+  Horizontal1dHeatmapTrack,
   Horizontal2DDomainsTrack,
   HorizontalChromosomeLabels,
   HorizontalGeneAnnotationsTrack,
@@ -117,6 +138,8 @@ const tracks = {
   HorizontalLine1DPixiTrack,
   HorizontalMultivecTrack,
   HorizontalPoint1DPixiTrack,
+  HorizontalRule,
+  HorizontalTiled1DPixiTrack,
   HorizontalTiledPlot,
   HorizontalTrack,
   Id2DTiledPixiTrack,
@@ -125,8 +148,11 @@ const tracks = {
   LeftAxisTrack,
   MapboxTilesTrack,
   MoveableTrack,
+  OSMTileIdsTrack,
   OSMTilesTrack,
+  OverlayTrack,
   PixiTrack,
+  RasterTilesTrack,
   SVGTrack,
   SquareMarkersTrack,
   Tiled1DPixiTrack,
@@ -134,8 +160,13 @@ const tracks = {
   TopAxisTrack,
   Track,
   ValueIntervalTrack,
+  VerticalRule,
   VerticalTiled1DPixiTrack,
   VerticalTrack,
+  ViewportTracker2D,
+  ViewportTracker2DPixi,
+  ViewportTrackerHorizontal,
+  ViewportTrackerVertical,
 };
 
 const factories = {


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Updated the track list in `AVAILABLE_FOR_PLUGINS`.

> Why is it necessary?

I was specifically missing HorizontalTiled1DPixiTrack for [`higlass-dynseq`](https://github.com/kundajelab/higlass-dynseq), which works only when it is added to `AVAILABLE_FOR_PLUGINS`.

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] <strike>Unit tests added or updated</strike> N/A
- [ ] <strike>Documentation added or updated</strike> N/A
- [ ] <strike>Example(s) added or updated</strike> N/A
- [ ] <strike>Update schema.json if there are changes to the viewconf JSON structure format</strike> N/A
- [ ] <strike>Screenshot for visual changes (e.g. new tracks or UI changes)</strike> N/A
- [x] Updated CHANGELOG.md
