### PR TITLE
feat: Allow React v18 as peer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## In Progress
+
+- Allow React v18 as a peer dependency.
+
 ## v1.12.2
 
 - Correctly set the selected assembly on startup.

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,8 +81,8 @@
       },
       "peerDependencies": {
         "pixi.js": "^5.0.3",
-        "react": "^16.6.3 || ^17.0.0",
-        "react-dom": "^16.6.3 || ^17.0.0"
+        "react": "^16.6.3 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.6.3 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -77,8 +77,8 @@
   },
   "peerDependencies": {
     "pixi.js": "^5.0.3",
-    "react": "^16.6.3 || ^17.0.0",
-    "react-dom": "^16.6.3 || ^17.0.0"
+    "react": "^16.6.3 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.6.3 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",


### PR DESCRIPTION
- fix: allow React 18 as peer dependency
- chore: update changelog

## Description

> What was changed in this pull request?

Allows a more flexible semver range for react/react-dom as a peer dependency. @keller-mark has had some success with using React 18 with HiGlass in Vitessce, and adding this to the `package.json` will allow folks to allow more flexible installs of HiGlass.

In the longer term, we should test different version of React, but this seems like the most flexible "fix" at the moment.

> Why is it necessary?

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md


## Screen Recording

I bumped the React dependency locally to 18, and things seem to work fine. There is just a console err from using `ReactDOM.render`, which says it's falling back to React 17 functionality. Users of the HiGlass component won't run into this issue.

https://user-images.githubusercontent.com/24403730/235989310-ec5c6858-20c0-43af-84f3-09b1641cf610.mov


