### PR TITLE
Add more type annotations for various `util`

### DIFF
--- a/app/scripts/types.ts
+++ b/app/scripts/types.ts
@@ -34,7 +34,7 @@ export type UnknownTrackConfig = {
 
 export type CombinedTrackConfig = {
   type: 'combined';
-  contents: TrackConfig[];
+  contents: Array<UnknownTrackConfig>;
   uid: string;
   server?: string;
   tilesetUid?: string;

--- a/app/scripts/types.ts
+++ b/app/scripts/types.ts
@@ -22,6 +22,8 @@ export type UnknownTrackConfig = {
   position?: TrackPosition;
   data?: Record<string, unknown>;
   coordSystem?: unknown;
+  height?: number;
+  width?: number;
   x?: number;
   y?: number;
   chromInfoPath?: string;
@@ -37,6 +39,8 @@ export type CombinedTrackConfig = {
   contents: Array<UnknownTrackConfig>;
   uid: string;
   server?: string;
+  height?: number;
+  width?: number;
   tilesetUid?: string;
   options?: Record<string, unknown>;
   position?: TrackPosition;

--- a/app/scripts/utils/background-task-scheduler.js
+++ b/app/scripts/utils/background-task-scheduler.js
@@ -41,6 +41,7 @@ class BackgroundTaskScheduler {
    * @param {string | null=} trackId
    * @return {void}
    */
+
   /**
    * If `taskData` is `null` the `taskHandler` will eventaully be called without any arguments.
    *
@@ -50,6 +51,7 @@ class BackgroundTaskScheduler {
    * @param {string | null=} trackId
    * @return {void}
    */
+
   /**
    * @param {(data: any) => void} taskHandler
    * @param {any} taskData

--- a/app/scripts/utils/color-domain-to-rgba-array.js
+++ b/app/scripts/utils/color-domain-to-rgba-array.js
@@ -1,24 +1,34 @@
-// @ts-nocheck
 import { range } from 'd3-array';
 import { rgb } from 'd3-color';
 import { scaleLinear } from 'd3-scale';
+
+/** @typedef {[r: number, g: number, b: number, a: number]} Color */
 
 /**
  * Convert a color domain to a 255 element array of [r,g,b,a]
  * values (all from 0 to 255). The last color (255) will always be
  * transparent
+ *
+ * @param {readonly [start: string, end: string]} colorRange
+ * @param {boolean} noTansparent
+ * @returns {Array<Color>}
  */
 const colorDomainToRgbaArray = (colorRange, noTansparent = false) => {
   // we should always have at least two values in the color range
   const domain = colorRange.map((x, i) => i * (255 / (colorRange.length - 1)));
 
-  const d3Scale = scaleLinear().domain(domain).range(colorRange);
+  const d3Scale = scaleLinear().domain(domain).range(
+    // @ts-expect-error - d3-color types aren't correctly inferred here
+    colorRange,
+  );
 
   const fromX = noTansparent ? 255 : 254;
 
+  /** @type {Array<Color>} */
   const rgbaArray = range(fromX, -1, -1)
     .map(d3Scale)
     .map((x) => {
+      // @ts-expect-error - d3-color support 0-1 ranges but not in types
       const r = rgb(x);
       return [r.r, r.g, r.b, r.opacity * 255];
     });

--- a/app/scripts/utils/expand-combined-tracks.js
+++ b/app/scripts/utils/expand-combined-tracks.js
@@ -1,19 +1,23 @@
-// @ts-nocheck
+import { isCombinedTrackConfig } from './type-guards';
+
+/** @import * as t from '../types' */
+
 /**
  * Go through a list of tracks and expand combined
  * tracks.
  *
- * @param {list} tracks: A list of tracks some of which might be combined
- * @returns {list} tracks: A list of tracks without combined
+ * @param {Array<t.TrackConfig>} trackList - A list of tracks some of which might be combined
+ * @returns {Array<t.UnknownTrackConfig>} A list of tracks without combined
  */
 const expandCombinedTracks = (trackList) => {
+  /** @type {Array<t.UnknownTrackConfig>} */
   let newTracks = [];
 
-  for (let i = 0; i < trackList.length; i++) {
-    if (trackList[i].contents) {
-      newTracks = newTracks.concat(trackList[i].contents);
+  for (const track of trackList) {
+    if (isCombinedTrackConfig(track)) {
+      newTracks = newTracks.concat(track.contents);
     } else {
-      newTracks.push(trackList[i]);
+      newTracks.push(track);
     }
   }
 

--- a/app/scripts/utils/fill-in-min-widths.js
+++ b/app/scripts/utils/fill-in-min-widths.js
@@ -1,35 +1,60 @@
-// @ts-nocheck
-// Configs
 import {
   MIN_HORIZONTAL_HEIGHT,
   MIN_VERTICAL_WIDTH,
   TRACKS_INFO_BY_TYPE,
 } from '../configs';
 
+/** @import * as t from '../types' */
+
 /**
- * If tracks don't have specified dimensions, add in the known
- * minimums
+ * @typedef CompleteTracks
+ * @property {Array<t.TrackConfig>} center
+ * @property {Array<t.TrackConfig>} left
+ * @property {Array<t.TrackConfig>} right
+ * @property {Array<t.TrackConfig>} top
+ * @property {Array<t.TrackConfig>} bottom
+ * @property {Array<t.TrackConfig>} whole
+ * @property {Array<t.TrackConfig>} gallery
+ */
+
+/**
+ * @template {t.TrackPosition} K
+ * @template {Array<t.TrackConfig>} T
+ * @typedef {Array<T[number] & { width: number }>} WithMinWidth
+ */
+
+/**
+ * If tracks don't have specified dimensions, add in the known minimums
+ *
+ * WARNING: Mutates `tracks` argument
+ *
+ * @template {Partial<CompleteTracks>} T
+ * @param {T} tracks
+ * @returns {{
+ *  [K in t.TrackPosition]: K extends keyof T ? T[K] extends undefined ? Array<t.TrackConfig> : T[K] : Array<t.TrackConfig>
+ * }}
  *
  * Operates on the tracks stored for this TiledPlot.
  */
 const fillInMinWidths = (tracks) => {
-  const horizontalLocations = ['top', 'bottom', 'gallery'];
-  const verticalLocations = ['left', 'right', 'gallery'];
+  // biome-ignore format: nicer to have as one line
+  const horizontalLocations = /** @type {const} */ (['top', 'bottom', 'gallery']);
+  const verticalLocations = /** @type {const} */ (['left', 'right', 'gallery']);
 
   // first make sure all track types are specified
   // this will make the code later on simpler
-  tracks.center = tracks.center || [];
-  tracks.left = tracks.left || [];
-  tracks.right = tracks.right || [];
-  tracks.top = tracks.top || [];
-  tracks.bottom = tracks.bottom || [];
-  tracks.whole = tracks.whole || [];
-  tracks.gallery = tracks.gallery || [];
+  tracks.center ??= [];
+  tracks.left ??= [];
+  tracks.right ??= [];
+  tracks.top ??= [];
+  tracks.bottom ??= [];
+  tracks.whole ??= [];
+  tracks.gallery ??= [];
 
   horizontalLocations
     .map((horizontalLocation) => tracks[horizontalLocation])
     .forEach((horizontalTracks) =>
-      horizontalTracks.forEach((track) => {
+      (horizontalTracks ?? []).forEach((track) => {
         const trackInfo = TRACKS_INFO_BY_TYPE[track.type];
         const defaultOptions = trackInfo?.defaultOptions || {};
         const options = track.options
@@ -37,6 +62,7 @@ const fillInMinWidths = (tracks) => {
           : defaultOptions;
 
         if (options.minHeight !== undefined && track.height === undefined) {
+          // @ts-expect-error - minHeight could be anything that's not undefined
           track.height = options.minHeight;
         }
 
@@ -49,7 +75,7 @@ const fillInMinWidths = (tracks) => {
   verticalLocations
     .map((verticalLocation) => tracks[verticalLocation])
     .forEach((verticalTracks) =>
-      verticalTracks.forEach((track) => {
+      (verticalTracks ?? []).forEach((track) => {
         const trackInfo = TRACKS_INFO_BY_TYPE[track.type];
         const defaultOptions = trackInfo?.defaultOptions || {};
 
@@ -58,6 +84,7 @@ const fillInMinWidths = (tracks) => {
           : defaultOptions;
 
         if (options.minWidth !== undefined && track.width === undefined) {
+          // @ts-expect-error - minWidth could be anything that's not undefined
           track.width = options.minWidth;
         }
 
@@ -67,6 +94,7 @@ const fillInMinWidths = (tracks) => {
       }),
     );
 
+  // @ts-expect-error - TS cannot infer that we have made the type correctly
   return tracks;
 };
 

--- a/app/scripts/utils/type-guards.js
+++ b/app/scripts/utils/type-guards.js
@@ -5,7 +5,7 @@
  * @return {trackConfig is t.CombinedTrackConfig}
  */
 export function isCombinedTrackConfig(trackConfig) {
-  return trackConfig.type === 'combined';
+  return 'contents' in trackConfig && trackConfig.type === 'combined';
 }
 
 /**

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import colorDomainToRgbaArray from '../app/scripts/utils/color-domain-to-rgba-array';
 import flatten from '../app/scripts/utils/flatten';
 import reduce from '../app/scripts/utils/reduce';
 import selectedItemsToCumWeights from '../app/scripts/utils/selected-items-to-cum-weights';
@@ -78,5 +79,32 @@ describe('reduce', () => {
 describe('flatten', () => {
   it('should flatten a nested array into a single-level array', () => {
     expect(flatten([[1, 2], [3, 4, 5], [6]])).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+});
+
+describe('colorDomainToRgbaArray', () => {
+  it.each(
+    /** @type {const} */ ([
+      { colors: ['red', 'blue'], description: 'named' },
+      { colors: ['#ff0000', '#0000ff'], description: 'hex' },
+      { colors: ['rgba(255,0,0,1)', 'rgba(0,0,255,1)'], description: 'RGBA' },
+    ]),
+  )('generates RGBA array with transparency for $description', ({ colors }) => {
+    const range = colorDomainToRgbaArray(colors);
+    expect(range.length).toBe(256);
+    expect(range.at(2)).toEqual([3, 0, 252, 255]);
+    expect(range.at(50)).toEqual([51, 0, 204, 255]);
+    expect(range.at(-10)).toEqual([247, 0, 8, 255]);
+    expect(range.at(-1)).toEqual([255, 255, 255, 0]);
+  });
+
+  it('generates correct RGBA array without transparency', () => {
+    const noTransparent = true;
+    const range = colorDomainToRgbaArray(['yellow', 'green'], noTransparent);
+    expect(range.length).toBe(256);
+    expect(range.at(2)).toEqual([2, 129, 0, 255]);
+    expect(range.at(50)).toEqual([50, 153, 0, 255]);
+    expect(range.at(-10)).toEqual([246, 251, 0, 255]);
+    expect(range.at(-1)).toEqual([255, 255, 0, 255]);
   });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -120,3 +120,91 @@ describe('expandCombinedTracks', () => {
     expect(tracks.length).toBe(4);
   });
 });
+
+describe('fillInMinWidths', () => {
+  it('fills in tracks with default min width and min height', () => {
+    const tracks = utils.fillInMinWidths({
+      top: [
+        {
+          uid: '1',
+          type: 'horizontal-line',
+          server: 'http://higlass.io/api/v1',
+          tilesetUid: 'F2vbUeqhS86XkxuO1j2rPA',
+        },
+        {
+          uid: '3',
+          type: 'horizontal-line',
+          server: 'http://higlass.io/api/v1',
+          tilesetUid: 'F2vbUeqhS86XkxuO1j2rPA',
+          options: {
+            minHeight: 100,
+          },
+        },
+      ],
+      right: [
+        {
+          uid: '2',
+          type: 'vertical-line',
+          server: 'http://higlass.io/api/v1',
+          tilesetUid: 'F2vbUeqhS86XkxuO1j2rPA',
+        },
+        {
+          uid: '4',
+          type: 'vertical-line',
+          server: 'http://higlass.io/api/v1',
+          tilesetUid: 'F2vbUeqhS86XkxuO1j2rPA',
+          options: {
+            minWidth: 100,
+          },
+        },
+      ],
+    });
+    expect(tracks).toMatchInlineSnapshot(`
+      {
+        "bottom": [],
+        "center": [],
+        "gallery": [],
+        "left": [],
+        "right": [
+          {
+            "server": "http://higlass.io/api/v1",
+            "tilesetUid": "F2vbUeqhS86XkxuO1j2rPA",
+            "type": "vertical-line",
+            "uid": "2",
+            "width": 20,
+          },
+          {
+            "options": {
+              "minWidth": 100,
+            },
+            "server": "http://higlass.io/api/v1",
+            "tilesetUid": "F2vbUeqhS86XkxuO1j2rPA",
+            "type": "vertical-line",
+            "uid": "4",
+            "width": 100,
+          },
+        ],
+        "top": [
+          {
+            "height": 20,
+            "server": "http://higlass.io/api/v1",
+            "tilesetUid": "F2vbUeqhS86XkxuO1j2rPA",
+            "type": "horizontal-line",
+            "uid": "1",
+          },
+          {
+            "height": 100,
+            "options": {
+              "minHeight": 100,
+            },
+            "server": "http://higlass.io/api/v1",
+            "tilesetUid": "F2vbUeqhS86XkxuO1j2rPA",
+            "type": "horizontal-line",
+            "uid": "3",
+          },
+        ],
+        "whole": [],
+      }
+    `);
+  });
+});


### PR DESCRIPTION
Add more type annotations (and unit tests) for various utilities

- **Annotate `utils/color-domain-to-rgba-array.js`**
- **Annotate `utils/expand-combined-tracks.js`**
- **Annotate types for `app/scripts/utils/fill-in-min-widths.js`**

> Why is it necessary?

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [x] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
