### PR TITLE
Make a simple cache structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,13 +55,4 @@ jobs:
           cache: 'npm'
       - run: npm ci --legacy-peer-deps
       - run: npx playwright install chromium --with-deps
-
-      - name: Clone higlass-test-mocks
-        run: |
-          git clone --depth=1 https://github.com/higlass/higlass-test-mocks.git higlass-test-mocks
-          echo "HIGLASS_MOCKS_DIR=$(pwd)/higlass-test-mocks" >> $GITHUB_ENV
-
       - run: npm test -- --maxWorkers=1 --no-file-parallelism --shard ${{ matrix.shard }}
-        env:
-          VITE_USE_MOCKS: 1
-          HIGLASS_MOCKS_DIR: ${{ env.HIGLASS_MOCKS_DIR }}

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ lib/vendor
 app/test*.html
 response-cache.json
 test/mocks
+test/cache

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -7,165 +7,16 @@ import { server } from '@vitest/browser/context';
 /** @type {import('./scripts/vitest-browser-commands.mjs').ServerCache} */
 const CACHE = /** @type {any} */ (server.commands);
 
-/**
- * @template {unknown} T
- *
- * @param {ReadonlyArray<string>} ids
- * @param {{ origin: string, route: string, transform: (x: string) => T }} options
- *
- * @returns {Promise<undefined | Record<string, T>>}
- */
-async function tryFetchCached(ids, { origin, route, transform }) {
-  const results = await Promise.all(
-    ids.map((id) => CACHE.get([origin, route, id])),
-  );
-  if (results.some((i) => i === undefined)) {
-    return undefined;
+/** @param {URL} input */
+function normalizeURL(input) {
+  if (input.search) {
+    input.searchParams.sort();
+    input.search = `?${input.searchParams}`;
   }
-  return Object.fromEntries(
-    results.map((text, i) => [ids[i], transform(/** @type {string} */ (text))]),
-  );
-}
-
-/**
- * @param {string} origin
- * @param {"tiles" | "tileset_info"} route
- * @returns {msw.ResponseResolver}
- */
-function tilesOrTilesetInfo(origin, route) {
-  return async ({ request }) => {
-    const url = new URL(request.url);
-    const ids = url.searchParams.getAll('d');
-    const cached = await tryFetchCached(ids, {
-      origin,
-      route,
-      transform: JSON.parse,
-    });
-
-    if (cached) {
-      return msw.HttpResponse.json(cached);
-    }
-
-    // Persist request to our cache for next time.
-    const response = await fetch(msw.bypass(request));
-    const data = await response.json();
-    await Promise.all(
-      Object.entries(data).map(([k, v]) =>
-        CACHE.set([origin, route, k], JSON.stringify(v)),
-      ),
-    );
-  };
-}
-
-/**
- * @param {string} origin
- * @param {"chrom-sizes"} route
- * @returns {msw.ResponseResolver}
- */
-function chromsizes(origin, route) {
-  return async ({ request }) => {
-    const url = new URL(request.url);
-    const id = url.searchParams.get('id');
-    if (!id) return;
-    const maybeTsv = await CACHE.get([origin, route, id]);
-    if (maybeTsv) {
-      return msw.HttpResponse.text(maybeTsv);
-    }
-    const response = await fetch(msw.bypass(request));
-    const tsv = await response.text();
-    await CACHE.set([origin, route, id], tsv);
-  };
-}
-
-/**
- * @param {string} origin
- * @param {"tilesets"} route
- * @returns {msw.ResponseResolver}
- */
-function tilesets(origin, route) {
-  return async ({ request }) => {
-    const url = new URL(request.url);
-    const limit = url.searchParams.get('limit');
-    const dt = url.searchParams.get('dt');
-    if (!limit || !dt) {
-      return;
-    }
-    const maybeJson = await CACHE.get([
-      origin,
-      route,
-      `dt_${dt}`,
-      `limit_${limit}`,
-    ]);
-    if (maybeJson) {
-      return new msw.HttpResponse(maybeJson);
-    }
-    const response = await fetch(msw.bypass(request));
-    const json = await response.text();
-    await CACHE.set([origin, route, `limit_${limit}`, `dt_${dt}`], json);
-  };
-}
-
-/**
- * @param {string} origin
- * @param {"suggest"} route
- * @returns {msw.ResponseResolver}
- */
-function suggest(origin, route) {
-  return async ({ request }) => {
-    const url = new URL(request.url);
-    const d = url.searchParams.get('d');
-    const ac = url.searchParams.get('ac');
-    if (!d || !ac) {
-      return;
-    }
-    const maybeJson = await CACHE.get([origin, route, `d_${d}`, `ac_${ac}`]);
-    if (maybeJson) {
-      return new msw.HttpResponse(maybeJson);
-    }
-    const response = await fetch(msw.bypass(request));
-    const json = await response.text();
-    await CACHE.set([origin, route, `d_${d}`, `ac_${ac}`], json);
-  };
-}
-
-/**
- * @param {string} origin
- * @param {"viewconfs"} route
- * @returns {msw.ResponseResolver}
- */
-function viewconfs(origin, route) {
-  /** @param {{ request: Request }} ctx */
-  return async ({ request }) => {
-    const url = new URL(request.url);
-    const d = url.searchParams.get('d');
-    if (!d) {
-      return;
-    }
-    const maybeJson = await CACHE.get([origin, route, d]);
-    if (maybeJson) {
-      return new msw.HttpResponse(maybeJson);
-    }
-    const response = await fetch(msw.bypass(request));
-    const json = await response.text();
-    await CACHE.set([origin, route, d], json);
-  };
-}
-
-/**
- * @param {string} origin
- * @param {"available-chrom-sizes"} route
- * @returns {msw.ResponseResolver}
- */
-function availableChromsizes(origin, route) {
-  return async ({ request }) => {
-    const maybeJson = await CACHE.get([origin, route]);
-    if (maybeJson) {
-      return new msw.HttpResponse(maybeJson);
-    }
-    const response = await fetch(msw.bypass(request));
-    const json = await response.text();
-    await CACHE.set([origin, route], json);
-  };
+  if (input.pathname === '/') {
+    return input.toString().replace(/\/$/, '');
+  }
+  return input.toString();
 }
 
 /**
@@ -174,30 +25,22 @@ function availableChromsizes(origin, route) {
  * @param {string} origin
  * @returns {Array<msw.HttpHandler>}
  */
-function higlassServer(origin) {
-  /**
-   * Create a pair of HTTP/HTTPS resolvers for a given higlass origin and route.
-   *
-   * @template {string} R
-   * @param {string} origin
-   * @param {R} route
-   * @param {(base: string, route: R) => msw.ResponseResolver} resolver
-   * @returns {Array<msw.HttpHandler>}
-   */
-  function get(origin, route, resolver) {
-    return [
-      msw.http.get(`http://${origin}/${route}`, resolver(origin, route)),
-      msw.http.get(`https://${origin}/${route}`, resolver(origin, route)),
-    ];
-  }
+function cachedHiglassServer(origin) {
+  /** @param {{ request: Request }} ctx */
+  const handler = async ({ request }) => {
+    const url = new URL(request.url);
+    const key = normalizeURL(url);
+    const cached = await CACHE.get(key);
+    if (cached) {
+      return new msw.HttpResponse(cached);
+    }
+    const data = await fetch(msw.bypass(request));
+    const text = await data.text();
+    CACHE.set(key, text);
+  };
   return [
-    ...get(origin, 'tiles', tilesOrTilesetInfo),
-    ...get(origin, 'tileset_info', tilesOrTilesetInfo),
-    ...get(origin, 'chrom-sizes', chromsizes),
-    ...get(origin, 'tilesets', tilesets),
-    ...get(origin, 'suggest', suggest),
-    ...get(origin, 'viewconfs', viewconfs),
-    ...get(origin, 'available-chrom-sizes', availableChromsizes),
+    msw.http.get(`http://${origin}/*`, handler),
+    msw.http.get(`https://${origin}/*`, handler),
   ];
 }
 
@@ -251,12 +94,10 @@ bar	243199373`.trim(),
 
 if (import.meta.env.VITE_USE_MOCKS === '1') {
   const worker = setupWorker(
-    ...higlassServer('higlass.io/api/v1'),
-    ...higlassServer('resgen.io/api/v1'),
-    ...higlassServer('resgen.io/api/v1/gt/paper-data'),
+    ...cachedHiglassServer('higlass.io/api/v1'),
+    ...cachedHiglassServer('resgen.io/api/v1'),
     ...staticAssets(),
   );
-
   beforeAll(() => worker.start());
   afterAll(() => worker.stop());
   afterEach(() => worker.resetHandlers());


### PR DESCRIPTION
## Description

This PR proposes an alternative to the caching approach described in #1218. In that implementation, we explicitly handled all the different routes from a Higlass server and stored the results in a file cache that mirrored the routing structure. While this made the cache more structured and human-readable, it also introduced additional complexity—both in logic and in defining a data structure for storing the data.

Previous approach (file cache structure):

```sh
test/mocks
├── higlass.io
│   └── api
│       └── v1
│           ├── chrom-sizes
│           ├── suggest
│           ├── tiles
│           ├── tileset_info
│           ├── tilesets
│           ├── viewconfs
│           └── available-chrom-sizes
└── resgen.io
    └── api
        └── v1
            ├── chrom-sizes
            ├── gt
            ├── tiles
            └── tileset_info
 ````

One advantage of this structure is that the cache remains somewhat human-readable—you can easily see the structure of requests and even modify them if needed. However, the benefits of this readability are debatable.

> What was changed in this pull request?

This PR introduces a much simpler alternative: instead of a structured file cache, every captured request is stored in a flat cache:

```sh
test/cache
├── 0b5496a89e0f21b5e0437f9ba8cbd0dd
├── 0f3a10ae2255525882884ffac0f6525a
├── 0f57d6d6391247a3e1f31276795f1c51
├── 002f8ca5e32e2ca29644a85743de2f4f
├── 01f4ca160905b535fb9b21c408f30fc0
├── 0137f7aa6fa7a8cbbe86e1b3a956b3f5
├── 0239affac0d5b961be79a710a3d46823
├── 026bacdd84d43b369ee17b3e5d018598
├── 03ba92b542ea1fa8481be23b1ff0a4dd
```

This dramatically simplifies the logic, making the code much easier to read. However, it comes with two trade-offs:

- Loss of structural semantics (human readability). We could address this by prefixing each request with its path, though this would require additional handling.
- No cache hits for shared tiles/tileset_info. Since we're storing full batched tile responses rather than individual tiles/tileset_info, we miss out on potential reuse. As a result, full cache size increases from ~74MB to ~150MB (about 2x).

Despite the increased cache size, I lean towards this approach because of its simplicity. That said, I’m open to reconsidering the previous method if we can find a way to simplify it further. Let me know what you think!

> Why is it necessary?

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
