### PR TITLE
Use setError for track error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.13.5
 
 - Allow tracks to pass in custom context menu items
+- Let tracks set errors with a source using setError
 
 ## v1.13.4
 

--- a/app/scripts/MapboxTilesTrack.js
+++ b/app/scripts/MapboxTilesTrack.js
@@ -17,9 +17,10 @@ class MapboxTilesTrack extends OSMTilesTrack {
     this.style = options.style;
 
     if (!this.options.accessToken) {
-      this.errorTextText =
+      this.setError(
         "No access token provided in the viewconf's track options " +
-        "('accessToken' option).";
+          "('accessToken' option).",
+      );
       this.drawError();
     }
   }

--- a/app/scripts/PixiTrack.js
+++ b/app/scripts/PixiTrack.js
@@ -315,16 +315,11 @@ class PixiTrack extends Track {
     this.errorText.x = this.position[0] + this.dimensions[0] / 2;
     this.errorText.y = this.position[1] + this.dimensions[1] / 2;
 
-    let errorTextText = '';
-    Object.values(this.errorTexts).forEach((x) => {
-      // Go through all the errors and render them.
-      if (x && x.length) {
-        if (errorTextText.length) {
-          errorTextText += '\n';
-        }
-        errorTextText += x;
-      }
-    });
+    // Collect all the error texts, filter out the ones that are empty
+    // and put the non-empty ones separate lines
+    const errorTextText = Object.values(this.errorTexts)
+      .filter((x) => x && x.length)
+      .reduce((acc, x) => (acc ? `${acc}\n${x}` : x), '');
 
     this.errorText.text = errorTextText;
     this.errorText.alpha = 0.8;

--- a/app/scripts/PixiTrack.js
+++ b/app/scripts/PixiTrack.js
@@ -208,12 +208,14 @@ class PixiTrack extends Track {
     this.errorText.anchor.x = 0.5;
     this.errorText.anchor.y = 0.5;
     this.pLabel.addChild(this.errorText);
-    /** @type {string} */
-    this.errorTextText = '';
+
     /** @type {boolean} */
     this.flipText = false;
     /** @type {import('./types').TilesetInfo | undefined} */
     this.tilesetInfo = undefined;
+
+    /** @type {{ [key: string]: string }} */
+    this.errorTexts = {};
   }
 
   setLabelText() {
@@ -294,15 +296,43 @@ class PixiTrack extends Track {
     );
   }
 
+  /** Set an error for this track.
+   *
+   * The error can be associated with a source so that multiple
+   * components within the track can set their own independent errors
+   * that will be displayed to the user without overlapping.
+   *
+   * @param {string} error The error text
+   * @param {string} source The source of the error
+   */
+  setError(error, source) {
+    this.errorTexts[source] = error;
+
+    this.drawError();
+  }
+
   drawError() {
     this.errorText.x = this.position[0] + this.dimensions[0] / 2;
     this.errorText.y = this.position[1] + this.dimensions[1] / 2;
 
-    this.errorText.text = this.errorTextText;
+    let errorTextText = '';
+    Object.values(this.errorTexts).forEach((x) => {
+      // Go through all the errors and render them.
+      if (x && x.length) {
+        if (errorTextText.length) {
+          errorTextText += '\n';
+        }
+        errorTextText += x;
+      }
+    });
 
-    if (this.errorTextText && this.errorTextText.length) {
+    this.errorText.text = errorTextText;
+    this.errorText.alpha = 0.8;
+
+    if (errorTextText && errorTextText.length) {
       // draw a red border around the track to bring attention to its
       // error
+
       const graphics = this.pBorder;
       graphics.clear();
       graphics.lineStyle(1, colorToHex('red'));
@@ -313,6 +343,8 @@ class PixiTrack extends Track {
         this.dimensions[0],
         this.dimensions[1],
       );
+    } else {
+      this.pBorder.clear();
     }
   }
 

--- a/app/scripts/RasterTilesTrack.js
+++ b/app/scripts/RasterTilesTrack.js
@@ -16,8 +16,9 @@ class RasterTilesTrack extends OSMTilesTrack {
     this.style = options.style;
 
     if (!this.options.tileSource) {
-      this.errorTextText =
-        'No tile source string provided in the options. It should be in the form of http://a.com/{z}/{x}/{y}';
+      this.setError(
+        'No tile source string provided in the options. It should be in the form of http://a.com/{z}/{x}/{y}',
+      );
       this.drawError();
     }
   }

--- a/app/scripts/TiledPixiTrack.js
+++ b/app/scripts/TiledPixiTrack.js
@@ -619,6 +619,9 @@ class TiledPixiTrack extends PixiTrack {
   }
 
   fetchNewTiles(toFetch) {
+    this._checkForErrors();
+    this.draw();
+
     if (toFetch.length > 0) {
       const toFetchList = [...new Set(toFetch.map((x) => x.remoteId))];
 
@@ -723,7 +726,7 @@ class TiledPixiTrack extends PixiTrack {
     }
   }
 
-  checkForErrors() {
+  _checkForErrors() {
     const errors = Object.values(this.fetchedTiles)
       .map(
         (x) =>
@@ -774,7 +777,7 @@ class TiledPixiTrack extends PixiTrack {
       });
     }
 
-    this.checkForErrors();
+    this._checkForErrors();
 
     super.draw();
 

--- a/app/scripts/TiledPixiTrack.js
+++ b/app/scripts/TiledPixiTrack.js
@@ -224,12 +224,6 @@ class TiledPixiTrack extends PixiTrack {
     });
   }
 
-  setError(error) {
-    this.errorTextText = error;
-    this.draw();
-    this.animate();
-  }
-
   setFixedValueScaleMin(value) {
     if (!Number.isNaN(+value)) this.fixedValueScaleMin = +value;
     else this.fixedValueScaleMin = null;
@@ -729,6 +723,29 @@ class TiledPixiTrack extends PixiTrack {
     }
   }
 
+  checkForErrors() {
+    const errors = Object.values(this.fetchedTiles)
+      .map(
+        (x) =>
+          x.tileData && x.tileData.error && `${x.tileId}: ${x.tileData.error}`,
+      )
+      .filter((x) => x);
+
+    if (errors.length) {
+      this.errorTexts.TiledPixiTrack = errors.join('\n');
+    } else {
+      this.errorTexts.TiledPixiTrack = '';
+    }
+
+    if (this.tilesetInfoError) {
+      this.errorTexts.TiledPixiTrack = this.tilesetInfoError;
+
+      errors.push(this.tilesetInfoError);
+    }
+
+    return errors;
+  }
+
   draw() {
     if (this.delayDrawing) return;
 
@@ -756,18 +773,8 @@ class TiledPixiTrack extends PixiTrack {
         uuid: this.uuid,
       });
     }
-    const errors = Object.values(this.fetchedTiles)
-      .map(
-        (x) =>
-          x.tileData && x.tileData.error && `${x.tileId}: ${x.tileData.error}`,
-      )
-      .filter((x) => x);
 
-    if (errors.length) {
-      this.errorTextText = errors.join('\n');
-    } else {
-      this.errorTextText = '';
-    }
+    this.checkForErrors();
 
     super.draw();
 

--- a/app/scripts/UnknownPixiTrack.js
+++ b/app/scripts/UnknownPixiTrack.js
@@ -7,7 +7,7 @@ class UnknownPixiTrack extends PixiTrack {
     // so that the tests checking for retrieved tilesetInfo pass
     this.tilesetInfo = {};
 
-    this.errorTextText = `Unknown track type: ${options.type}`;
+    this.setError(`Unknown track type: ${options.type}`);
   }
 
   zoomed() {

--- a/index.html
+++ b/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>HiGlass</title>
     <style type="text/css">
       #demo {
@@ -18,7 +18,7 @@
     <script id="higlass-import" type="module">
       // we import higlass here and set a global so that we can
       // replace this block with our UMD build in './scripts/compile.mjs'
-      import * as hglib from './app/scripts/hglib';
+      import * as hglib from "./app/scripts/hglib";
       globalThis.hglib = hglib;
     </script>
     <!-- HIGLASS IMPORT -->
@@ -37,11 +37,17 @@
             w: 12,
             h: 7,
             x: 0,
-            y: 0,
+            y: 0
           },
           uid: 'aa',
-          initialYDomain: [2534823997.9776945, 2547598956.834603],
-          initialXDomain: [2521015726.4619913, 2558682921.8435397],
+          initialYDomain: [
+            2534823997.9776945,
+            2547598956.834603
+          ],
+          initialXDomain: [
+            2521015726.4619913,
+            2558682921.8435397
+          ],
           tracks: {
             left: [],
             top: [
@@ -63,7 +69,7 @@
                   mousePositionColor: '#000000',
                   geneAnnotationHeight: 10,
                   geneLabelPosition: 'outside',
-                  geneStrandSpacing: 4,
+                  geneStrandSpacing: 4
                 },
               },
               {
@@ -84,8 +90,8 @@
                   labelTextOpacity: 0.4,
                   showMousePosition: true,
                   mousePositionColor: '#000000',
-                  showTooltip: false,
-                },
+                  showTooltip: false
+                }
               },
               {
                 uid: 'line2',
@@ -105,7 +111,7 @@
                   labelTextOpacity: 0.4,
                   showMousePosition: true,
                   mousePositionColor: '#000000',
-                  showTooltip: false,
+                  showTooltip: false
                 },
               },
               {
@@ -126,7 +132,7 @@
                   labelTextOpacity: 0.4,
                   showMousePosition: true,
                   mousePositionColor: '#000000',
-                  showTooltip: false,
+                  showTooltip: false
                 },
               },
               {
@@ -147,14 +153,13 @@
                   labelTextOpacity: 0.4,
                   showMousePosition: true,
                   mousePositionColor: '#000000',
-                  showTooltip: false,
+                  showTooltip: false
                 },
               },
               {
                 uid: 'chroms',
                 height: 18,
-                chromInfoPath:
-                  '//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv',
+                chromInfoPath: '//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv',
                 type: 'horizontal-chromosome-labels',
                 options: {
                   color: '#777777',
@@ -162,9 +167,9 @@
                   fontSize: 11,
                   fontIsLeftAligned: true,
                   showMousePosition: true,
-                  mousePositionColor: '#000000',
+                  mousePositionColor: '#000000'
                 },
-              },
+              }
             ],
             right: [],
             center: [
@@ -185,7 +190,7 @@
                         'white',
                         'rgba(245,166,35,1.0)',
                         'rgba(208,2,27,1.0)',
-                        'black',
+                        'black'
                       ],
                       maxZoom: null,
                       colorbarPosition: 'topRight',
@@ -199,13 +204,13 @@
                       scaleEndPercent: '1.00000',
                       showMousePositionGlobally: true,
                     },
-                  },
+                  }
                 ],
-              },
+              }
             ],
             bottom: [],
             whole: [],
-            gallery: [],
+            gallery: []
           },
           chromInfoPath: '//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv',
           genomePositionSearchBox: {
@@ -213,9 +218,9 @@
             chromInfoServer: 'http://higlass.io/api/v1',
             chromInfoId: 'hg19',
             autocompleteServer: 'http://higlass.io/api/v1',
-            autocompleteId: 'OHJakQICQD6gTD7skx4EWA',
-          },
-        },
+            autocompleteId: 'OHJakQICQD6gTD7skx4EWA'
+          }
+        }
       ],
       editable: true,
       viewEditable: true,
@@ -223,40 +228,49 @@
       exportViewUrl: '/api/v1/viewconfs',
       zoomLocks: {
         locksByViewUid: {},
-        locksDict: {},
+        locksDict: {}
       },
-      trackSourceServers: ['http://higlass.io/api/v1'],
+      trackSourceServers: [
+        'http://higlass.io/api/v1'
+      ],
       locationLocks: {
         locksByViewUid: {
           aa: 'PkNgAl3mSIqttnSsCewngw',
-          ewZvJwlDSei_dbpIAkGMlg: 'PkNgAl3mSIqttnSsCewngw',
+          ewZvJwlDSei_dbpIAkGMlg: 'PkNgAl3mSIqttnSsCewngw'
         },
         locksDict: {
           PkNgAl3mSIqttnSsCewngw: {
-            aa: [1550000000, 1550000000, 3380588.876772046],
-            ewZvJwlDSei_dbpIAkGMlg: [
-              1550000000.0000002, 1549999999.9999993, 3380588.876772046,
+            aa: [
+              1550000000,
+              1550000000,
+              3380588.876772046
             ],
-            uid: 'PkNgAl3mSIqttnSsCewngw',
-          },
-        },
+            ewZvJwlDSei_dbpIAkGMlg: [
+              1550000000.0000002,
+              1549999999.9999993,
+              3380588.876772046
+            ],
+            uid: 'PkNgAl3mSIqttnSsCewngw'
+          }
+        }
       },
       valueScaleLocks: {
         locksByViewUid: {},
-        locksDict: {},
-      },
+        locksDict: {}
+      }
     };
 
-    const hgApi = (window.hgApi = hglib.viewer(
+    const hgApi = window.hgApi = hglib.viewer(
       document.getElementById('demo'),
       viewConfig,
       { bounded: true },
-    ));
+    );
 
     hgApi.setBroadcastMousePositionGlobally(true);
 
     hgApi.on('viewConfig', () => {
       console.log('View Config changed');
     });
+
   </script>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>HiGlass</title>
     <style type="text/css">
       #demo {
@@ -18,7 +18,7 @@
     <script id="higlass-import" type="module">
       // we import higlass here and set a global so that we can
       // replace this block with our UMD build in './scripts/compile.mjs'
-      import * as hglib from "./app/scripts/hglib";
+      import * as hglib from './app/scripts/hglib';
       globalThis.hglib = hglib;
     </script>
     <!-- HIGLASS IMPORT -->
@@ -37,17 +37,11 @@
             w: 12,
             h: 7,
             x: 0,
-            y: 0
+            y: 0,
           },
           uid: 'aa',
-          initialYDomain: [
-            2534823997.9776945,
-            2547598956.834603
-          ],
-          initialXDomain: [
-            2521015726.4619913,
-            2558682921.8435397
-          ],
+          initialYDomain: [2534823997.9776945, 2547598956.834603],
+          initialXDomain: [2521015726.4619913, 2558682921.8435397],
           tracks: {
             left: [],
             top: [
@@ -69,7 +63,7 @@
                   mousePositionColor: '#000000',
                   geneAnnotationHeight: 10,
                   geneLabelPosition: 'outside',
-                  geneStrandSpacing: 4
+                  geneStrandSpacing: 4,
                 },
               },
               {
@@ -90,8 +84,8 @@
                   labelTextOpacity: 0.4,
                   showMousePosition: true,
                   mousePositionColor: '#000000',
-                  showTooltip: false
-                }
+                  showTooltip: false,
+                },
               },
               {
                 uid: 'line2',
@@ -111,7 +105,7 @@
                   labelTextOpacity: 0.4,
                   showMousePosition: true,
                   mousePositionColor: '#000000',
-                  showTooltip: false
+                  showTooltip: false,
                 },
               },
               {
@@ -132,7 +126,7 @@
                   labelTextOpacity: 0.4,
                   showMousePosition: true,
                   mousePositionColor: '#000000',
-                  showTooltip: false
+                  showTooltip: false,
                 },
               },
               {
@@ -153,13 +147,14 @@
                   labelTextOpacity: 0.4,
                   showMousePosition: true,
                   mousePositionColor: '#000000',
-                  showTooltip: false
+                  showTooltip: false,
                 },
               },
               {
                 uid: 'chroms',
                 height: 18,
-                chromInfoPath: '//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv',
+                chromInfoPath:
+                  '//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv',
                 type: 'horizontal-chromosome-labels',
                 options: {
                   color: '#777777',
@@ -167,9 +162,9 @@
                   fontSize: 11,
                   fontIsLeftAligned: true,
                   showMousePosition: true,
-                  mousePositionColor: '#000000'
+                  mousePositionColor: '#000000',
                 },
-              }
+              },
             ],
             right: [],
             center: [
@@ -190,7 +185,7 @@
                         'white',
                         'rgba(245,166,35,1.0)',
                         'rgba(208,2,27,1.0)',
-                        'black'
+                        'black',
                       ],
                       maxZoom: null,
                       colorbarPosition: 'topRight',
@@ -204,13 +199,13 @@
                       scaleEndPercent: '1.00000',
                       showMousePositionGlobally: true,
                     },
-                  }
+                  },
                 ],
-              }
+              },
             ],
             bottom: [],
             whole: [],
-            gallery: []
+            gallery: [],
           },
           chromInfoPath: '//s3.amazonaws.com/pkerp/data/hg19/chromSizes.tsv',
           genomePositionSearchBox: {
@@ -218,9 +213,9 @@
             chromInfoServer: 'http://higlass.io/api/v1',
             chromInfoId: 'hg19',
             autocompleteServer: 'http://higlass.io/api/v1',
-            autocompleteId: 'OHJakQICQD6gTD7skx4EWA'
-          }
-        }
+            autocompleteId: 'OHJakQICQD6gTD7skx4EWA',
+          },
+        },
       ],
       editable: true,
       viewEditable: true,
@@ -228,49 +223,40 @@
       exportViewUrl: '/api/v1/viewconfs',
       zoomLocks: {
         locksByViewUid: {},
-        locksDict: {}
+        locksDict: {},
       },
-      trackSourceServers: [
-        'http://higlass.io/api/v1'
-      ],
+      trackSourceServers: ['http://higlass.io/api/v1'],
       locationLocks: {
         locksByViewUid: {
           aa: 'PkNgAl3mSIqttnSsCewngw',
-          ewZvJwlDSei_dbpIAkGMlg: 'PkNgAl3mSIqttnSsCewngw'
+          ewZvJwlDSei_dbpIAkGMlg: 'PkNgAl3mSIqttnSsCewngw',
         },
         locksDict: {
           PkNgAl3mSIqttnSsCewngw: {
-            aa: [
-              1550000000,
-              1550000000,
-              3380588.876772046
-            ],
+            aa: [1550000000, 1550000000, 3380588.876772046],
             ewZvJwlDSei_dbpIAkGMlg: [
-              1550000000.0000002,
-              1549999999.9999993,
-              3380588.876772046
+              1550000000.0000002, 1549999999.9999993, 3380588.876772046,
             ],
-            uid: 'PkNgAl3mSIqttnSsCewngw'
-          }
-        }
+            uid: 'PkNgAl3mSIqttnSsCewngw',
+          },
+        },
       },
       valueScaleLocks: {
         locksByViewUid: {},
-        locksDict: {}
-      }
+        locksDict: {},
+      },
     };
 
-    const hgApi = window.hgApi = hglib.viewer(
+    const hgApi = (window.hgApi = hglib.viewer(
       document.getElementById('demo'),
       viewConfig,
       { bounded: true },
-    );
+    ));
 
     hgApi.setBroadcastMousePositionGlobally(true);
 
     hgApi.on('viewConfig', () => {
       console.log('View Config changed');
     });
-
   </script>
 </html>


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Make tracks use `setError` for setting error texts. This lets one track set multiple errors by using the `source` parameter.

> Why is it necessary?

So that tracks can set and display multiple errors. If this functionality wasn't there, the different overlaps would overlap and be illegible.

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
