### PR TITLE
fix: compile away env vars in un-minified hglib.js

### DIFF
--- a/scripts/compile.mjs
+++ b/scripts/compile.mjs
@@ -55,7 +55,6 @@ await fs.promises.writeFile(
 
 // delete the vite now that we have the final UMDs
 await fs.promises.unlink(viteUmdOutput);
-
 // =========================================
 //       UMD demo (dist/index.html)
 // =========================================


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Makes sure esbuild compiles away `process.env.NODE_ENV` environment variables in `hglib.js`. This happened previously in `hglib.min.js` since `minify: true` sets this behavior, but we need to do the same for the unminified build.

> Why is it necessary?

loading the unminifed `hglib.js` currently throws in the browser because `process` is not defined.

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
