### PR TITLE
Refactor tile proxy batching to make aggregator generic

### DIFF
--- a/app/scripts/services/tile-proxy.js
+++ b/app/scripts/services/tile-proxy.js
@@ -145,21 +145,19 @@ export const getTileProxyAuthHeader = () => authHeader;
  */
 export function bundleRequestsById(requests) {
   /** @type {Array<T>} */
-  const bundledRequest = [];
+  const bundle = [];
   /** @type {Record<string, number>} */
-  const requestMapper = {};
+  const mapper = {};
 
   for (const request of requests) {
-    const requestId = requestMapper[request.id];
-    if (requestId === undefined) {
-      requestMapper[request.id] = bundledRequest.length;
-      bundledRequest.push(request);
-    } else {
-      bundledRequest[requestId].ids.push(...request.ids);
+    if (mapper[request.id] === undefined) {
+      mapper[request.id] = bundle.length;
+      bundle.push({ ...request, ids: [] });
     }
+    bundle[mapper[request.id]].ids.push(...request.ids);
   }
 
-  return bundledRequest;
+  return bundle;
 }
 
 /**

--- a/app/scripts/services/tile-proxy.js
+++ b/app/scripts/services/tile-proxy.js
@@ -61,10 +61,7 @@ const delayedBatchExecutor = (processBatch, interval, finalWait) => {
 
   /** @param {Args} args */
   const callFunc = (...args) => {
-    // NB: In a normal situation we would just call `func(...args)` but since we
-    // always trigger `reset()` afterwards I created
-    // this helper function to avoid code duplication. Think of this function
-    // as the actual function call that is being throttled and debounced.
+    // Flush the "bundle" (of collected items) to the processor
     processBatch(items, ...args);
     reset();
   };
@@ -86,17 +83,13 @@ const delayedBatchExecutor = (processBatch, interval, finalWait) => {
     timeout = setTimeout(later, finalWait);
   };
 
-  debounced.cancel = () => {
-    clearTimeout(timeout);
-    reset();
-  };
-
   let wait = false;
   /**
    * @param {T} item
    * @param {Args} args
    */
   const throttled = (item, ...args) => {
+    // Collect items into the current queue any time the caller makes a request
     items.push(item);
 
     if (!wait) {
@@ -140,7 +133,6 @@ export const getTileProxyAuthHeader = () => authHeader;
  *
  * const bundled = bundleRequests(requests);
  * console.log(bundled);
- * // Output:
  * // [
  * //   { id: "A", ids: ["1", "2", "4", "5"] },
  * //   { id: "B", ids: ["3"] }

--- a/test/tile-proxy.test.js
+++ b/test/tile-proxy.test.js
@@ -132,13 +132,13 @@ describe('bundleRequestsById', () => {
   it('merges requests with the same id', () => {
     expect(
       bundleRequestsById([
-        { id: 'A', ids: ['1', '2'] },
-        { id: 'B', ids: ['3'] },
-        { id: 'A', ids: ['4', '5'] },
+        { id: 'A', ids: ['1', '2'], answer: 42 },
+        { id: 'B', ids: ['3'], bar: 'baz' },
+        { id: 'A', ids: ['4', '5'], answer: 123 },
       ]),
     ).toEqual([
-      { id: 'A', ids: ['1', '2', '4', '5'] },
-      { id: 'B', ids: ['3'] },
+      { id: 'A', ids: ['1', '2', '4', '5'], answer: 42 },
+      { id: 'B', ids: ['3'], bar: 'baz' },
     ]);
   });
 

--- a/test/tile-proxy.test.js
+++ b/test/tile-proxy.test.js
@@ -2,6 +2,7 @@ import { assert, describe, expect, it } from 'vitest';
 
 import tileProxy, {
   tileDataToPixData,
+  bundleRequestsById,
 } from '../app/scripts/services/tile-proxy';
 import fakePubSub from '../app/scripts/utils/fake-pub-sub';
 import { defaultColorScale } from './testdata/colorscale-data';
@@ -125,4 +126,35 @@ describe('tile-proxy text', () => {
         selectedRowsOptions,
       );
     }));
+});
+
+describe('bundleRequestsById', () => {
+  it('merges requests with the same id', () => {
+    expect(
+      bundleRequestsById([
+        { id: 'A', ids: ['1', '2'] },
+        { id: 'B', ids: ['3'] },
+        { id: 'A', ids: ['4', '5'] },
+      ]),
+    ).toEqual([
+      { id: 'A', ids: ['1', '2', '4', '5'] },
+      { id: 'B', ids: ['3'] },
+    ]);
+  });
+
+  it('returns the same array when all ids are unique', () => {
+    expect(
+      bundleRequestsById([
+        { id: 'X', ids: ['10'] },
+        { id: 'Y', ids: ['20', '30'] },
+      ]),
+    ).toEqual([
+      { id: 'X', ids: ['10'] },
+      { id: 'Y', ids: ['20', '30'] },
+    ]);
+  });
+
+  it('returns an empty array when input is empty', () => {
+    expect(bundleRequestsById([])).toEqual([]);
+  });
 });


### PR DESCRIPTION
Although `throttleAndDebounce` has a generic name, the function signature is coupled to `fetchMultiRequestTiles`. 

For example, I would expect such function to work like:

```ts
const debounced = throttleAndDebounce((item: string) => console.log(item), 100, 100);

setInterval(() => {
  debounced("hi"); // 
}, 10);
```

However, after reviewing the implementation, I realized that `throttleAndDebounce` is actually an _aggregator_. It collects multiple calls and submits them in batches to the provided function, which operates on the aggregated input rather than individual requests.

This PR decouples it by changing the type signature, explicitly transforming a function that processes a batch `(items: Array<T>) => void` into one that handles individual items `(item: T) => void` (thus a rename to `delayedBatchExecutor`). 


```typescript
const submitItem = delayedBatchExecutor(
  (items: Array<string>) => console.log(`processing:  ${items}`), { interval: 100, finalWait: 100 }
 );

setInterval(() => {
  submitItem("hi"); // now correctly batches inputs
}, 10);
```

Notice how the function returned from `delayedBatchExecutor` operates on a scalar input rather than a batch. All the logic to handle the batch is confined to the implementation (and not the responsibility of the generic helper.

> Why is it necessary?

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
