### PR TITLE
fix: deprecation warning for pixi.js@6.x.x

### DIFF
--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -512,9 +512,8 @@ class HiGlassComponent extends React.Component {
       autoResize: true,
     };
     
-
     const version_number = parseInt(PIXI.VERSION[0])
-    
+
     if (version_number === 4) {
       console.warn(
         'Deprecation warning: please update Pixi.js to version 5 or above!',
@@ -524,18 +523,14 @@ class HiGlassComponent extends React.Component {
       } else {
         this.pixiRenderer = new GLOBALS.PIXI.WebGLRenderer(rendererOptions);
       }
-    } else if (version_number < 4) {
-      console.warn(
-        'Deprecation warning: please update Pixi.js to version 5 or above! ' +
-          'This version of Pixi.js is unsupported. Good luck 🤞',
-      );
-      if (this.props.options.renderer === 'canvas') {
-        this.pixiRenderer = new GLOBALS.PIXI.CanvasRenderer(rendererOptions);
-      } else {
-        this.pixiRenderer = new GLOBALS.PIXI.Renderer(rendererOptions);
-      }
     } else {
-      // version 5 or above
+      if (version_number < 4) {
+        console.warn(
+          'Deprecation warning: please update Pixi.js to version 5 or above! ' +
+          'This version of Pixi.js is unsupported. Good luck 🤞',
+        );
+      }
+
       if (this.props.options.renderer === 'canvas') {
         this.pixiRenderer = new GLOBALS.PIXI.CanvasRenderer(rendererOptions);
       } else {

--- a/app/scripts/HiGlassComponent.js
+++ b/app/scripts/HiGlassComponent.js
@@ -511,32 +511,36 @@ class HiGlassComponent extends React.Component {
       resolution: 2,
       autoResize: true,
     };
+    
 
-    switch (PIXI.VERSION[0]) {
-      case '4':
-        console.warn(
-          'Deprecation warning: please update Pixi.js to version 5!',
-        );
-        if (this.props.options.renderer === 'canvas') {
-          this.pixiRenderer = new GLOBALS.PIXI.CanvasRenderer(rendererOptions);
-        } else {
-          this.pixiRenderer = new GLOBALS.PIXI.WebGLRenderer(rendererOptions);
-        }
-        break;
-
-      default:
-        console.warn(
-          'Deprecation warning: please update Pixi.js to version 5! ' +
-            'This version of Pixi.js is unsupported. Good luck 🤞',
-        );
-      // eslint-disable-next-line
-      case '5':
-        if (this.props.options.renderer === 'canvas') {
-          this.pixiRenderer = new GLOBALS.PIXI.CanvasRenderer(rendererOptions);
-        } else {
-          this.pixiRenderer = new GLOBALS.PIXI.Renderer(rendererOptions);
-        }
-        break;
+    const version_number = parseInt(PIXI.VERSION[0])
+    
+    if (version_number === 4) {
+      console.warn(
+        'Deprecation warning: please update Pixi.js to version 5 or above!',
+      );
+      if (this.props.options.renderer === 'canvas') {
+        this.pixiRenderer = new GLOBALS.PIXI.CanvasRenderer(rendererOptions);
+      } else {
+        this.pixiRenderer = new GLOBALS.PIXI.WebGLRenderer(rendererOptions);
+      }
+    } else if (version_number < 4) {
+      console.warn(
+        'Deprecation warning: please update Pixi.js to version 5 or above! ' +
+          'This version of Pixi.js is unsupported. Good luck 🤞',
+      );
+      if (this.props.options.renderer === 'canvas') {
+        this.pixiRenderer = new GLOBALS.PIXI.CanvasRenderer(rendererOptions);
+      } else {
+        this.pixiRenderer = new GLOBALS.PIXI.Renderer(rendererOptions);
+      }
+    } else {
+      // version 5 or above
+      if (this.props.options.renderer === 'canvas') {
+        this.pixiRenderer = new GLOBALS.PIXI.CanvasRenderer(rendererOptions);
+      } else {
+        this.pixiRenderer = new GLOBALS.PIXI.Renderer(rendererOptions);
+      }
     }
 
     // PIXI.RESOLUTION=2;


### PR DESCRIPTION


## Description

> What was changed in this pull request?

fix: deprecation warning for pixi.js 6.x.x

> Why is it necessary?

The current script gives a deprecation warning when using the latest pixi.js

## Checklist
Not applicable
- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
