### PR TITLE
chore: bump pub-sub-es to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2399,7 +2399,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -2515,11 +2516,6 @@
         "hoopy": "^0.1.2",
         "tryer": "^1.0.0"
       }
-    },
-    "big-integer": {
-      "version": "1.6.43",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.43.tgz",
-      "integrity": "sha512-9dULc9jsKmXl0Aeunug8wbF+58n+hQoFjqClN7WeZwGLh0XJUWyJJ9Ee+Ep+Ql/J9fRsTVaeThp8MhiCCrY0Jg=="
     },
     "big.js": {
       "version": "5.2.2",
@@ -2771,6 +2767,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2865,20 +2862,6 @@
           "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
-      }
-    },
-    "broadcast-channel": {
-      "version": "2.1.12",
-      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-2.1.12.tgz",
-      "integrity": "sha512-U0b7c3Nwru3a8nDRt9R2OYXhX8GfmcEeaCwBZyIly7CIS3de4eXcl+DO6jgN6ux4Ly2eeBoBGKVneS60Cpfnjw==",
-      "requires": {
-        "@babel/runtime": "7.4.3",
-        "detect-node": "2.0.4",
-        "js-sha3": "0.8.0",
-        "microseconds": "0.1.0",
-        "nano-time": "1.0.0",
-        "rimraf": "2.6.3",
-        "unload": "2.1.0"
       }
     },
     "brorand": {
@@ -4140,7 +4123,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -5963,7 +5947,8 @@
     "detect-node": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
-      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
+      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
+      "dev": true
     },
     "dev-ip": {
       "version": "1.0.1",
@@ -8104,7 +8089,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "1.2.8",
@@ -8925,6 +8911,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -9883,6 +9870,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -10535,11 +10523,6 @@
           }
         }
       }
-    },
-    "js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -12573,11 +12556,6 @@
         }
       }
     },
-    "microseconds": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.1.0.tgz",
-      "integrity": "sha1-R9x7z2IXG4Aw4hUv2C8SpolKcRk="
-    },
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -12654,6 +12632,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -13108,14 +13087,6 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
       "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
       "dev": true
-    },
-    "nano-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
-      "integrity": "sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=",
-      "requires": {
-        "big-integer": "^1.6.16"
-      }
     },
     "nanoid": {
       "version": "2.0.1",
@@ -13724,6 +13695,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -14214,7 +14186,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -17157,12 +17130,9 @@
       "dev": true
     },
     "pub-sub-es": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/pub-sub-es/-/pub-sub-es-1.2.1.tgz",
-      "integrity": "sha512-QohEHVGVMa1u3qCO/dSZ0KbLrel5R1ARW8BuXGuUWP6Z0n7SmKbRfKuZgEDu7YIedkVp9AZmdpWy92QGJrQ39Q==",
-      "requires": {
-        "broadcast-channel": "^2.1.8"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pub-sub-es/-/pub-sub-es-2.0.1.tgz",
+      "integrity": "sha512-KuL5i+1YdQ/o9xGCz7AsG6hb6PBUFhKNIt3NhZ6Jh/d6F3fVfURyq5fAAwxPcpJS6kkrR4vOYyzZfMpYI8sxlQ=="
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -18153,6 +18123,7 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -20566,30 +20537,6 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
-    "unload": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/unload/-/unload-2.1.0.tgz",
-      "integrity": "sha512-vOg/orTFrHv60iWLZbBpgrgoFaSovkcgQJUmBHNGFWlSFdwtoANZaT3uSePVhggkWSsPxs2rpBl5LHpmcSGjRw==",
-      "requires": {
-        "@babel/runtime": "7.1.5",
-        "detect-node": "2.0.4"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.1.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz",
-          "integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
-          "requires": {
-            "regenerator-runtime": "^0.12.0"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
-        }
-      }
-    },
     "unminified-webpack-plugin": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unminified-webpack-plugin/-/unminified-webpack-plugin-2.0.0.tgz",
@@ -21591,7 +21538,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "path": "^0.12.7",
     "prismjs": "^1.16.0",
     "prop-types": "^15.6.0",
-    "pub-sub-es": "^1.2.1",
+    "pub-sub-es": "^2.0.1",
     "react": "^16.6.3",
     "react-autocomplete": "github:tiemevanveen/react-autocomplete#fix-176",
     "react-bootstrap": "0.32.1",


### PR DESCRIPTION
## Description

> Why is it necessary?

I've been working on several applications with both HiGlass/Gosling where I'm generating HTML on the fly for the web-browser. I'd like to avoid writing the HTML to disk, and instead load the content via a data url (e.g. `data:text/html,<doctype!><html><h1>Hey</h1></html>`). Currently this throws an unrecoverable error due to an edge case with the version of `pub-sub-es` that higlass is on. This can additionally be useful with `puppeteer` for taking screenshots:

```javascript
import puppeteer from "puppeteer";

let viewconf = JSON.stringify(...);
let html = `\
<!doctype html>
<head>
  <link rel="stylesheet" href="https://unpkg.com/higlass@1.7/dist/hglib.css">
  <script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
  <script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
  <script src="https://unpkg.com/pixi.js@6/dist/browser/pixi.min.js"></script>
  <script src="https://unpkg.com/higlass@1.7/dist/hglib.min.js"></script>
</head>
<body></body>
<script>
	hglib.viewer(document.body, JSON.parse(\`${viewconf}\`);
</script>
</html>`;

let browser = await puppeteer.launch();
let page = await browser.newPage();
await page.setContent(html, { waitUntil: "networkidle0" });
let component = await page.waitForSelector(".higlass");
await component.screenshot({ path: "./example.jpeg" });
await browser.close();
```

> Details

`pub-sub-es` instantiates a browser `BroadcastChannel` if available _on import_ to broadcast events from the `gloablPubSub`. Instantiating a `BroadcastChannel` throws if the website does not contain an origin, which is the case when the page content _is_ the url. The previous version of `pub-sub-es` doesn't catch this edge case,

####  **pub-sub-es v1.2**
```javascript
const bc = (() => {
  const BC = window.BroadcastChannel;
  if (!BC) {
    console.warn("The Broadcast Channel API is not available in your browser.");
    return { postMessage: () => {} };
  }
  return new BC("pub-sub-es"); // throws because no origin, not caught
})();
```

while the latest version wraps the instantiation in a blanket `try`/`catch`.

#### **pub-sub-es v2**

```javascript
const bc = (() => {
  try {
    return new window.BroadcastChannel('pub-sub-es');
  } catch (e) {
    return { postMessage: () => {} };
  }
})();
```

### Breaking changes?

From what I can tell, the breaking changes in v2 are changes to options parameter for `createPubSub`, which higlass does not rely on. @flekschas 

https://github.com/flekschas/pub-sub/blob/master/CHANGELOG.md

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
