### PR TITLE
feat: implement `api.reload()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Update track list in `AVAILABLE_FOR_PLUGINS`
 - Correctly setup initial scales of vertical tracks when the width of a center track is zero.
 - Config-wise, allow axis-specific location locks (e.g., lock the vertical axis in a view to the horizontal axis in another).
+- Add `reload` implementation to `HiGlassComponenet` API.
 
 _[Detailed changes since v1.11.5](https://github.com/higlass/higlass/compare/v1.11.7...develop)_
 

--- a/app/scripts/api.js
+++ b/app/scripts/api.js
@@ -131,9 +131,7 @@ const createApi = function api(context, pubSub) {
           const track = self.getTrackObject(viewId, trackId);
           // Trevor: not a method on every track? refresh data?
           if (track.fetchedTiles) {
-            for (const tileId in track.fetchedTiles) {
-              delete track.fetchedTiles[tileId];
-            }
+            track.removeTiles(Object.keys(track.fetchedTiles));
             track.fetching.clear();
             track.refreshTiles();
           }

--- a/app/scripts/api.js
+++ b/app/scripts/api.js
@@ -130,7 +130,13 @@ const createApi = function api(context, pubSub) {
         for (const { viewId, trackId } of tracks) {
           const track = self.getTrackObject(viewId, trackId);
           // Trevor: not a method on every track? refresh data?
-          if (track.refreshTiles) track.refreshTiles();
+          if (track.fetchedTiles) {
+            for (const tileId in track.fetchedTiles) {
+              delete track.fetchedTiles[tileId];
+            }
+            track.fetching.clear();
+            track.refreshTiles();
+          }
           // second argument forces re-render
           track.rerender(track.options, true);
         }

--- a/app/scripts/api.js
+++ b/app/scripts/api.js
@@ -128,15 +128,18 @@ const createApi = function api(context, pubSub) {
         }
 
         for (const { viewId, trackId } of tracks) {
-          const track = self.getTrackObject(viewId, trackId);
-          // Trevor: not a method on every track? refresh data?
-          if (track.fetchedTiles) {
-            track.removeTiles(Object.keys(track.fetchedTiles));
-            track.fetching.clear();
-            track.refreshTiles();
+          const selectedTrack = self.getTrackObject(viewId, trackId);
+          // iterate over childTracks if CombinedTrack
+          for (const track of selectedTrack.childTracks || [selectedTrack]) {
+            // reload tiles for tracks with tiles.
+            if (track.fetchedTiles) {
+              track.removeTiles(Object.keys(track.fetchedTiles));
+              track.fetching.clear();
+              track.refreshTiles();
+            }
+            // second argument forces re-render
+            track.rerender(track.options, true);
           }
-          // second argument forces re-render
-          track.rerender(track.options, true);
         }
       },
 

--- a/app/scripts/api.js
+++ b/app/scripts/api.js
@@ -15,6 +15,7 @@ const forceUpdate = (self) => {
 };
 
 const createApi = function api(context, pubSub) {
+  /** @type {import('./HiGlassComponent').default} */
   const self = context;
 
   let pubSubs = [];
@@ -112,10 +113,27 @@ const createApi = function api(context, pubSub) {
       },
 
       /**
-       * Reload all of the tiles
+       * Reload all or specific tiles for viewId/trackId
+       * @param {({ viewId: string, trackId: string } | string)[]} target
        */
-      reload() {
-        console.warn('Not implemented yet!');
+      reload(target) {
+        /** @type {{ viewId: string, trackId: string}[]} */
+        let tracks;
+        if (!target) {
+          tracks = self.iterateOverTracks();
+        } else {
+          tracks = target.flatMap((d) =>
+            typeof d === 'string' ? self.iterateOverTracksInView(d) : d,
+          );
+        }
+
+        for (const { viewId, trackId } of tracks) {
+          const track = self.getTrackObject(viewId, trackId);
+          // Trevor: not a method on every track? refresh data?
+          if (track.refreshTiles) track.refreshTiles();
+          // second argument forces re-render
+          track.rerender(track.options, true);
+        }
       },
 
       /**


### PR DESCRIPTION
## Description


```javascript

const hgApi = hglib.viewer(
  document.getElementById('demo'),
  viewConfig,
);

hgApi.reload(); // all tracks

hgApi.reload(['aa', 'bb']); // all tracks for each viewId 'aa' & 'bb'

hgApi.reload([{ viewId: 'bb', trackId: 'genes' }]); // specific track

hgApi.reload(['aa', { viewId: 'bb', trackId: 'genes' }]); // combination
```

> What was changed in this pull request?

Implements `reload` for the public higlass api.

> Why is it necessary?

Replaces stub with feature.

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
