### PR TITLE
Fix GenomePositionSearchBox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release notes
 
+## Unreleased changes
+
+- Fix GenomePositionSearchBox
+- Reduced position text in GenomePositionSearchBox when there are only 1D horizontal tracks
+
 ## v1.12.0
 
 - Migrate to Vite from webpack

--- a/app/scripts/GenomePositionSearchBox.jsx
+++ b/app/scripts/GenomePositionSearchBox.jsx
@@ -750,11 +750,15 @@ class GenomePositionSearchBox extends React.Component {
     );
   }
 
-  handleAssemblySelect(evt) {
-    this.setSelectedAssembly(evt.target.value);
+  handleAssemblySelectEvt(evt) {
+    this.handleAssemblySelect(evt.target.value);
+  }
+
+  handleAssemblySelect(assembly) {
+    this.setSelectedAssembly(assembly);
 
     this.setState({
-      selectedAssembly: evt.target.value,
+      selectedAssembly: assembly,
     });
   }
 
@@ -790,7 +794,7 @@ class GenomePositionSearchBox extends React.Component {
             }}
             className={styles['genome-position-search-bar-button']}
             id={this.uid}
-            onChange={this.handleAssemblySelect.bind(this)}
+            onChange={this.handleAssemblySelectEvt.bind(this)}
             title={
               this.state.selectedAssembly
                 ? this.state.selectedAssembly

--- a/app/scripts/GenomePositionSearchBox.jsx
+++ b/app/scripts/GenomePositionSearchBox.jsx
@@ -623,7 +623,7 @@ class GenomePositionSearchBox extends React.Component {
         let range2 = rangePair[1];
 
         if (!range1) {
-          this.setPositionText(this.origPositionText);
+          this.setPositionText();
           return;
         }
 
@@ -751,10 +751,10 @@ class GenomePositionSearchBox extends React.Component {
   }
 
   handleAssemblySelect(evt) {
-    this.setSelectedAssembly(evt);
+    this.setSelectedAssembly(evt.target.value);
 
     this.setState({
-      selectedAssembly: evt,
+      selectedAssembly: evt.target.value,
     });
   }
 
@@ -790,7 +790,7 @@ class GenomePositionSearchBox extends React.Component {
             }}
             className={styles['genome-position-search-bar-button']}
             id={this.uid}
-            onSelect={this.handleAssemblySelect.bind(this)}
+            onChange={this.handleAssemblySelect.bind(this)}
             title={
               this.state.selectedAssembly
                 ? this.state.selectedAssembly

--- a/app/scripts/HiGlassComponent.jsx
+++ b/app/scripts/HiGlassComponent.jsx
@@ -5130,7 +5130,7 @@ class HiGlassComponent extends React.Component {
                 )
               }
               trackSourceServers={this.state.viewConfig.trackSourceServers}
-              twoD={true}
+              twoD={!!(view.tracks.left.length || view.tracks.right.length || view.tracks.center.length)}
             />
           );
         };

--- a/app/scripts/HiGlassComponent.jsx
+++ b/app/scripts/HiGlassComponent.jsx
@@ -5130,7 +5130,13 @@ class HiGlassComponent extends React.Component {
                 )
               }
               trackSourceServers={this.state.viewConfig.trackSourceServers}
-              twoD={!!(view.tracks.left.length || view.tracks.right.length || view.tracks.center.length)}
+              twoD={
+                !!(
+                  view.tracks.left.length ||
+                  view.tracks.right.length ||
+                  view.tracks.center.length
+                )
+              }
             />
           );
         };

--- a/app/scripts/icons.jsx
+++ b/app/scripts/icons.jsx
@@ -382,11 +382,12 @@ export const svgArrowheadDomainsIcon = parser.parseFromString(
   'text/xml',
 ).documentElement;
 
-export function SearchIcon({ theStyle }) {
+export function SearchIcon({ theStyle, onClick }) {
   return (
     <svg
       className={classes[theStyle]}
       viewBox="0 0 12 13"
+      onClick={onClick}
       xmlns="http://www.w3.org/2000/svg"
     >
       <g fill="none" stroke="#6c6c6c" strokeWidth="2">


### PR DESCRIPTION
## Description

> What was changed in this pull request?

The GenomePositionSearchBox and the assembly selection has not been working correctly for quite some time. This PR fixes that. Furthermore, in the absence of 2D or vertical tracks the position info in the search box only shows the x-coordinates now.

> Why is it necessary?

GenomePositionSearchBox was not working

Fixes #___

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
