### PR TITLE
chore: rename Adapter imports from 'enzyme-adapter-react-16' -> '@wojtekmaj/enzyme-adapter-react-17'

### DIFF
--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -50,7 +50,7 @@ add a line to `karma.conf.js` to include it in the tests.
       // render,
     } from 'enzyme';
 
-    import Adapter from 'enzyme-adapter-react-16';
+    import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 
     import { expect } from 'chai';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
         "babel-plugin-react-css-modules": "^5.2.6",
         "chai": "^4.3.4",
         "enzyme": "^3.4.1",
-        "enzyme-adapter-react-16": "^1.2.0",
         "eslint": "^8.7.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^8.3.0",
@@ -1860,35 +1859,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/airbnb-prop-types": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.16.0.tgz",
-      "integrity": "sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==",
-      "dev": true,
-      "dependencies": {
-        "array.prototype.find": "^2.1.1",
-        "function.prototype.name": "^1.1.2",
-        "is-regex": "^1.1.0",
-        "object-is": "^1.1.2",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.2",
-        "prop-types": "^15.7.2",
-        "prop-types-exact": "^1.2.0",
-        "react-is": "^16.13.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      },
-      "peerDependencies": {
-        "react": "^0.14 || ^15.0.0 || ^16.0.0-alpha"
-      }
-    },
-    "node_modules/airbnb-prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2083,21 +2053,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.find": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.2.0.tgz",
-      "integrity": "sha512-sn40qmUiLYAcRb/1HsIQjTTZ1kCy8II8VtZJpMn2Aoen9twULhbWXisfh3HimGqMlHGUul0/TfKCnXg42LuPpQ==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.4",
-        "es-shim-unscopables": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3729,101 +3684,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/enzyme-adapter-react-16": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.6.tgz",
-      "integrity": "sha512-yFlVJCXh8T+mcQo8M6my9sPgeGzj85HSHi6Apgf1Cvq/7EL/J9+1JoJmJsRxZgyTvPMAqOEpRSu/Ii/ZpyOk0g==",
-      "dev": true,
-      "dependencies": {
-        "enzyme-adapter-utils": "^1.14.0",
-        "enzyme-shallow-equal": "^1.0.4",
-        "has": "^1.0.3",
-        "object.assign": "^4.1.2",
-        "object.values": "^1.1.2",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.13.1",
-        "react-test-renderer": "^16.0.0-0",
-        "semver": "^5.7.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      },
-      "peerDependencies": {
-        "enzyme": "^3.0.0",
-        "react": "^16.0.0-0",
-        "react-dom": "^16.0.0-0"
-      }
-    },
-    "node_modules/enzyme-adapter-react-16/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
-    },
-    "node_modules/enzyme-adapter-react-16/node_modules/react-test-renderer": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
-      "integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
-      "dev": true,
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.8.6",
-        "scheduler": "^0.19.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0"
-      }
-    },
-    "node_modules/enzyme-adapter-react-16/node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "node_modules/enzyme-adapter-react-16/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/enzyme-adapter-utils": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.14.0.tgz",
-      "integrity": "sha512-F/z/7SeLt+reKFcb7597IThpDp0bmzcH1E9Oabqv+o01cID2/YInlqHbFl7HzWBl4h3OdZYedtwNDOmSKkk0bg==",
-      "dev": true,
-      "dependencies": {
-        "airbnb-prop-types": "^2.16.0",
-        "function.prototype.name": "^1.1.3",
-        "has": "^1.0.3",
-        "object.assign": "^4.1.2",
-        "object.fromentries": "^2.0.3",
-        "prop-types": "^15.7.2",
-        "semver": "^5.7.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      },
-      "peerDependencies": {
-        "react": "0.13.x || 0.14.x || ^15.0.0-0 || ^16.0.0-0"
-      }
-    },
-    "node_modules/enzyme-adapter-utils/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/enzyme-shallow-equal": {
@@ -8021,17 +7881,6 @@
         "react-is": "^16.13.1"
       }
     },
-    "node_modules/prop-types-exact": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
-      "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
-      "dev": true,
-      "dependencies": {
-        "has": "^1.0.3",
-        "object.assign": "^4.1.0",
-        "reflect.ownkeys": "^0.2.0"
-      }
-    },
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -8486,12 +8335,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/reflect.ownkeys": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
-      "integrity": "sha512-qOLsBKHCpSOFKK1NUOCGC5VyeufB6lEsFe92AL2bhIJsacZS1qdoOZSbPk3MYKuT2cFlRDnulKXuuElIrMjGUg==",
-      "dev": true
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
@@ -11192,31 +11035,6 @@
         "indent-string": "^4.0.0"
       }
     },
-    "airbnb-prop-types": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.16.0.tgz",
-      "integrity": "sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==",
-      "dev": true,
-      "requires": {
-        "array.prototype.find": "^2.1.1",
-        "function.prototype.name": "^1.1.2",
-        "is-regex": "^1.1.0",
-        "object-is": "^1.1.2",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.2",
-        "prop-types": "^15.7.2",
-        "prop-types-exact": "^1.2.0",
-        "react-is": "^16.13.1"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-          "dev": true
-        }
-      }
-    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -11358,18 +11176,6 @@
         "es-abstract": "^1.19.0",
         "es-array-method-boxes-properly": "^1.0.0",
         "is-string": "^1.0.7"
-      }
-    },
-    "array.prototype.find": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.2.0.tgz",
-      "integrity": "sha512-sn40qmUiLYAcRb/1HsIQjTTZ1kCy8II8VtZJpMn2Aoen9twULhbWXisfh3HimGqMlHGUul0/TfKCnXg42LuPpQ==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.4",
-        "es-shim-unscopables": "^1.0.0"
       }
     },
     "array.prototype.flat": {
@@ -12596,82 +12402,6 @@
         "raf": "^3.4.1",
         "rst-selector-parser": "^2.2.3",
         "string.prototype.trim": "^1.2.1"
-      }
-    },
-    "enzyme-adapter-react-16": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.6.tgz",
-      "integrity": "sha512-yFlVJCXh8T+mcQo8M6my9sPgeGzj85HSHi6Apgf1Cvq/7EL/J9+1JoJmJsRxZgyTvPMAqOEpRSu/Ii/ZpyOk0g==",
-      "dev": true,
-      "requires": {
-        "enzyme-adapter-utils": "^1.14.0",
-        "enzyme-shallow-equal": "^1.0.4",
-        "has": "^1.0.3",
-        "object.assign": "^4.1.2",
-        "object.values": "^1.1.2",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.13.1",
-        "react-test-renderer": "^16.0.0-0",
-        "semver": "^5.7.0"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-          "dev": true
-        },
-        "react-test-renderer": {
-          "version": "16.14.0",
-          "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
-          "integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-is": "^16.8.6",
-            "scheduler": "^0.19.1"
-          }
-        },
-        "scheduler": {
-          "version": "0.19.1",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
-      }
-    },
-    "enzyme-adapter-utils": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.14.0.tgz",
-      "integrity": "sha512-F/z/7SeLt+reKFcb7597IThpDp0bmzcH1E9Oabqv+o01cID2/YInlqHbFl7HzWBl4h3OdZYedtwNDOmSKkk0bg==",
-      "dev": true,
-      "requires": {
-        "airbnb-prop-types": "^2.16.0",
-        "function.prototype.name": "^1.1.3",
-        "has": "^1.0.3",
-        "object.assign": "^4.1.2",
-        "object.fromentries": "^2.0.3",
-        "prop-types": "^15.7.2",
-        "semver": "^5.7.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
       }
     },
     "enzyme-shallow-equal": {
@@ -15746,17 +15476,6 @@
         }
       }
     },
-    "prop-types-exact": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
-      "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.3",
-        "object.assign": "^4.1.0",
-        "reflect.ownkeys": "^0.2.0"
-      }
-    },
     "proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -16091,12 +15810,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
       "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
-      "dev": true
-    },
-    "reflect.ownkeys": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
-      "integrity": "sha512-qOLsBKHCpSOFKK1NUOCGC5VyeufB6lEsFe92AL2bhIJsacZS1qdoOZSbPk3MYKuT2cFlRDnulKXuuElIrMjGUg==",
       "dev": true
     },
     "regenerator-runtime": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "babel-plugin-react-css-modules": "^5.2.6",
     "chai": "^4.3.4",
     "enzyme": "^3.4.1",
-    "enzyme-adapter-react-16": "^1.2.0",
     "eslint": "^8.7.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.3.0",

--- a/test/2DRectangleDomainsTests.js
+++ b/test/2DRectangleDomainsTests.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 // Utils

--- a/test/AddAndRemoveViewconfTests.js
+++ b/test/AddAndRemoveViewconfTests.js
@@ -1,6 +1,6 @@
 /* eslint-env node, mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import { simpleCenterViewConfig } from './view-configs';

--- a/test/AddTrackTests.js
+++ b/test/AddTrackTests.js
@@ -1,6 +1,6 @@
 /* eslint-env node, mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import { oneViewConfig } from './view-configs';

--- a/test/AxisSpecificLocationLockTests.js
+++ b/test/AxisSpecificLocationLockTests.js
@@ -1,6 +1,6 @@
 /* eslint-env node, mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import Ajv from 'ajv';

--- a/test/AxisTests.js
+++ b/test/AxisTests.js
@@ -1,6 +1,6 @@
 /* eslint-env node, mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import FetchMockHelper from './utils/FetchMockHelper';

--- a/test/BarTrackTests.js
+++ b/test/BarTrackTests.js
@@ -1,6 +1,6 @@
 /* eslint-env node, mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 // Utils

--- a/test/BedLikeTests.js
+++ b/test/BedLikeTests.js
@@ -1,6 +1,6 @@
 /* eslint-env node, jasmine, mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 // Utils

--- a/test/ChromSizesTests.js
+++ b/test/ChromSizesTests.js
@@ -1,6 +1,6 @@
 /* eslint-env node, mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 // Utils

--- a/test/ChromosomeLabelsTests.js
+++ b/test/ChromosomeLabelsTests.js
@@ -1,6 +1,6 @@
 /* eslint-env node, mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 // Utils

--- a/test/DenseDataExtremaTests.js
+++ b/test/DenseDataExtremaTests.js
@@ -1,6 +1,6 @@
 /* eslint-env node, mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import FetchMockHelper from './utils/FetchMockHelper';

--- a/test/EmptyTrackTests.js
+++ b/test/EmptyTrackTests.js
@@ -1,6 +1,6 @@
 /* eslint-env node, mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 // Utils

--- a/test/GeneAnnotationsTrackTests.js
+++ b/test/GeneAnnotationsTrackTests.js
@@ -1,6 +1,6 @@
 /* eslint-env node, mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import { geneAnnotationsOnly } from './view-configs';

--- a/test/GenomePositionSearchBoxTest.jsx
+++ b/test/GenomePositionSearchBoxTest.jsx
@@ -1,6 +1,6 @@
 /* eslint-env node, mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import React from 'react';

--- a/test/HeatmapTests.js
+++ b/test/HeatmapTests.js
@@ -1,6 +1,6 @@
 /* eslint-env node, mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 // Utils

--- a/test/HiGlassComponent/1d-viewport-projection.js
+++ b/test/HiGlassComponent/1d-viewport-projection.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import {

--- a/test/HiGlassComponent/2d-rectangle-domains.js
+++ b/test/HiGlassComponent/2d-rectangle-domains.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import {

--- a/test/HiGlassComponent/add-overlay-tracks.js
+++ b/test/HiGlassComponent/add-overlay-tracks.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import {

--- a/test/HiGlassComponent/api.js
+++ b/test/HiGlassComponent/api.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import { mountHGComponent, removeHGComponent } from '../../app/scripts/utils';

--- a/test/HiGlassComponent/cheat-codes.js
+++ b/test/HiGlassComponent/cheat-codes.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 
 import { mountHGComponent, removeHGComponent } from '../../app/scripts/utils';
 

--- a/test/HiGlassComponent/chromosome-labels.js
+++ b/test/HiGlassComponent/chromosome-labels.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import {

--- a/test/HiGlassComponent/close-view-tests.js
+++ b/test/HiGlassComponent/close-view-tests.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import {

--- a/test/HiGlassComponent/color-scale-limiting.js
+++ b/test/HiGlassComponent/color-scale-limiting.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import {

--- a/test/HiGlassComponent/colormap-tests.js
+++ b/test/HiGlassComponent/colormap-tests.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 
 import {
   mountHGComponent,

--- a/test/HiGlassComponent/divergent-track.js
+++ b/test/HiGlassComponent/divergent-track.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import { mountHGComponent, removeHGComponent } from '../../app/scripts/utils';

--- a/test/HiGlassComponent/division-track.js
+++ b/test/HiGlassComponent/division-track.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 
 import { mountHGComponent, removeHGComponent } from '../../app/scripts/utils';
 

--- a/test/HiGlassComponent/double-view.js
+++ b/test/HiGlassComponent/double-view.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import ReactDOM from 'react-dom';

--- a/test/HiGlassComponent/existing-genome-position-search-box.js
+++ b/test/HiGlassComponent/existing-genome-position-search-box.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import {

--- a/test/HiGlassComponent/export-svg.jsx
+++ b/test/HiGlassComponent/export-svg.jsx
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 import * as React from 'react';
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import {

--- a/test/HiGlassComponent/invalid-track-type.js
+++ b/test/HiGlassComponent/invalid-track-type.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import { mountHGComponent, removeHGComponent } from '../../app/scripts/utils';

--- a/test/HiGlassComponent/osm.js
+++ b/test/HiGlassComponent/osm.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 
 import { mountHGComponent, removeHGComponent } from '../../app/scripts/utils';
 

--- a/test/HiGlassComponent/single-view.js
+++ b/test/HiGlassComponent/single-view.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import {

--- a/test/HiGlassComponent/template.js
+++ b/test/HiGlassComponent/template.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 
 import { mountHGComponent, removeHGComponent } from '../../app/scripts/utils';
 

--- a/test/HiGlassComponent/three-views-and-linking.js
+++ b/test/HiGlassComponent/three-views-and-linking.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import {

--- a/test/HiGlassComponent/track-addition-and-removal.js
+++ b/test/HiGlassComponent/track-addition-and-removal.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import {

--- a/test/HiGlassComponent/track-dimension-modification.js
+++ b/test/HiGlassComponent/track-dimension-modification.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import {

--- a/test/HiGlassComponent/track-positioning.js
+++ b/test/HiGlassComponent/track-positioning.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import slugid from 'slugid';

--- a/test/HiGlassComponent/track-resizing.js
+++ b/test/HiGlassComponent/track-resizing.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import {

--- a/test/HiGlassComponent/track-type-menu.js
+++ b/test/HiGlassComponent/track-type-menu.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import {

--- a/test/HiGlassComponent/track-types.js
+++ b/test/HiGlassComponent/track-types.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import {

--- a/test/HiGlassComponent/two-linked-views.js
+++ b/test/HiGlassComponent/two-linked-views.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import {

--- a/test/HiGlassComponent/value-interval-track.js
+++ b/test/HiGlassComponent/value-interval-track.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import { mountHGComponent, removeHGComponent } from '../../app/scripts/utils';

--- a/test/HiGlassComponent/value-scale-locking.js
+++ b/test/HiGlassComponent/value-scale-locking.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import {

--- a/test/HiGlassComponent/window-resizing.js
+++ b/test/HiGlassComponent/window-resizing.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import {

--- a/test/HiGlassComponent/zoom-restriction.js
+++ b/test/HiGlassComponent/zoom-restriction.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import {

--- a/test/HiGlassComponentCreationTests.js
+++ b/test/HiGlassComponentCreationTests.js
@@ -1,6 +1,6 @@
 /* eslint-env node, mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 // Utils

--- a/test/HorizontalHeatmapTests.js
+++ b/test/HorizontalHeatmapTests.js
@@ -4,7 +4,7 @@ import {
   // render,
 } from 'enzyme';
 
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 
 import { expect } from 'chai';
 

--- a/test/HorizontalMultivecTests.js
+++ b/test/HorizontalMultivecTests.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import { select } from 'd3-selection';

--- a/test/LabelTests.js
+++ b/test/LabelTests.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
 import { expect } from 'chai';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 
 import {
   mountHGComponent,

--- a/test/LeftTrackModifierTests.js
+++ b/test/LeftTrackModifierTests.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 // Utils

--- a/test/LocalTileFetcherTests.js
+++ b/test/LocalTileFetcherTests.js
@@ -1,6 +1,6 @@
 /* eslint-env node, mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import viewconf from './view-configs-more/local-tiles-viewconf.json';

--- a/test/LockTests.js
+++ b/test/LockTests.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 import Ajv from 'ajv';
 

--- a/test/MinimalViewconfTest.js
+++ b/test/MinimalViewconfTest.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 // Utils

--- a/test/OSMTests.js
+++ b/test/OSMTests.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 // Utils

--- a/test/RuleTests.js
+++ b/test/RuleTests.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 // Utils

--- a/test/SvgExportTest.js
+++ b/test/SvgExportTest.js
@@ -1,7 +1,7 @@
 /* eslint-env node, jasmine, mocha */
 import { configure } from 'enzyme';
 
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 
 import { expect } from 'chai';
 

--- a/test/TiledPixiTrackTests.js
+++ b/test/TiledPixiTrackTests.js
@@ -1,6 +1,6 @@
 /* eslint-env node, mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 
 // Utils
 import {

--- a/test/TrackLabelsTest.js
+++ b/test/TrackLabelsTest.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 // Utils
 import { mountHGComponent, removeHGComponent } from '../app/scripts/utils';

--- a/test/ViewConfigEditorTests.js
+++ b/test/ViewConfigEditorTests.js
@@ -1,6 +1,6 @@
 /* eslint-env node, mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 import {

--- a/test/ViewManipulationTests.js
+++ b/test/ViewManipulationTests.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
 // Utils

--- a/vite.config.js
+++ b/vite.config.js
@@ -99,7 +99,6 @@ export default defineConfig(({ mode }) => {
   return {
     resolve: {
       alias: {
-        'enzyme-adapter-react-16': '@wojtekmaj/enzyme-adapter-react-17',
         slugid: path.resolve(__dirname, './app/bufferless-slugid.js'),
         lodash: 'lodash-es',
       },


### PR DESCRIPTION
## Description

#1111 used additional configuration to alias imports for `enzyme-adapter-react-16` to `@wojtekmaj/enzyme-adapter-react-17`. This PR removes the former as a dependency and changes the actual imports.

> What was changed in this pull request?

```js
import Adapter from 'enzyme-adapter-react-16';
```

changes to

```js
import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
```

> Why is it necessary?

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
