### PR TITLE
Set selected assembly on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release notes
 
+## Unreleased
+
+- Correctly set the selected assembly on startup.
+- Hide position text in genome position search box when assembly is invalid or not set.
+
 ## v1.12.1
 
 - Fix GenomePositionSearchBox

--- a/app/scripts/GenomePositionSearchBox.jsx
+++ b/app/scripts/GenomePositionSearchBox.jsx
@@ -795,11 +795,7 @@ class GenomePositionSearchBox extends React.Component {
             className={styles['genome-position-search-bar-button']}
             id={this.uid}
             onChange={this.handleAssemblySelectEvt.bind(this)}
-            value={
-              this.state.selectedAssembly
-                ? this.state.selectedAssembly
-                : '(none)'
-            }
+            value={this.state.selectedAssembly || undefined}
           >
             {assemblyMenuItems}
           </select>
@@ -839,7 +835,7 @@ class GenomePositionSearchBox extends React.Component {
             </div>
           )}
           renderMenu={this.handleRenderMenu.bind(this)}
-          value={this.state.selectedAssembly ? this.positionText : ''}
+          value={this.state.selectedAssembly ? this.positionText : 'No valid assembly selected'}
           wrapperStyle={{ width: '100%' }}
         />
 

--- a/app/scripts/GenomePositionSearchBox.jsx
+++ b/app/scripts/GenomePositionSearchBox.jsx
@@ -795,7 +795,7 @@ class GenomePositionSearchBox extends React.Component {
             className={styles['genome-position-search-bar-button']}
             id={this.uid}
             onChange={this.handleAssemblySelectEvt.bind(this)}
-            title={
+            value={
               this.state.selectedAssembly
                 ? this.state.selectedAssembly
                 : '(none)'
@@ -839,7 +839,7 @@ class GenomePositionSearchBox extends React.Component {
             </div>
           )}
           renderMenu={this.handleRenderMenu.bind(this)}
-          value={this.positionText}
+          value={this.state.selectedAssembly ? this.positionText : ''}
           wrapperStyle={{ width: '100%' }}
         />
 

--- a/app/scripts/GenomePositionSearchBox.jsx
+++ b/app/scripts/GenomePositionSearchBox.jsx
@@ -835,7 +835,11 @@ class GenomePositionSearchBox extends React.Component {
             </div>
           )}
           renderMenu={this.handleRenderMenu.bind(this)}
-          value={this.state.selectedAssembly ? this.positionText : 'No valid assembly selected'}
+          value={
+            this.state.selectedAssembly
+              ? this.positionText
+              : 'No valid assembly selected'
+          }
           wrapperStyle={{ width: '100%' }}
         />
 

--- a/test/HiGlassComponent/existing-genome-position-search-box.js
+++ b/test/HiGlassComponent/existing-genome-position-search-box.js
@@ -87,7 +87,7 @@ describe('Exising genome position search box', () => {
     const button =
       hgc.instance().genomePositionSearchBoxes.aa.assemblyPickButton;
 
-    expect(button.title).to.equal('mm9');
+    expect(button.value).to.equal('mm9');
 
     hgc.instance().genomePositionSearchBoxes.aa.handleAssemblySelect('hg19');
 
@@ -99,7 +99,7 @@ describe('Exising genome position search box', () => {
     const button =
       hgc.instance().genomePositionSearchBoxes.aa.assemblyPickButton;
 
-    expect(button.title).to.equal('hg19');
+    expect(button.value).to.equal('hg19');
 
     waitForJsonComplete(done);
   });


### PR DESCRIPTION
## Description

> What was changed in this pull request?

- Correctly set the selected assembly on startup.
- Hide position text in genome position search box when assembly is invalid or not set.

> Why is it necessary?

Currently the genome position search box does not show the correct assembly on startup in the select element (i.e., the one from the viewconfig).

Fixes #___

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
