### PR TITLE
fix(test): create synthetic mouse event relative to container

### DIFF
--- a/test/APITests.js
+++ b/test/APITests.js
@@ -26,9 +26,15 @@ import removeDiv from './utils/remove-div';
 
 import { version as VERSION } from '../package.json';
 
+
 describe('API Tests', () => {
   let div = null;
   let api = null;
+
+  before(() => {
+    // important for our synthetic mouse events to be correctly positioned
+    document.body.style.margin = 0;
+  });
 
   describe('Options tests', () => {
     it('adjust view spacing', () => {


### PR DESCRIPTION
## Description

Fixes error with capturing synthetic mouse events in `APITests.js`. 

> What was changed in this pull request?

The test previously relied on the `tiledPlotDiv` being absolutely positioned at top: 0px and left 0px. This PR creates the mouse events relative to the `tiledPlotDiv`'s position on the page.

> Why is it necessary?

Fixes broken tests.

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
