### PR TITLE
feat: Rewrite `tile-proxy.js`

### DIFF
--- a/app/scripts/data-fetchers/DataFetcher.js
+++ b/app/scripts/data-fetchers/DataFetcher.js
@@ -54,15 +54,11 @@ function createDefaultTileSource(pubSub) {
   return {
     fetchTiles(request) {
       return new Promise((done) => {
-        tileProxy.fetchTilesDebounced(
-          {
-            ...request,
-            ids: request.tileIds ?? [],
-            // @ts-expect-error - This is just really hard to type correctly
-            done,
-          },
-          pubSub,
-        );
+        tileProxy.fetchTilesDebounced({
+          ...request,
+          // @ts-expect-error - This is just really hard to type correctly
+          done,
+        });
       });
     },
     fetchTilesetInfo({ server, tilesetUid }) {
@@ -265,22 +261,20 @@ export default class DataFetcher {
         tileIds: tileIds.map((x) => `${this.dataConfig.tilesetUid}.${x}`),
         options: this.dataConfig.options,
       });
-      return /** @type {Promise<Record<string, Tile>>} */ (promise).then(
-        (returnedTiles) => {
-          const tilesetUid = dictValues(returnedTiles)[0].tilesetUid;
-          /** @type {Record<string, Tile>} */
-          const newTiles = {};
+      return promise.then((returnedTiles) => {
+        const tilesetUid = dictValues(returnedTiles)[0].tilesetUid;
+        /** @type {Record<string, Tile>} */
+        const newTiles = {};
 
-          for (let i = 0; i < tileIds.length; i++) {
-            const fullTileId = this.fullTileId(tilesetUid, tileIds[i]);
+        for (let i = 0; i < tileIds.length; i++) {
+          const fullTileId = this.fullTileId(tilesetUid, tileIds[i]);
 
-            returnedTiles[fullTileId].tilePositionId = tileIds[i];
-            newTiles[tileIds[i]] = returnedTiles[fullTileId];
-          }
-          receivedTiles(newTiles);
-          return newTiles;
-        },
-      );
+          returnedTiles[fullTileId].tilePositionId = tileIds[i];
+          newTiles[tileIds[i]] = returnedTiles[fullTileId];
+        }
+        receivedTiles(newTiles);
+        return newTiles;
+      });
     }
 
     // multiple child tracks, need to wait for all of them to


### PR DESCRIPTION
This was mostly an exercise to understanding what is actually going on in `tile-proxy.js`.

This PR restructures request batching in `tile-proxy.js` to improve readability and fine-tuning.

Reading through the existing code, I found it very challenging to understand the control flow. The logic is quite intertwined, with tightly coupled closures and state dependencies, making it difficult to track how requests move through the system.

My current understanding is that `DataFetcher` makes a generates a unique `id` for a tile request, dispatching a request to `fetchTilesDebounced`, which batches requests in three stages:

1.) Group by time/debouncing (groups multiple requests together)
2.) Group by `request.id`
3.) Group by `request.server`
4.) Limit max group size by threshold (`MAX_REQUEST_TILES`)

This refactor separates concerns into distinct layers:

- `bufferedBatcher` – a generic function for debounced request queueing (1)
- `fetchMultiRequestTiles` – processing batched requests
    - `bundleRequests` – consolidating requests before dispatch (2, 3, 4)

I get the "don’t fix what isn't broken" perspective, but the existing structure made it difficult to reason about what was happening.

Separating concerns improves readability, maintainability, and reusability while keeping the core logic intact.

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
