### PR TITLE
feat: Inject CSS via JS in final HiGlass build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## In Progress
+
+- Inject HiGlass CSS via JS, removing the need to include `hglib.css` in HTML templates.
+
 ## v1.13.2
 
 - Add entrypoint for importing from `higlass/dist/*` with bundlers

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,8 @@
         "tinyspy": "^1.0.2",
         "typescript": "^5.2.2",
         "vite": "^5.0.3",
-        "vite-plugin-babel": "^1.1.3"
+        "vite-plugin-babel": "^1.1.3",
+        "vite-plugin-css-injected-by-js": "^3.3.0"
       },
       "engines": {
         "node": ">=0.12.0"
@@ -9790,6 +9791,15 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0",
         "vite": "^2.7.0 || ^3.0.0 || ^4.0.0"
+      }
+    },
+    "node_modules/vite-plugin-css-injected-by-js": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-css-injected-by-js/-/vite-plugin-css-injected-by-js-3.3.0.tgz",
+      "integrity": "sha512-xG+jyHNCmUqi/TXp6q88wTJGeAOrNLSyUUTp4qEQ9QZLGcHWQQsCsSSKa59rPMQr8sOzfzmWDd8enGqfH/dBew==",
+      "dev": true,
+      "peerDependencies": {
+        "vite": ">2.0.0-0"
       }
     },
     "node_modules/vite/node_modules/rollup": {

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "tinyspy": "^1.0.2",
     "typescript": "^5.2.2",
     "vite": "^5.0.3",
-    "vite-plugin-babel": "^1.1.3"
+    "vite-plugin-babel": "^1.1.3",
+    "vite-plugin-css-injected-by-js": "^3.3.0"
   }
 }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -73,6 +73,7 @@ async function build() {
     build: {
       write: false,
       minify: false,
+      cssMinify: true,
       lib: {
         entry: path.resolve(__dirname, '../app/scripts/hglib.jsx'),
         name: 'hglib',

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -22,6 +22,7 @@ import * as url from 'node:url';
 import * as esbuild from 'esbuild';
 import * as vite from 'vite';
 import babel from 'vite-plugin-babel';
+import injectCssByJs from 'vite-plugin-css-injected-by-js';
 
 import * as React from 'react';
 import * as PIXI from 'pixi.js';
@@ -64,7 +65,7 @@ function collectExpectedViteBuildOutputs(buildResult, filenames) {
 /**
  * Generates the UMD and ESM builds library code.
  *
- * @returns {Promise<{ umd: string, minifiedUmd: string, esm: string, css: string }>}
+ * @returns {Promise<{ umd: string, minifiedUmd: string, esm: string }>}
  */
 async function build() {
   const viteBuildResult = await vite.build({
@@ -101,13 +102,13 @@ async function build() {
           plugins: ['@babel/plugin-transform-classes'],
         },
       }),
+      injectCssByJs(),
     ],
   });
 
   const expected = collectExpectedViteBuildOutputs(viteBuildResult, [
     'higlass.umd.js',
     'higlass.mjs',
-    'style.css',
   ]);
 
   const minifiedUmd = await esbuild.transform(expected['higlass.umd.js'], {
@@ -118,7 +119,6 @@ async function build() {
     umd: expected['higlass.umd.js'],
     minifiedUmd: minifiedUmd.code,
     esm: expected['higlass.mjs'],
-    css: expected['style.css'],
   };
 }
 
@@ -152,7 +152,12 @@ async function main({ outDir }) {
   await Promise.all([
     fs.promises.mkdir(outDir, { recursive: true }),
     // CSS
-    fs.promises.writeFile(path.resolve(outDir, 'hglib.css'), bundle.css),
+    fs.promises.writeFile(
+      path.resolve(outDir, 'hglib.css'),
+      `\
+/* Since, v1.13.3 HiGlass styles are now injected via JS. No need to separately load this file. */
+`,
+    ),
     // UMD
     fs.promises.writeFile(path.resolve(outDir, 'hglib.js'), bundle.umd),
     fs.promises.writeFile(
@@ -162,7 +167,6 @@ async function main({ outDir }) {
     fs.promises.writeFile(
       path.resolve(outDir, 'index.html'),
       await generateHTML(`\
-    <link rel="stylesheet" href="./hglib.css">
     <script src="https://unpkg.com/react@${REACT_VERSION}/umd/react.production.min.js"></script>
     <script src="https://unpkg.com/react-dom@${REACT_VERSION}/umd/react-dom.production.min.js"></script>
     <script src="https://unpkg.com/pixi.js@${PIXI_VERSION}/dist/browser/pixi.min.js"></script>
@@ -174,7 +178,6 @@ async function main({ outDir }) {
     fs.promises.writeFile(
       path.resolve(outDir, 'esm.html'),
       await generateHTML(`\
-    <link rel="stylesheet" href="./hglib.css">
     <script type="importmap">
       {
         "imports": {


### PR DESCRIPTION
Historically users need to require both `hglib.css` and `hglib.js` in their HTML templates and bundler code. 

```html
    <link rel="stylesheet" href="https://unpkg.com/higlass@1.13/dist/hglib.css">
    <script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
    <script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
    <script src="https://unpkg.com/pixi.js@6/dist/browser/pixi.min.js"></script>
    <script src="https://unpkg.com/higlass@1.13/dist/hglib.min.js"></script>
```

This requires that users keep the versions in sync over time in the HTML template. 

This PR injects the final CSS via JS, eliminating the need to also have `hglib.css` in the template:

```diff
--  <link rel="stylesheet" href="https://unpkg.com/higlass@1.13/dist/hglib.css">
    <script src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
    <script src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
    <script src="https://unpkg.com/pixi.js@6/dist/browser/pixi.min.js"></script>
    <script src="https://unpkg.com/higlass@1.13/dist/hglib.min.js"></script>
```


Many JS libraries put their final CSS in JS so that loading the JS also accomplishes adding the styles to the page. 

This technique makes it easier to use use HiGlass, especially via ESM:

```javascript
import * as hglib from "http://esm.sh/higlass@1.13";
```

and ensures anytime a specific HiGlass version is imported you also have the corresponding styles for that build. It is also beneficial for libraries using HiGlass (like Gosling), since it's one less import that we need to worry about including. 


## Try it out

```
npm run build
http-server dist # open http://localhost:8080 and http://localhost:8080/esm.html
```


## Alternatives

Alternatively we keep the stylesheet separate and provide the end user with a function to load the styles via JS.

```javascript
import * as hglib from "https://esm.sh/higlass@1.13"; // doesn't load styles
await hglib.loadStyles(); // fetches ./hglib.css and adds the styles to the current document
```

Not sure what you think about these approaches @etowahadams 