### PR TITLE
Fix AMD name for pixi.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Correctly setup initial scales of vertical tracks when the width of a center track is zero.
 - Config-wise, allow axis-specific location locks (e.g., lock the vertical axis in a view to the horizontal axis in another).
 - Add `reload` implementation to `HiGlassComponenet` API.
+- Rename AMD module name for `"pixi.js"` to `"pixi"`.
 
 _[Detailed changes since v1.11.5](https://github.com/higlass/higlass/compare/v1.11.7...develop)_
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -180,7 +180,7 @@ module.exports = (env, argv) => ({
     'pixi.js': {
       commonjs: 'pixi.js',
       commonjs2: 'pixi.js',
-      amd: 'pixi.js',
+      amd: 'pixijs',
       root: 'PIXI'
     },
     react: {


### PR DESCRIPTION
## Description
You cannot load HiGlass as an AMD module with RequireJS.

```javascript
window.require?.config({
	paths: {
		"react": `https://unpkg.com/react@17.0.2/umd/react.production.min`,
		"react-dom": `https://unpkg.com/react-dom@17.0.2/umd/react-dom.production.min`,
		"pixi.js": `https://unpkg.com/pixi.js@6.2.2/dist/browser/pixi.min`,
		"higlass": `https://unpkg.com/@11.1/dist/higlib`,
	},
});

define(["higlass"], function (hglib) { // err, tries to require "localhost:8000/pixi.js"
  // do something ... 
})
```

An AMD module in RequireJS cannot include ".js", or else it is inferred to be a be a _file_ rather than another module. 
Jupyter widgets (in classic notebooks) use AMD modules via RequireJS.  This PR changes the AMD name to "pixijs", so that it can be aliased correctly in the require config.

```javascript
window.require?.config({
	paths: {
        // ...
		"pixijs": `https://unpkg.com/pixi.js@6.2.2/dist/browser/pixi.min`,
       // ...
	},
});
```

- reference: https://www.html5gamedevs.com/topic/43179-solved-how-to-run-pixijs-typescript-with-amd-and-requirejs/

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md

PS: Is there any chance that we could do a release soon with #1062?