### PR TITLE
Correctly setup initial scales of vertical tracks when the width of a center track is zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added an option menu item for rectangle domain fill opacity
 - Add data fetchers to `AVAILABLE_FOR_PLUGINS`
 - Update track list in `AVAILABLE_FOR_PLUGINS`
+- Correctly calculate `initialYDomain` when the width of a `center` track is `zero`.
 
 _[Detailed changes since v1.11.5](https://github.com/higlass/higlass/compare/v1.11.7...develop)_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Added an option menu item for rectangle domain fill opacity
 - Add data fetchers to `AVAILABLE_FOR_PLUGINS`
 - Update track list in `AVAILABLE_FOR_PLUGINS`
-- Correctly calculate `initialYDomain` when the width of a `center` track is `zero`.
+- Correctly setup initial scales of vertical tracks when the width of a center track is zero.
 
 _[Detailed changes since v1.11.5](https://github.com/higlass/higlass/compare/v1.11.7...develop)_
 

--- a/app/scripts/TrackRenderer.js
+++ b/app/scripts/TrackRenderer.js
@@ -604,17 +604,28 @@ class TrackRenderer extends React.Component {
       ])
       .range([initialXDomain[0], initialXDomain[1]]);
 
+    let startY; let endY;
+    if (this.currentProps.centerWidth === 0) {
+      // If the width of the center track is zero, we do not want to make startY and endY equal.
+      startY = this.currentProps.paddingTop + this.currentProps.topHeight;
+      endY =
+        this.currentProps.paddingTop +
+        this.currentProps.topHeight +
+        this.currentProps.centerHeight;
+    } else {
+      startY =
+        this.currentProps.paddingTop +
+        this.currentProps.topHeight +
+        this.currentProps.centerHeight / 2 -
+        this.currentProps.centerWidth / 2;
+      endY =
+        this.currentProps.paddingTop +
+        this.currentProps.topHeight +
+        this.currentProps.centerHeight / 2 +
+        this.currentProps.centerWidth / 2;
+    }
     this.drawableToDomainY = scaleLinear()
-      .domain([
-        this.currentProps.paddingTop +
-          this.currentProps.topHeight +
-          this.currentProps.centerHeight / 2 -
-          this.currentProps.centerWidth / 2,
-        this.currentProps.paddingTop +
-          this.currentProps.topHeight +
-          this.currentProps.centerHeight / 2 +
-          this.currentProps.centerWidth / 2,
-      ])
+      .domain([startY, endY])
       .range([initialYDomain[0], initialYDomain[1]]);
 
     this.prevCenterX =


### PR DESCRIPTION
## Description

> What was changed in this pull request?

This PR correctly setups initial scales of vertical tracks when the width of a center track is zero.

> Why is it necessary?

Previously, if the width of the center track is zero (e.g., no tracks are added to the center and vertical tracks use the full width of a view), the scale was not correctly determined (i.e., `min` and `max` values became the same in `d3.domain([min, max])`, [code](https://github.com/higlass/higlass/blob/7342071813c576dff34dcd31a89de43cf062010a/app/scripts/TrackRenderer.js#L616)). This led to showing an empty white space in the vertical tracks (refer to the screenshots below).

### Screenshots
#### Before
![Screen Shot 2021-08-06 at 3 41 11 PM](https://user-images.githubusercontent.com/9922882/128564143-eed6ae6e-d50b-47f3-8fa3-37e3da9675b2.png)

#### After
![Screen Shot 2021-08-06 at 3 40 56 PM](https://user-images.githubusercontent.com/9922882/128564149-74872b1a-e604-4b82-b255-dc914f6cfb15.png)

<details>
<summary>Example View Config</summary>

```js
{
    "editable": false,
    "zoomFixed": false,
    "trackSourceServers": [
      "//higlass.io/api/v1",
      "https://resgen.io/api/v1/gt/paper-data"
    ],
    "exportViewUrl": "/api/v1/viewconfs",
    "views": [
      {
        "uid": "aa",
        "autocompleteSource": "/api/v1/suggest/?d=OHJakQICQD6gTD7skx4EWA&",
        "genomePositionSearchBox": {
          "autocompleteServer": "//higlass.io/api/v1",
          "autocompleteId": "OHJakQICQD6gTD7skx4EWA",
          "chromInfoServer": "//higlass.io/api/v1",
          "chromInfoId": "hg19",
          "visible": true
        },
        "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
        "tracks": {
          "top": [],
          "left": [
            {
              "type": "vertical-gene-annotations",
              "width": 60,
              "tilesetUid": "OHJakQICQD6gTD7skx4EWA",
              "server": "//higlass.io/api/v1",
              "options": {
                "labelPosition": "bottomRight",
                "name": "Gene Annotations (hg19)",
                "fontSize": 10,
                "labelColor": "black",
                "labelBackgroundColor": "#ffffff",
                "labelLeftMargin": 0,
                "labelRightMargin": 0,
                "labelTopMargin": 0,
                "labelBottomMargin": 0,
                "minHeight": 24,
                "plusStrandColor": "blue",
                "minusStrandColor": "red",
                "trackBorderWidth": 0,
                "trackBorderColor": "black",
                "showMousePosition": false,
                "mousePositionColor": "#000000",
                "geneAnnotationHeight": 16,
                "geneLabelPosition": "outside",
                "geneStrandSpacing": 4
              },
              "uid": "dqBTMH78Rn6DeSyDBoAEXw",
              "height": 600
            },
            {
              "chromInfoPath": "//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv",
              "type": "vertical-chromosome-labels",
              "width": 70,
              "uid": "RHdQK4IRQ7yJeDmKWb7Pcg",
              "options": {
                "color": "#808080",
                "stroke": "#ffffff",
                "fontSize": 12,
                "fontIsLeftAligned": false,
                "showMousePosition": false,
                "mousePositionColor": "#000000",
                "reverseOrientation": false
              },
              "height": 600
            }
          ],
          "center": [],
          "right": [],
          "bottom": [],
          "whole": [],
          "gallery": []
        },
        "layout": {
          "w": 12,
          "h": 12,
          "x": 0,
          "y": 0,
          "moved": false,
          "static": false
        },
        "initialXDomain": [
          0,
          3088269832
        ],
        "initialYDomain": [
          0,
          3088269832
        ]
      }
    ],
    "zoomLocks": {
      "locksByViewUid": {},
      "locksDict": {}
    },
    "locationLocks": {
      "locksByViewUid": {},
      "locksDict": {}
    },
    "valueScaleLocks": {
      "locksByViewUid": {},
      "locksDict": {}
    }
  }
```
</details>

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [x] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
