### PR TITLE
feat: check-in schema generated from higlass_schema

### DIFF
--- a/app/schema.json
+++ b/app/schema.json
@@ -2,524 +2,913 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://higlass.io/#viewconf",
   "title": "HiGlass viewconf",
+  "description": "Root object describing a HiGlass visualization.",
   "type": "object",
-  "additionalProperties": false,
-  "required": [],
   "properties": {
     "editable": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "viewEditable": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "tracksEditable": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
-    "zoomFixed": { "type": "boolean" },
-    "compactLayout": { "type": "boolean" },
-    "exportViewUrl": { "type": "string" },
+    "zoomFixed": {
+      "type": "boolean"
+    },
+    "compactLayout": {
+      "type": "boolean"
+    },
+    "exportViewUrl": {
+      "type": "string"
+    },
     "trackSourceServers": {
+      "minItems": 1,
       "type": "array",
-      "items": { "type": "string" },
-      "minLength": 1
-    },
-    "zoomLocks": { "$ref": "#/definitions/locks/zoomLocks" },
-    "locationLocks": { "$ref": "#/definitions/locks/locationLocks" },
-    "valueScaleLocks": { "$ref": "#/definitions/locks/valueScaleLocks" },
-    "views": {
-      "type": "array",
-      "items": { "$ref": "#/definitions/view" },
-      "minLength": 1
-    },
-    "chromInfoPath": { "type": "string" }
-  },
-  "definitions": {
-    "data": {
-      "type": "object",
-      "properties": {
-        "url": { "type": "string" },
-        "server": { "type": "string" },
-        "filetype": { "type": "string" },
-        "type": { "type": "string" },
-        "tilesetInfo": { "type": "object" },
-        "children": { "type": "array" },
-        "tiles": { "type": "object" }
+      "items": {
+        "type": "string"
       }
     },
-
-    "locks": {
-      "slug": { "type": "string" },
-
-      "locksByViewUid": {
-        "type": "object",
-        "additionalProperties": false,
-        "patternProperties": {
-          ".": { "$ref": "#/definitions/locks/slug" }
+    "views": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/View"
+      }
+    },
+    "zoomLocks": {
+      "$ref": "#/definitions/ZoomLocks"
+    },
+    "locationLocks": {
+      "$ref": "#/definitions/LocationLocks"
+    },
+    "valueScaleLocks": {
+      "$ref": "#/definitions/ValueScaleLocks"
+    },
+    "chromInfoPath": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Layout": {
+      "description": "Size and position of a View.",
+      "type": "object",
+      "properties": {
+        "x": {
+          "description": "The X Position",
+          "default": 0,
+          "type": "integer"
+        },
+        "y": {
+          "description": "The Y Position",
+          "default": 0,
+          "type": "integer"
+        },
+        "w": {
+          "description": "Width",
+          "default": 12,
+          "type": "integer"
+        },
+        "h": {
+          "description": "Height",
+          "default": 12,
+          "type": "integer"
+        },
+        "moved": {
+          "type": "boolean"
+        },
+        "static": {
+          "type": "boolean"
         }
       },
-
-      "axisSpecificLocks": {
-        "additionalProperties": false,
-        "properties": {
-          "axis": {
-            "enum": ["x", "y"],
-            "type": "string"
-          },
-          "lock": {
+      "additionalProperties": false
+    },
+    "Data": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "server": {
+          "type": "string"
+        },
+        "filetype": {
+          "type": "string"
+        },
+        "children": {
+          "type": "array",
+          "items": {}
+        },
+        "tilesetInfo": {
+          "type": "object"
+        },
+        "tiles": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    "EnumTrack": {
+      "type": "object",
+      "properties": {
+        "tilesetUid": {
+          "type": "string"
+        },
+        "server": {
+          "type": "string"
+        },
+        "uid": {
+          "type": "string"
+        },
+        "width": {
+          "type": "integer"
+        },
+        "height": {
+          "type": "integer"
+        },
+        "options": {
+          "type": "object"
+        },
+        "type": {
+          "anyOf": [
+            {
+              "enum": [
+                "viewport-projection-center",
+                "viewport-projection-vertical",
+                "viewport-projection-horizontal"
+              ],
+              "type": "string"
+            },
+            {
+              "enum": [
+                "multivec",
+                "1d-heatmap",
+                "line",
+                "point",
+                "bar",
+                "divergent-bar",
+                "stacked-interval",
+                "gene-annotations",
+                "linear-2d-rectangle-domains",
+                "chromosome-labels",
+                "linear-heatmap",
+                "1d-value-interval",
+                "2d-annotations",
+                "2d-chromosome-annotations",
+                "2d-chromosome-grid",
+                "2d-chromosome-labels",
+                "2d-rectangle-domains",
+                "2d-tiles",
+                "arrowhead-domains",
+                "bedlike",
+                "cross-rule",
+                "dummy",
+                "horizontal-1d-annotations",
+                "horizontal-1d-heatmap",
+                "horizontal-1d-tiles",
+                "horizontal-1d-value-interval",
+                "horizontal-2d-rectangle-domains",
+                "horizontal-bar",
+                "horizontal-chromosome-grid",
+                "horizontal-chromosome-labels",
+                "horizontal-divergent-bar",
+                "horizontal-gene-annotations",
+                "horizontal-heatmap",
+                "horizontal-line",
+                "horizontal-multivec",
+                "horizontal-point",
+                "horizontal-rule",
+                "horizontal-vector-heatmap",
+                "image-tiles",
+                "left-axis",
+                "left-stacked-interval",
+                "mapbox-tiles",
+                "osm-2d-tile-ids",
+                "osm-tiles",
+                "raster-tiles",
+                "simple-svg",
+                "square-markers",
+                "top-axis",
+                "top-stacked-interval",
+                "vertical-1d-annotations",
+                "vertical-1d-heatmap",
+                "vertical-1d-tiles",
+                "vertical-1d-value-interval",
+                "vertical-2d-rectangle-domains",
+                "vertical-bar",
+                "vertical-bedlike",
+                "vertical-chromosome-grid",
+                "vertical-chromosome-labels",
+                "vertical-gene-annotations",
+                "vertical-heatmap",
+                "vertical-line",
+                "vertical-multivec",
+                "vertical-point",
+                "vertical-rule",
+                "vertical-vector-heatmap"
+              ],
+              "type": "string"
+            }
+          ]
+        },
+        "data": {
+          "$ref": "#/definitions/Data"
+        },
+        "chromInfoPath": {
+          "type": "string"
+        },
+        "fromViewUid": {
+          "type": "string"
+        },
+        "x": {
+          "type": "number"
+        },
+        "y": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "HeatmapTrack": {
+      "type": "object",
+      "properties": {
+        "tilesetUid": {
+          "type": "string"
+        },
+        "server": {
+          "type": "string"
+        },
+        "uid": {
+          "type": "string"
+        },
+        "width": {
+          "type": "integer"
+        },
+        "height": {
+          "type": "integer"
+        },
+        "options": {
+          "type": "object"
+        },
+        "type": {
+          "enum": [
+            "heatmap"
+          ],
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/definitions/Data"
+        },
+        "position": {
+          "type": "string"
+        },
+        "transforms": {
+          "type": "array",
+          "items": {}
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "IndependentViewportProjectionTrack": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
+        },
+        "width": {
+          "type": "integer"
+        },
+        "height": {
+          "type": "integer"
+        },
+        "options": {
+          "type": "object"
+        },
+        "type": {
+          "enum": [
+            "viewport-projection-center",
+            "viewport-projection-vertical",
+            "viewport-projection-horizontal"
+          ],
+          "type": "string"
+        },
+        "fromViewUid": {
+          "type": "null"
+        },
+        "projectionXDomain": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "projectionYDomain": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "transforms": {
+          "type": "array",
+          "items": {}
+        },
+        "x": {
+          "type": "number"
+        },
+        "y": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "CombinedTrack": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "type": "string"
+        },
+        "width": {
+          "type": "integer"
+        },
+        "height": {
+          "type": "integer"
+        },
+        "options": {
+          "type": "object"
+        },
+        "type": {
+          "enum": [
+            "combined"
+          ],
+          "type": "string"
+        },
+        "contents": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/EnumTrack"
+              },
+              {
+                "$ref": "#/definitions/CombinedTrack"
+              },
+              {
+                "$ref": "#/definitions/HeatmapTrack"
+              },
+              {
+                "$ref": "#/definitions/IndependentViewportProjectionTrack"
+              }
+            ]
+          }
+        },
+        "position": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "contents"
+      ],
+      "additionalProperties": false
+    },
+    "Tracks": {
+      "description": "Track layout within a View.",
+      "type": "object",
+      "properties": {
+        "left": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/EnumTrack"
+              },
+              {
+                "$ref": "#/definitions/CombinedTrack"
+              },
+              {
+                "$ref": "#/definitions/HeatmapTrack"
+              },
+              {
+                "$ref": "#/definitions/IndependentViewportProjectionTrack"
+              }
+            ]
+          }
+        },
+        "right": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/EnumTrack"
+              },
+              {
+                "$ref": "#/definitions/CombinedTrack"
+              },
+              {
+                "$ref": "#/definitions/HeatmapTrack"
+              },
+              {
+                "$ref": "#/definitions/IndependentViewportProjectionTrack"
+              }
+            ]
+          }
+        },
+        "top": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/EnumTrack"
+              },
+              {
+                "$ref": "#/definitions/CombinedTrack"
+              },
+              {
+                "$ref": "#/definitions/HeatmapTrack"
+              },
+              {
+                "$ref": "#/definitions/IndependentViewportProjectionTrack"
+              }
+            ]
+          }
+        },
+        "bottom": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/EnumTrack"
+              },
+              {
+                "$ref": "#/definitions/CombinedTrack"
+              },
+              {
+                "$ref": "#/definitions/HeatmapTrack"
+              },
+              {
+                "$ref": "#/definitions/IndependentViewportProjectionTrack"
+              }
+            ]
+          }
+        },
+        "center": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/EnumTrack"
+              },
+              {
+                "$ref": "#/definitions/CombinedTrack"
+              },
+              {
+                "$ref": "#/definitions/HeatmapTrack"
+              },
+              {
+                "$ref": "#/definitions/IndependentViewportProjectionTrack"
+              }
+            ]
+          }
+        },
+        "whole": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/EnumTrack"
+              },
+              {
+                "$ref": "#/definitions/CombinedTrack"
+              },
+              {
+                "$ref": "#/definitions/HeatmapTrack"
+              },
+              {
+                "$ref": "#/definitions/IndependentViewportProjectionTrack"
+              }
+            ]
+          }
+        },
+        "gallery": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/EnumTrack"
+              },
+              {
+                "$ref": "#/definitions/CombinedTrack"
+              },
+              {
+                "$ref": "#/definitions/HeatmapTrack"
+              },
+              {
+                "$ref": "#/definitions/IndependentViewportProjectionTrack"
+              }
+            ]
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "GenomePositionSearchBox": {
+      "description": "Locations to search within a View.",
+      "type": "object",
+      "properties": {
+        "autocompleteServer": {
+          "description": "The Autocomplete Server URL",
+          "examples": [
+            "//higlass.io/api/v1"
+          ],
+          "type": "string"
+        },
+        "autocompleteId": {
+          "description": "The Autocomplete ID",
+          "examples": [
+            "OHJakQICQD6gTD7skx4EWA"
+          ],
+          "type": "string"
+        },
+        "chromInfoServer": {
+          "description": "The Chrominfo Server URL",
+          "examples": [
+            "//higlass.io/api/v1"
+          ],
+          "type": "string"
+        },
+        "chromInfoId": {
+          "description": "The Chromosome Info ID",
+          "examples": [
+            "hg19"
+          ],
+          "type": "string"
+        },
+        "visible": {
+          "description": "The Visible Schema",
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "OverlayOptions": {
+      "type": "object",
+      "properties": {
+        "extent": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          }
+        },
+        "minWidth": {
+          "type": "number"
+        },
+        "fill": {
+          "type": "string"
+        },
+        "fillOpacity": {
+          "type": "number"
+        },
+        "stroke": {
+          "type": "string"
+        },
+        "strokeOpacity": {
+          "type": "number"
+        },
+        "strokeWidth": {
+          "type": "number"
+        },
+        "strokePos": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "outline": {
+          "type": "string"
+        },
+        "outlineOpacity": {
+          "type": "number"
+        },
+        "outlineWidth": {
+          "type": "number"
+        },
+        "outlinePos": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "Overlay": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "uid": {
+          "type": "string"
+        },
+        "chromInfoPath": {
+          "type": "string"
+        },
+        "includes": {
+          "type": "array",
+          "items": {
             "type": "string"
           }
         },
-        "required": ["lock", "axis"],
-        "type": "object"
+        "options": {
+          "$ref": "#/definitions/OverlayOptions"
+        }
       },
-
-      "locationLocksByViewUid": {
-        "type": "object",
-        "additionalProperties": false,
-        "patternProperties": {
-          ".": {
+      "additionalProperties": false
+    },
+    "View": {
+      "description": "An arrangment of Tracks to display within a given Layout.",
+      "type": "object",
+      "properties": {
+        "layout": {
+          "$ref": "#/definitions/Layout"
+        },
+        "tracks": {
+          "$ref": "#/definitions/Tracks"
+        },
+        "uid": {
+          "type": "string"
+        },
+        "autocompleteSource": {
+          "type": "string"
+        },
+        "chromInfoPath": {
+          "type": "string"
+        },
+        "genomePositionSearchBox": {
+          "$ref": "#/definitions/GenomePositionSearchBox"
+        },
+        "genomePositionSearchBoxVisible": {
+          "type": "boolean"
+        },
+        "initialXDomain": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "initialYDomain": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "overlays": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Overlay"
+          }
+        },
+        "selectionView": {
+          "type": "boolean"
+        },
+        "zoomFixed": {
+          "type": "boolean"
+        },
+        "zoomLimits": {
+          "default": [
+            1,
+            null
+          ],
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        }
+      },
+      "required": [
+        "layout",
+        "tracks"
+      ],
+      "additionalProperties": false
+    },
+    "Lock": {
+      "type": "object",
+      "properties": {
+        "uid": {
+          "title": "Uid",
+          "type": "string"
+        }
+      },
+      "additionalProperties": {
+        "type": "array",
+        "minItems": 3,
+        "maxItems": 3,
+        "items": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      }
+    },
+    "ZoomLocks": {
+      "type": "object",
+      "properties": {
+        "locksByViewUid": {
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "locksDict": {
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Lock"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "AxisSpecificLock": {
+      "type": "object",
+      "properties": {
+        "axis": {
+          "enum": [
+            "x",
+            "y"
+          ],
+          "type": "string"
+        },
+        "lock": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "axis",
+        "lock"
+      ],
+      "additionalProperties": false
+    },
+    "AxisSpecificLocks": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "$ref": "#/definitions/AxisSpecificLock"
+        },
+        "y": {
+          "$ref": "#/definitions/AxisSpecificLock"
+        }
+      },
+      "additionalProperties": false
+    },
+    "LocationLocks": {
+      "type": "object",
+      "properties": {
+        "locksByViewUid": {
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
             "anyOf": [
               {
                 "type": "string"
               },
               {
-                "additionalProperties": false,
-                "properties": {
-                  "x": {
-                    "$ref": "#/definitions/locks/axisSpecificLocks"
-                  },
-                  "y": {
-                    "$ref": "#/definitions/locks/axisSpecificLocks"
-                  }
-                },
-                "type": "object"
+                "$ref": "#/definitions/AxisSpecificLocks"
               }
             ]
           }
-        }
-      },
-
-      "zoomLocks": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [],
-        "properties": {
-          "locksByViewUid": { "$ref": "#/definitions/locks/locksByViewUid" },
-          "locksDict": {
-            "type": "object",
-            "additionalProperties": false,
-            "patternProperties": {
-              ".": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "uid": { "$ref": "#/definitions/locks/slug" }
-                },
-                "patternProperties": {
-                  "^(?!uid).": {
-                    "type": "array",
-                    "minLength": 3,
-                    "maxLength": 3,
-                    "items": {
-                      "type": "number"
-                    }
-                  }
-                }
-              }
-            }
+        },
+        "locksDict": {
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Lock"
           }
         }
       },
-
-      "locationLocks": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [],
-        "properties": {
-          "locksByViewUid": {
-            "$ref": "#/definitions/locks/locationLocksByViewUid"
-          },
-          "locksDict": {
-            "type": "object",
-            "additionalProperties": false,
-            "patternProperties": {
-              ".": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "uid": { "$ref": "#/definitions/locks/slug" }
-                },
-                "patternProperties": {
-                  "^(?!uid).": {
-                    "type": "array",
-                    "minLength": 3,
-                    "maxLength": 3,
-                    "items": {
-                      "type": "number"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-
-      "valueScaleLocks": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["locksByViewUid", "locksDict"],
-        "properties": {
-          "locksByViewUid": { "$ref": "#/definitions/locks/locksByViewUid" },
-          "locksDict": {
-            "type": "object",
-            "additionalProperties": false,
-            "patternProperties": {
-              ".": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "uid": { "$ref": "#/definitions/locks/slug" },
-                  "ignoreOffScreenValues": { "type": "boolean" }
-                },
-                "patternProperties": {
-                  "^(?!(uid|ignoreOffScreenValues)).": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "required": ["view", "track"],
-                    "properties": {
-                      "view": { "type": "string" },
-                      "track": { "$ref": "#/definitions/locks/slug" }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+      "additionalProperties": false
     },
-
-    "view": {
+    "ValueScaleLock": {
       "type": "object",
-      "additionalProperties": false,
-      "required": ["tracks", "layout"],
       "properties": {
-        "autocompleteSource": { "type": "string" },
-        "chromInfoPath": { "type": "string" },
-        "genomePositionSearchBox": {
-          "$ref": "#/definitions/viewProperties/genomePositionSearchBox"
+        "uid": {
+          "title": "Uid",
+          "type": "string"
         },
-        "genomePositionSearchBoxVisible": { "type": "boolean" },
-        "initialXDomain": { "$ref": "#/definitions/viewProperties/domain" },
-        "initialYDomain": { "$ref": "#/definitions/viewProperties/domain" },
-        "layout": { "$ref": "#/definitions/viewProperties/layout" },
-        "overlays": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/viewProperties/overlay" }
-        },
-        "selectionView": { "type": "boolean" },
-        "tracks": { "$ref": "#/definitions/viewProperties/tracks_object" },
-        "uid": { "type": "string" },
-        "zoomFixed": { "type": "boolean" },
-        "zoomLimits": {
-          "type": "array",
-          "minLength": 2,
-          "maxLength": 2,
-          "default": [1, null]
+        "ignoreOffScreenValues": {
+          "title": "Ignoreoffscreenvalues",
+          "type": "boolean"
         }
+      },
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "view": {
+            "type": "string"
+          },
+          "track": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "view",
+          "track"
+        ]
       }
     },
-
-    "viewProperties": {
-      "genomePositionSearchBox": {
-        "type": "object",
-        "title": "The Genome Position Search Box Schema",
-        "required": ["chromInfoServer", "chromInfoId"],
-        "properties": {
-          "autocompleteServer": {
-            "type": "string",
-            "title": "The Autocomplete Server URL",
-            "default": "",
-            "examples": ["//higlass.io/api/v1"],
-            "pattern": "^(.*)$"
-          },
-          "autocompleteId": {
-            "type": "string",
-            "title": "The Autocomplete ID",
-            "default": "",
-            "examples": ["OHJakQICQD6gTD7skx4EWA"],
-            "pattern": "^(.*)$"
-          },
-          "chromInfoServer": {
-            "type": "string",
-            "title": "The Chrominfo Server URL",
-            "default": "",
-            "examples": ["//higlass.io/api/v1"],
-            "pattern": "^(.*)$"
-          },
-          "chromInfoId": {
-            "type": "string",
-            "title": "The Chromosome Info ID",
-            "default": "",
-            "examples": ["hg19"],
-            "pattern": "^(.*)$"
-          },
-          "visible": {
-            "type": "boolean",
-            "title": "The Visible Schema",
-            "default": false
+    "ValueScaleLocks": {
+      "type": "object",
+      "properties": {
+        "locksByViewUid": {
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "locksDict": {
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ValueScaleLock"
           }
         }
       },
-
-      "overlay": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "chromInfoPath": { "type": "string" },
-          "includes": { "type": "array" },
-          "options": {
-            "type": "object",
-            "properties": {
-              "extent": { "type": "array" },
-              "minWidth": { "type": "number" },
-              "fill": { "type": "string" },
-              "fillOpacity": { "type": "number" },
-              "stroke": { "type": "string" },
-              "strokeOpacity": { "type": "number" },
-              "strokeWidth": { "type": "number" },
-              "strokePos": { "type": ["string", "array"] },
-              "outline": { "type": "string" },
-              "outlineOpacity": { "type": "number" },
-              "outlineWidth": { "type": "number" },
-              "outlinePos": { "type": ["string", "array"] }
-            }
-          },
-          "type": { "type": "string" },
-          "uid": { "type": "string" }
-        }
-      },
-
-      "layout": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["w", "h", "x", "y"],
-        "properties": {
-          "x": {
-            "type": "integer",
-            "title": "The X Position",
-            "default": 0
-          },
-          "y": {
-            "type": "integer",
-            "title": "The Y Position",
-            "default": 0
-          },
-          "w": {
-            "type": "integer",
-            "title": "Width",
-            "default": 12
-          },
-          "h": {
-            "type": "integer",
-            "title": "Height",
-            "default": 12
-          },
-          "moved": { "type": "boolean" },
-          "static": { "type": "boolean" }
-        }
-      },
-
-      "tracks_object": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "left": { "$ref": "#/definitions/viewProperties/tracks_array" },
-          "right": { "$ref": "#/definitions/viewProperties/tracks_array" },
-          "top": { "$ref": "#/definitions/viewProperties/tracks_array" },
-          "bottom": { "$ref": "#/definitions/viewProperties/tracks_array" },
-          "center": { "$ref": "#/definitions/viewProperties/tracks_array" },
-          "whole": { "$ref": "#/definitions/viewProperties/tracks_array" },
-          "gallery": { "$ref": "#/definitions/viewProperties/tracks_array" }
-        }
-      },
-
-      "tracks_array": {
-        "type": "array",
-        "items": {
-          "oneOf": [
-            { "$ref": "#/definitions/tracks/enum_track" },
-            { "$ref": "#/definitions/tracks/combined_track" },
-            { "$ref": "#/definitions/tracks/heatmap_track" },
-            {
-              "$ref": "#/definitions/tracks/independent_viewport_projection_track"
-            }
-          ]
-        }
-      },
-
-      "domain": {
-        "type": "array",
-        "items": { "type": "number" },
-        "maxItems": 2,
-        "minItems": 2
-      }
-    },
-
-    "tracks": {
-      "heatmap_track": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [],
-        "properties": {
-          "uid": { "type": "string" },
-          "type": { "const": "heatmap" },
-          "data": { "$ref": "#/definitions/data" },
-          "height": { "type": "number" },
-          "options": { "type": "object" },
-          "position": { "type": "string" },
-          "server": { "type": "string" },
-          "tilesetUid": { "type": "string" },
-          "width": { "type": "number" },
-          "transforms": { "type": "array" }
-        }
-      },
-
-      "combined_track": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["contents"],
-        "properties": {
-          "contents": { "$ref": "#/definitions/viewProperties/tracks_array" },
-          "height": { "type": "number" },
-          "options": {},
-          "position": { "type": "string" },
-          "type": { "const": "combined" },
-          "uid": { "type": "string" },
-          "width": { "type": "number" }
-        }
-      },
-
-      "enum_track": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["type"],
-        "properties": {
-          "server": { "type": "string" },
-          "tilesetUid": { "type": "string" },
-          "data": { "$ref": "#/definitions/data" },
-          "uid": { "type": "string" },
-          "type": {
-            "enum": [
-              "multivec",
-              "1d-heatmap",
-              "line",
-              "point",
-              "bar",
-              "divergent-bar",
-              "stacked-interval",
-              "gene-annotations",
-              "linear-2d-rectangle-domains",
-              "chromosome-labels",
-              "linear-heatmap",
-              "1d-value-interval",
-              "2d-annotations",
-              "2d-chromosome-annotations",
-              "2d-chromosome-grid",
-              "2d-chromosome-labels",
-              "2d-rectangle-domains",
-              "2d-tiles",
-              "arrowhead-domains",
-              "bedlike",
-              "cross-rule",
-              "dummy",
-              "horizontal-1d-annotations",
-              "horizontal-1d-heatmap",
-              "horizontal-1d-tiles",
-              "horizontal-1d-value-interval",
-              "horizontal-2d-rectangle-domains",
-              "horizontal-bar",
-              "horizontal-chromosome-grid",
-              "horizontal-chromosome-labels",
-              "horizontal-divergent-bar",
-              "horizontal-gene-annotations",
-              "horizontal-heatmap",
-              "horizontal-line",
-              "horizontal-multivec",
-              "horizontal-point",
-              "horizontal-rule",
-              "horizontal-vector-heatmap",
-              "image-tiles",
-              "left-axis",
-              "left-stacked-interval",
-              "mapbox-tiles",
-              "osm-2d-tile-ids",
-              "osm-tiles",
-              "raster-tiles",
-              "simple-svg",
-              "square-markers",
-              "top-axis",
-              "top-stacked-interval",
-              "vertical-1d-annotations",
-              "vertical-1d-heatmap",
-              "vertical-1d-tiles",
-              "vertical-1d-value-interval",
-              "vertical-2d-rectangle-domains",
-              "vertical-bar",
-              "vertical-bedlike",
-              "vertical-chromosome-grid",
-              "vertical-chromosome-labels",
-              "vertical-gene-annotations",
-              "vertical-heatmap",
-              "vertical-line",
-              "vertical-multivec",
-              "vertical-point",
-              "vertical-rule",
-              "vertical-vector-heatmap",
-              "viewport-projection-center",
-              "viewport-projection-horizontal",
-              "viewport-projection-vertical"
-            ]
-          },
-          "chromInfoPath": { "type": "string" },
-          "fromViewUid": { "type": "string" },
-          "height": { "type": "number" },
-          "options": { "type": "object" },
-          "width": { "type": "number" },
-          "x": { "type": "number" },
-          "y": { "type": "number" }
-        }
-      },
-      "independent_viewport_projection_track": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "uid": { "type": "string" },
-          "type": {
-            "enum": [
-              "viewport-projection-horizontal",
-              "viewport-projection-vertical",
-              "viewport-projection-center"
-            ]
-          },
-          "fromViewUid": { "type": "null" },
-          "projectionXDomain": {
-            "$ref": "#/definitions/viewProperties/domain"
-          },
-          "projectionYDomain": {
-            "$ref": "#/definitions/viewProperties/domain"
-          },
-          "options": { "type": "object" },
-          "transforms": { "type": "array" },
-          "width": { "type": "number" },
-          "x": { "type": "number" },
-          "y": { "type": "number" }
-        }
-      }
+      "additionalProperties": false
     }
   }
 }


### PR DESCRIPTION
## Description

The file checked in was generated via:

```bash
pip install git+https://github.com/higlass/higlass-schema
python -m higlass_schema.main > app/schema.json
```

If the changes are desirable, we can discuss how to add `higlass_schema` as a dependency to this repo.

> What was changed in this pull request?

This PR introduces `schema.json` generated from [`higlass/higlass-schema`](https://github.com/higlass/higlass-schema). It replaces the old schema with one that is generated automatically from python class definitions. 

 The initial python code was bootstrapped via a [code-generation tool](https://pydantic-docs.helpmanual.io/datamodel_code_generator/) which used the `schema.json` from this repo as input. Classes were modified manually to better reflect the types described here. 


> Why is it necessary?

This is a step towards keeping the higlass client and any python API in sync with minimal manual refinement. The idea is that `higlass/higlass-schema` serves as the "source of truth" and schema changes should occur there.

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [x] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
