### PR TITLE
fix(test): ViewportProjectionTests.js

### DIFF
--- a/test/ViewportProjectionTests.js
+++ b/test/ViewportProjectionTests.js
@@ -39,10 +39,8 @@ describe('Viewport projection tests', () => {
         );
 
         const viewportRect = trackObj.gMain.select('rect.selection');
-
-        expect(viewportRect.style('color')).to.equal('rgb(51, 51, 51)');
-        expect(viewportRect.style('fill')).to.equal('rgb(0, 0, 0)');
-
+        expect(viewportRect.attr('stroke')).to.equal("black");
+        expect(viewportRect.attr('fill')).to.equal("black");
         done();
       }, 0);
     });


### PR DESCRIPTION
## Description

Fixes broken test in `ViewportProjectionTests.js`. 

> What was changed in this pull request?

Test previously was looking for `style` attribute on SVG element instead of `fill` and `stroke`. The expected values also differend from what was specified in `viewConfig`.

> Why is it necessary?

to fix more tests broken by #1111 

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
