### PR TITLE
fix: Disable logging unknown data-type in console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## In progress
+
+- fix: Disable logging unknown data types in console
+
 ## v1.13.3
 
 - Inject HiGlass CSS via JS, removing the need to include `hglib.css` in HTML templates.

--- a/app/scripts/TiledPlot.jsx
+++ b/app/scripts/TiledPlot.jsx
@@ -1630,6 +1630,14 @@ class TiledPlot extends React.Component {
    */
   getIdealizedTrackPositionsOverlay() {
     const evtJson = this.props.draggingHappening;
+
+    // For whatever reason, evtJson is sometimes a boolean. This rest of
+    // this code block assumes it's an object, so we return undefined if
+    // it's not.
+    if (typeof evtJson === 'boolean') {
+      return undefined;
+    }
+
     const datatype = evtJson.datatype;
 
     if (!(datatype in DEFAULT_TRACKS_FOR_DATATYPE) && !evtJson.defaultTracks) {


### PR DESCRIPTION
## Description


For whatever reason, the `evtJson` is often a `boolean` here:

```js
    if (!(datatype in DEFAULT_TRACKS_FOR_DATATYPE) && !evtJson.defaultTracks) {
      console.warn('unknown data type:', evtJson.higlassTrack);
      return undefined;
    }

```

and therefore `evtJson.defaultTracks` is `undefined`, leading to the console erroring:

```
unknown data type: undefined
```

consistently.


> What was changed in this pull request?

I've seen this log for ages in both Gosling.js and HiGlass but never had the time to
look very deeply into it.

> Why is it necessary?

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
