### PR TITLE
Annotate Higher Order React Components

### DIFF
--- a/app/scripts/AddTrackDialog.jsx
+++ b/app/scripts/AddTrackDialog.jsx
@@ -15,7 +15,7 @@ import { getDefaultTrackForDatatype } from './utils';
 // Styles
 import '../styles/AddTrackDialog.module.scss';
 
-class AddTrackDialog extends React.Component {
+export class AddTrackDialog extends React.Component {
   constructor(props) {
     super(props);
 

--- a/app/scripts/HiGlassComponent.jsx
+++ b/app/scripts/HiGlassComponent.jsx
@@ -116,6 +116,7 @@ class HiGlassComponent extends React.Component {
     this.resizeSensor = null;
 
     this.uid = slugid.nice();
+    /** @type {Record<string, import('./TiledPlot').TiledPlot> */
     this.tiledPlots = {};
     this.genomePositionSearchBoxes = {};
 

--- a/app/scripts/TiledPlot.jsx
+++ b/app/scripts/TiledPlot.jsx
@@ -50,7 +50,7 @@ import stylesCenterTrack from '../styles/CenterTrack.module.scss';
 // Styles
 import styles from '../styles/TiledPlot.module.scss';
 
-class TiledPlot extends React.Component {
+export class TiledPlot extends React.Component {
   constructor(props) {
     super(props);
 

--- a/app/scripts/TilesetFinder.jsx
+++ b/app/scripts/TilesetFinder.jsx
@@ -13,7 +13,7 @@ import withPubSub from './hocs/with-pub-sub';
 // Configs
 import { TRACKS_INFO } from './configs';
 
-class TilesetFinder extends React.Component {
+export class TilesetFinder extends React.Component {
   constructor(props) {
     super(props);
 

--- a/app/scripts/TrackRenderer.jsx
+++ b/app/scripts/TrackRenderer.jsx
@@ -221,7 +221,7 @@ const SCROLL_TIMEOUT = 100;
 /**
  * @extends {React.Component<TrackRendererProps>}
  */
-class TrackRenderer extends React.Component {
+export class TrackRenderer extends React.Component {
   /**
    * Maintain a list of tracks, and re-render them whenever either
    * their size changes or the zoom level changes

--- a/app/scripts/configs/themes.js
+++ b/app/scripts/configs/themes.js
@@ -1,4 +1,3 @@
-// @ts-nocheck
 export const THEME_LIGHT = Symbol('Light theme');
 
 export const THEME_DARK = Symbol('Dark theme');

--- a/app/scripts/hocs/with-modal.jsx
+++ b/app/scripts/hocs/with-modal.jsx
@@ -1,21 +1,43 @@
-// @ts-nocheck
-
 import React from 'react';
 
-import { toVoid } from '../utils';
+import toVoid from '../utils/to-void';
 
 const { Provider, Consumer } = React.createContext({
   close: toVoid,
   open: toVoid,
 });
 
-// Higher order component
-const withModal = (Component) =>
-  React.forwardRef((props, ref) => (
-    <Consumer>
-      {(modal) => <Component ref={ref} {...props} modal={modal} />}
-    </Consumer>
-  ));
+// Trevor: Not sure how to type these HOCs correctly.
+//
+// We want the wrapped component to retain the same instance API while
+// eliminating the need to pass `modal` explicitly.
+//
+// Ideally, we'd use Higher Kinded Types (HKT), but since TypeScript lacks them,
+// we preserve the original type instead.
+//
+// This may cause instantiation errors (e.g., TS complaining about a missing `modal`),
+// but I think this is acceptable because:
+//
+// 1. It only affects instantiation (we can ignore the error in one place).
+// 2. We control instantiation, so this won't impact external consumers.
+// 3. Explicitly passing the new props would erase type information for the rest of the API,
+//    reducing type safety everywhere else.
+
+/** @typedef {{ open: () => void, close: () => void }} Modal  */
+
+/**
+ * @template {typeof React.Component<{ modal?: Modal }>} T
+ * @param {T} Component
+ * @returns {T}
+ */
+function withModal(Component) {
+  // @ts-expect-error See comment above
+  return React.forwardRef((props, ref) =>
+    React.createElement(Consumer, null, (/** @type {Modal} */ modal) =>
+      React.createElement(Component, { ref, ...props, modal }),
+    ),
+  );
+}
 
 export default withModal;
 

--- a/app/scripts/hocs/with-pub-sub.js
+++ b/app/scripts/hocs/with-pub-sub.js
@@ -1,14 +1,23 @@
-// @ts-nocheck
 import React from 'react';
 
 import fakePubSub from '../utils/fake-pub-sub';
 
 const { Provider, Consumer } = React.createContext(fakePubSub);
 
-// Written without JSX to make it so we don't need JSX-transformation to load this file
+// Trevor: Not sure how to type these HOCs correctly.
+// This is a workaround. See ./with-modal for more information.
+
+/** @import { PubSub } from 'pub-sub-es' */
+
+/**
+ * @template {typeof React.Component<{ pubSub?: PubSub }>} T
+ * @param {T} Component
+ * @returns {T}
+ */
 function withPubSub(Component) {
+  // @ts-expect-error See comment in ./with-modal
   return React.forwardRef((props, ref) =>
-    React.createElement(Consumer, null, (pubSub) =>
+    React.createElement(Consumer, null, (/** @type {PubSub} */ pubSub) =>
       React.createElement(Component, { ref, ...props, pubSub }),
     ),
   );

--- a/app/scripts/hocs/with-theme.jsx
+++ b/app/scripts/hocs/with-theme.jsx
@@ -1,21 +1,28 @@
-// @ts-nocheck
-
 import React from 'react';
+import * as themes from '../configs/themes';
 
-import { toVoid } from '../utils';
+/** @typedef {themes.THEME_LIGHT | themes.THEME_DARK} Theme */
 
-const { Provider, Consumer } = React.createContext({
-  close: toVoid,
-  open: toVoid,
-});
+const { Provider, Consumer } = React.createContext(
+  /** @type {Theme} */ (themes.THEME_DEFAULT),
+);
 
-// Higher order component
-const withTheme = (Component) =>
-  React.forwardRef((props, ref) => (
-    <Consumer>
-      {(theme) => <Component ref={ref} {...props} theme={theme} />}
-    </Consumer>
-  ));
+// Trevor: Not sure how to type these HOCs correctly.
+// This is a workaround. See ./with-modal for more information.
+
+/**
+ * @template {typeof React.Component<{ theme?: Theme }>} T
+ * @param {T} Component
+ * @returns {T}
+ */
+function withTheme(Component) {
+  // @ts-expect-error See comment in ./with-modal
+  return React.forwardRef((props, ref) =>
+    React.createElement(Consumer, null, (/** @type {Theme} */ theme) =>
+      React.createElement(Component, { ref, ...props, theme }),
+    ),
+  );
+}
 
 export default withTheme;
 

--- a/app/scripts/utils/get-higlass-components.js
+++ b/app/scripts/utils/get-higlass-components.js
@@ -1,19 +1,43 @@
-// @ts-nocheck
+/** @import * as t from '../types' */
+/** @import HiGlassComponent from '../HiGlassComponent' */
+/** @import { TrackRenderer } from '../TrackRenderer' */
+/** @import { TiledPlot } from '../TiledPlot' */
+
+/**
+ * @param {HiGlassComponent} hgc
+ * @param {string} viewUid
+ * @param {string | undefined} trackUid
+ * @returns {t.TrackObject | undefined}
+ */
 export const getTrackObjectFromHGC = (hgc, viewUid, trackUid) => {
+  /** @type {string} */
   let newViewUid = viewUid;
-  let newTrackUid = trackUid;
+  /** @type {string} */
+  let newTrackUid;
 
   if (!trackUid) {
     // didn't specify a trackUid so use the viewUid as the trackUid
     // and use the first plot
     newTrackUid = viewUid;
     newViewUid = Object.values(hgc.state.views)[0].uid;
+  } else {
+    newTrackUid = trackUid;
   }
 
-  return hgc.tiledPlots[newViewUid].trackRenderer.getTrackObject(newTrackUid);
+  return hgc.tiledPlots[newViewUid].trackRenderer?.getTrackObject(newTrackUid);
 };
 
+/**
+ * @param {HiGlassComponent} hgc
+ * @param {string} viewUid
+ * @returns {TrackRenderer | null}
+ */
 export const getTrackRenderer = (hgc, viewUid) =>
   hgc.tiledPlots[viewUid].trackRenderer;
 
+/**
+ * @param {HiGlassComponent} hgc
+ * @param {string} viewUid
+ * @returns {TiledPlot}
+ */
 export const getTiledPlot = (hgc, viewUid) => hgc.tiledPlots[viewUid];


### PR DESCRIPTION
Adds type annotations for HOCs to preserve instance API

This ensures the wrapped component retains the same instance API while removing
the need to pass wrapped props (e.g., `modal`) explicitly.

Since TypeScript lacks Higher Kinded Types (HKT), we preserve the original type
instead. Potential instantiation errors (e.g., missing `modal`) are acceptable
as we control instantiation, and this approach maintains better type safety for
consumers.

> Why is it necessary?

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
