### PR TITLE
Annotate types and add unit tests for `utils/get-default-track-for-datatype.js`

### DIFF
--- a/app/scripts/utils/get-default-track-for-datatype.js
+++ b/app/scripts/utils/get-default-track-for-datatype.js
@@ -1,15 +1,43 @@
-// @ts-nocheck
 // Configs
 import { DEFAULT_TRACKS_FOR_DATATYPE } from '../configs';
+
+/** @typedef {typeof DEFAULT_TRACKS_FOR_DATATYPE} DataTypeMapping */
+/** @typedef {keyof DataTypeMapping} DataType */
+/** @typedef {"top" | "bottom" | "left" | "right" | "center"} TrackPosition */
+
+/**
+ * @template {string} D
+ * @template {string} P
+ * @typedef {D extends DataType ? P extends keyof DataTypeMapping[D] ? DataTypeMapping[D][P] : undefined : undefined} ExtractDataType
+ */
+
+/**
+ * @template {DataType | string & {}} D
+ * @template {TrackPosition} P
+ *
+ * @param {D} datatype
+ * @param {P} position
+ * @returns {ExtractDataType<D, P>}
+ */
+function findDefaultTrackType(datatype, position) {
+  // @ts-expect-error - ok with undefined check
+  return DEFAULT_TRACKS_FOR_DATATYPE[datatype] !== undefined
+    ? // @ts-expect-error - ok with undefined check
+      DEFAULT_TRACKS_FOR_DATATYPE[datatype][position]
+    : undefined;
+}
 
 /**
  * Gets the default track as defined in utils/default-tracks-for-datatype.js
  *
- * @param  {string} datatype The datatype to get the default track for
- * @param  {string} position   top, bottom, left, right, center
- * @param  {array} availableTracks   list of tracks to choose from,
- * typically obtained from AVAILABLE_TRACK_TYPES(...)
- * @return {object}  an element of availableTracks or undefined
+ * @template {DataType | string & {}} D
+ * @template {TrackPosition} P
+ * @template {ReadonlyArray<{ type: string }>} ATracks
+ *
+ * @param  {D} datatype - The datatype to get the default track for
+ * @param  {P} position - top, bottom, left, right, center
+ * @param  {ATracks} availableTracks - List of tracks to choose from, typically obtained from AVAILABLE_TRACK_TYPES(...)
+ * @return {ATracks[number] | undefined} An element of availableTracks or undefined
  */
 const getDefaultTrackForDatatype = (datatype, position, availableTracks) => {
   if (availableTracks.length === 0) {
@@ -21,10 +49,8 @@ const getDefaultTrackForDatatype = (datatype, position, availableTracks) => {
   }
 
   let usedTrack = availableTracks[0];
-  const defaultTrackType =
-    DEFAULT_TRACKS_FOR_DATATYPE[datatype] !== undefined
-      ? DEFAULT_TRACKS_FOR_DATATYPE[datatype][position]
-      : undefined;
+
+  const defaultTrackType = findDefaultTrackType(datatype, position);
 
   if (defaultTrackType !== undefined) {
     // If we found a default track type for this datatype,

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -208,3 +208,36 @@ describe('fillInMinWidths', () => {
     `);
   });
 });
+
+describe('getDefaultTrackForDatatype', () => {
+  it('finds fails to find track without any available', () => {
+    expect(
+      utils.getDefaultTrackForDatatype('vector', 'top', []),
+    ).toBeUndefined();
+  });
+
+  // Trevor: Weird behavior of the method
+  it('picks first track only one available, regardless of type', () => {
+    expect(
+      utils.getDefaultTrackForDatatype('vector', 'top', [{ type: 'blah' }]),
+    ).toEqual({ type: 'blah' });
+  });
+
+  it('picks first available track with matching type', () => {
+    expect(
+      utils.getDefaultTrackForDatatype('vector', 'top', [
+        {
+          type: 'blah',
+        },
+        {
+          type: 'bar',
+          tag: 'first',
+        },
+        {
+          type: 'bar',
+          tag: 'second',
+        },
+      ]),
+    ).toEqual({ type: 'bar', tag: 'first' });
+  });
+});


### PR DESCRIPTION
## Description

> What was changed in this pull request?



> Why is it necessary?

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [x] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
