### PR TITLE
chore: update ignore-rev commit hash

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
 # Run code through prettier
-1852b142602adedc1fd24eedd223cc08208017b6
+20676a970fabc61977dc55c364f1955df0e4f0d0


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Updates the `ignore-rev` commit hash with the hash for the squashed commit from #1129 . 

> Why is it necessary?

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
