### PR TITLE
Switch to `_` for private class attributes to resolve build issues

### DIFF
--- a/app/scripts/data-fetchers/DataFetcher.js
+++ b/app/scripts/data-fetchers/DataFetcher.js
@@ -90,16 +90,13 @@ function createDefaultTileSource(pubSub) {
 
 /** @implements {AbstractDataFetcher<Tile | DividedTile>} */
 export default class DataFetcher {
-  /** @type {TileSource<Tile>} */
-  #tileSource;
-
   /**
    * @param {import('../types').DataConfig} dataConfig
    * @param {import('pub-sub-es').PubSub} pubSub
    * @param {TileSource<Tile>} [tileSource]
    */
   constructor(dataConfig, pubSub, tileSource) {
-    this.#tileSource = tileSource || createDefaultTileSource(pubSub);
+    this._tileSource = tileSource || createDefaultTileSource(pubSub);
     /** @type {boolean} */
     this.tilesetInfoLoading = true;
 
@@ -139,7 +136,7 @@ export default class DataFetcher {
    * @param {string=} opts.coordSystem - The coordinate system being served (e.g. 'hg38')
    */
   async registerFileUrl({ server, url, filetype, coordSystem }) {
-    return this.#tileSource.registerTileset({
+    return this._tileSource.registerTileset({
       server,
       url,
       filetype,
@@ -195,7 +192,7 @@ export default class DataFetcher {
         );
         finished(null);
       } else {
-        this.#tileSource
+        this._tileSource
           .fetchTilesetInfo({ server, tilesetUid })
           .then((tilesetInfo) => {
             // tileset infos are indxed by by tilesetUids, we can just resolve
@@ -262,7 +259,7 @@ export default class DataFetcher {
 
     if (!this.dataConfig.children && this.dataConfig.tilesetUid) {
       // no children, just return the fetched tiles as is
-      const promise = this.#tileSource.fetchTiles({
+      const promise = this._tileSource.fetchTiles({
         id: slugid.nice(),
         server: this.dataConfig.server,
         tileIds: tileIds.map((x) => `${this.dataConfig.tilesetUid}.${x}`),
@@ -443,7 +440,7 @@ export default class DataFetcher {
     }
 
     // actually fetch the new tileIds
-    const promise = this.#tileSource.fetchTiles({
+    const promise = this._tileSource.fetchTiles({
       id: slugid.nice(),
       server: this.dataConfig.server,
       tileIds: newTileIds.map((x) => `${this.dataConfig.tilesetUid}.${x}`),


### PR DESCRIPTION
This change replaces the `#` syntax for private class attributes with
the `_` convention. The legacy ES5 transformation for classes appears to
have compatibility issues with the `#` syntax, breaking the build.

While `#` provides "true" private encapsulation in JavaScript, the `_`
convention is probably sufficient for our use case. This approach
maintains compatibility with legacy requirements for plugins and ensures
a successful build.

## Description

> What was changed in this pull request?



> Why is it necessary?

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
