### PR TITLE
Prevent erroneous lines on 2D tracks by clearing stale mouse position data

### DIFF
--- a/app/scripts/utils/show-mouse-position.js
+++ b/app/scripts/utils/show-mouse-position.js
@@ -119,6 +119,22 @@ const showMousePosition = (
       y = event.isFrom2dTrack ? event.dataY : event.dataX;
     }
 
+    // If a track is not 2d and is horizontal, the event.dataY
+    // value of the mouse pointer location should not be allowed
+    // to impact how other tracks globally render their mouse
+    // position (see https://github.com/higlass/higlass/issues/814).
+    // Likewise, if a track is not 2d and is vertical, the
+    // event.dataX value should not be used by other tracks for
+    // position reporting.
+
+    if (!event.isFrom2dTrack) {
+      if (!event.isFromVerticalTrack) {
+        y = Number.MIN_SAFE_INTEGER;
+      } else {
+        x = Number.MIN_SAFE_INTEGER;
+      }
+    }
+
     // 2d or central tracks are not offset and rather rely on a mask, i.e., the
     // top left *visible* position is *not* [0,0] but given by `getPosition()`.
     const offset = is2d ? getPosition() : [0, 0];


### PR DESCRIPTION
## Description

> What was changed in this pull request?

When the `showMousePosition` option is set to `true` and the mouse pointer moves over a non-2d track, x and y values are published internally that can cause another 2d track to draw nonsensical vertical or horizontal lines. This test clears the relevant value so that it cannot be used to render such lines.

> Why is it necessary?

Fixes #814

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
