### PR TITLE
fix(test): Update final x position of exported SVG

### DIFF
--- a/test/HiGlassComponent/divergent-track.js
+++ b/test/HiGlassComponent/divergent-track.js
@@ -34,10 +34,10 @@ describe('Divergent tracks', () => {
   it('Check that there are green and red rects', async () => {
     const svg = hgc.instance().createSVG();
     expect(
-      svg.querySelector("rect[fill='green'][stroke='green'][x='11.249637595676889']")
+      svg.querySelector("rect[fill='green'][stroke='green'][x^='11.24963759567']")
     ).to.exist;
     expect(
-      svg.querySelector("rect[fill='red'][stroke='red'][x='29.818754489547988']")
+      svg.querySelector("rect[fill='red'][stroke='red'][x^='29.81875448954']")
     ).to.exist;
   });
 });

--- a/test/HiGlassComponent/divergent-track.js
+++ b/test/HiGlassComponent/divergent-track.js
@@ -3,7 +3,7 @@ import Enzyme from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { expect } from 'chai';
 
-import { mountHGComponent, removeHGComponent } from '../../app/scripts/utils';
+import { mountHGComponentAsync, removeHGComponent } from '../../app/scripts/utils';
 
 import { divergentTrackConfig } from '../view-configs';
 
@@ -16,9 +16,9 @@ describe('Divergent tracks', () => {
   let div = null;
   // const fetchMockHelper = new FetchMockHelper(null, 'higlass.io');
 
-  before((done) => {
+  before(async () => {
     // await fetchMockHelper.activateFetchMock();
-    [div, hgc] = mountHGComponent(div, hgc, divergentTrackConfig, done, {
+    [div, hgc] = await mountHGComponentAsync(div, hgc, divergentTrackConfig, {
       style: 'width:800px; height:400px; background-color: lightgreen',
       bounded: true,
     });
@@ -31,17 +31,13 @@ describe('Divergent tracks', () => {
     // await fetchMockHelper.storeDataAndResetFetchMock();
   });
 
-  it('Check that there are green and red rects', (done) => {
+  it('Check that there are green and red rects', async () => {
     const svg = hgc.instance().createSVG();
-
-    const svgText = new XMLSerializer().serializeToString(svg);
     expect(
-      svgText.indexOf('fill="green" stroke="green" x="11.24963759567723"'),
-    ).to.be.greaterThan(0);
+      svg.querySelector("rect[fill='green'][stroke='green'][x='11.249637595676889']")
+    ).to.exist;
     expect(
-      svgText.indexOf('fill="red" stroke="red" x="29.818754489548308"'),
-    ).to.be.greaterThan(0);
-
-    done();
+      svg.querySelector("rect[fill='red'][stroke='red'][x='29.818754489547988']")
+    ).to.exist;
   });
 });


### PR DESCRIPTION
## Description

Fixes the broken SVG export test. 

> What was changed in this pull request?

The expect x/y positions for the expected svg elements are slightly different. I'm guessing this is due to the new testing environment and not a regression. I updated the positions in the test from this correct SVG export:

<img width="681" alt="image" src="https://user-images.githubusercontent.com/24403730/188978685-24dbc12a-b96e-4230-8c1e-134e57ad5e85.png">


> Why is it necessary?

Fixes the last outstanding broken test.

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
