### PR TITLE
feat: entrypoint for higlass/dist contents 

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
     ".": {
       "import": "./dist/higlass.mjs"
     },
-    "./dist/hglib.css": {
-      "import": "./dist/hglib.css"
-    }
+    "./dist/*": "./dist/*"
   },
   "files": [
     "app",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "exports": {
     ".": {
       "import": "./dist/higlass.mjs"
+    },
+    "./dist/hglib.css": {
+      "import": "./dist/hglib.css"
     }
   },
   "files": [


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Adds an entrypoint `hglib.css`

> Why is it necessary?

Now that higlass is behaving properly as a ES module, vite yells at you if you try to access 'higlass/dist/hglib.css'. 
```
[ERROR] Missing "./dist/hglib.css" specifier in "higlass" package [plugin vite:dep-scan]

    editor/index.tsx:6:7:
      6 │ import 'higlass/dist/hglib.css';
 ```
We could also come up with another name for this entry point. Perhaps just "./css" or something. 

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
