### PR TITLE
Add strand info to tileData in GeneAnnotation track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release notes
 
 - Remove react-bootstrap from the GenomePositionSearchBox
+- Fix color issue in GeneAnnotation SVG export
 
 ## v1.11.8
 

--- a/app/scripts/HorizontalGeneAnnotationsTrack.js
+++ b/app/scripts/HorizontalGeneAnnotationsTrack.js
@@ -141,6 +141,8 @@ function externalInitTile(track, tile, options) {
     const geneId = track.geneId(geneInfo, td.type);
     const strand = td.strand || geneInfo[5];
 
+    td.strand = strand;
+
     let fill = plusStrandColor || DEFAULT_PLUS_STRAND_COLOR;
 
     if (strand === '-') {

--- a/app/scripts/HorizontalGeneAnnotationsTrack.js
+++ b/app/scripts/HorizontalGeneAnnotationsTrack.js
@@ -141,7 +141,7 @@ function externalInitTile(track, tile, options) {
     const geneId = track.geneId(geneInfo, td.type);
     const strand = td.strand || geneInfo[5];
 
-    td.strand = strand;
+    td.strand = td.strand || strand;
 
     let fill = plusStrandColor || DEFAULT_PLUS_STRAND_COLOR;
 


### PR DESCRIPTION
## Description

> What was changed in this pull request?

The GeneAnnotation track uses `tile.tileData.strand` in various places, but it is actually undefined. This PR adds it in the `externalInitTile` function.

> Why is it necessary?

The SVG export ignores the colors of the strands, because this value is undefined

Fixes #___

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
