### PR TITLE
fix(test): HGC comparison tests for plugins

### DIFF
--- a/app/scripts/TrackRenderer.jsx
+++ b/app/scripts/TrackRenderer.jsx
@@ -1504,6 +1504,7 @@ class TrackRenderer extends React.Component {
       dataConfig,
       this.props.pubSub,
       this.props.pluginDataFetchers,
+      this.availableForPlugins,
     );
 
     // To simplify the context creation via ES6 object shortcuts.

--- a/app/scripts/TrackRenderer.jsx
+++ b/app/scripts/TrackRenderer.jsx
@@ -1444,7 +1444,7 @@ class TrackRenderer extends React.Component {
           };
           try {
             return new pluginTrack.track( // eslint-disable-line new-cap
-              AVAILABLE_FOR_PLUGINS,
+              this.availableForPlugins,
               context,
               track.options,
             );
@@ -1772,7 +1772,7 @@ class TrackRenderer extends React.Component {
         const pluginTrack = this.props.pluginTracks[track.type];
 
         if (pluginTrack && !pluginTrack.isMetaTrack) {
-          context.AVAILABLE_FOR_PLUGINS = AVAILABLE_FOR_PLUGINS;
+          context.AVAILABLE_FOR_PLUGINS = this.availableForPlugins;
           context.baseEl = this.baseEl;
           context.definition = track;
 
@@ -1788,7 +1788,7 @@ class TrackRenderer extends React.Component {
 
           try {
             return new pluginTrack.track( // eslint-disable-line new-cap
-              AVAILABLE_FOR_PLUGINS,
+              this.availableForPlugins,
               context,
               options,
             );

--- a/app/scripts/data-fetchers/get-data-fetcher.js
+++ b/app/scripts/data-fetchers/get-data-fetcher.js
@@ -3,13 +3,13 @@ import LocalDataFetcher from './local-tile-fetcher';
 import DataFetcher from '../DataFetcher';
 import { AVAILABLE_FOR_PLUGINS } from '../configs';
 
-const getDataFetcher = (dataConfig, pubSub, pluginDataFetchers) => {
+const getDataFetcher = (dataConfig, pubSub, pluginDataFetchers, availableForPlugins = AVAILABLE_FOR_PLUGINS) => {
   // Check if a plugin data fetcher is available.
   const pluginDataFetcher = pluginDataFetchers[dataConfig.type];
   if (pluginDataFetcher) {
     // eslint-disable-next-line new-cap
     return new pluginDataFetcher.dataFetcher(
-      AVAILABLE_FOR_PLUGINS,
+      availableForPlugins,
       dataConfig,
       pubSub,
     );

--- a/test/PluginDataFetcherTests.js
+++ b/test/PluginDataFetcherTests.js
@@ -32,7 +32,6 @@ describe('Plugin data fetchers:', () => {
       expect(dummyDataFetcher.constructor.name).to.equal(
         'DummyDataFetcherClass',
       );
-
       expect(dummyDataFetcher.hgc).to.deep.equal(
         trackRenderer.availableForPlugins,
       );

--- a/test/PluginDataFetcherTests.js
+++ b/test/PluginDataFetcherTests.js
@@ -32,6 +32,7 @@ describe('Plugin data fetchers:', () => {
       expect(dummyDataFetcher.constructor.name).to.equal(
         'DummyDataFetcherClass',
       );
+
       expect(dummyDataFetcher.hgc).to.deep.equal(
         trackRenderer.availableForPlugins,
       );


### PR DESCRIPTION
## Description

Fixes broken tests in `PluginTrackTests.js` and `PluginDataFetcherTests.js`.

I'm not actually sure how this test was passing previously... The tests both check to make sure that `trackRenderer.avaiableForPlugins` is the same as `plugin.hgc`, BUT the `TrackRenderer` mutates HGC to add additional servies at runtime

- (prior to #1111) https://github.com/higlass/higlass/blob/04df604872ea820a190995f2b34f92fcd552a68b/app/scripts/TrackRenderer.js#L119-L121
- (after #1111) https://github.com/higlass/higlass/blob/dc2098eb4e738903fbc7da2dd0589416dced80d5/app/scripts/TrackRenderer.jsx#L119-L126


so `AVAILABLE_FOR_PLUGINS` will never be the same as `trackRenderer.avaiableForPlugins`.


> What was changed in this pull request?

use `trackRenderer.avaiableForPlugins` when initiating plugins instead of global `AVAILABLE_FOR_PLUGINS`.

> Why is it necessary?

Fixes 2/4 remaining failing tests.

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
