### PR TITLE
Extract and unit test server-bundling logic in tile-proxy

### DIFF
--- a/app/scripts/services/tile-proxy.js
+++ b/app/scripts/services/tile-proxy.js
@@ -28,7 +28,7 @@ export let authHeader = null;
  */
 
 /**
- * Iterator helper to chunk an array into smaller arrways of a fixed size.
+ * Iterator helper to chunk an array into smaller arrays of a fixed size.
  *
  * @template T
  * @param {Iterable<T>} iterable

--- a/test/tile-proxy.test.js
+++ b/test/tile-proxy.test.js
@@ -161,15 +161,32 @@ describe('bundleRequestsById', () => {
 });
 
 describe('bundleRequestsByServer', () => {
+  /**
+   * @param {ReturnType<typeof bundleRequestsByServer>} requests
+   */
+  function toLegacy(requests) {
+    return {
+      requestsByServer: Object.fromEntries(
+        requests.map((r) => [
+          r.server,
+          Object.fromEntries(r.ids.map((id) => [id, true])),
+        ]),
+      ),
+      requestBodyByServer: Object.fromEntries(
+        requests.map((r) => [r.server, r.body]),
+      ),
+    };
+  }
+
   it('merges requests for the same server and combines ids', () => {
-    expect(
-      bundleRequestsByServer([
-        { server: 'A', ids: ['AA.1', 'AA.2'] },
-        { server: 'B', ids: ['BB.3'] },
-        { server: 'A', ids: ['AA.4', 'AA.5'] },
-        { server: 'A', ids: ['BB.4', 'BB.5'] },
-      ]),
-    ).toMatchInlineSnapshot(`
+    const result = bundleRequestsByServer([
+      { server: 'A', ids: ['AA.1', 'AA.2'] },
+      { server: 'B', ids: ['BB.3'] },
+      { server: 'A', ids: ['AA.4', 'AA.5'] },
+      { server: 'A', ids: ['BB.4', 'BB.5'] },
+    ]);
+    expect(result).toMatchInlineSnapshot();
+    expect(toLegacy(result)).toMatchInlineSnapshot(`
       {
         "requestBodyByServer": {
           "A": [],
@@ -193,14 +210,14 @@ describe('bundleRequestsByServer', () => {
   });
 
   it('creates and appends body entries for request with options', () => {
-    expect(
-      bundleRequestsByServer([
-        { server: 'A', ids: ['AA.1', 'AA.2'], options: { answer: 42 } },
-        { server: 'B', ids: ['BB.3'], options: { name: 'monty' } },
-        { server: 'A', ids: ['AA.4', 'AA.5'] },
-        { server: 'A', ids: ['BB.4', 'BB.5'], options: { name: 'python' } },
-      ]),
-    ).toEqual({
+    const result = bundleRequestsByServer([
+      { server: 'A', ids: ['AA.1', 'AA.2'], options: { answer: 42 } },
+      { server: 'B', ids: ['BB.3'], options: { name: 'monty' } },
+      { server: 'A', ids: ['AA.4', 'AA.5'] },
+      { server: 'A', ids: ['BB.4', 'BB.5'], options: { name: 'python' } },
+    ]);
+    expect(result).toMatchInlineSnapshot();
+    expect(toLegacy(result)).toEqual({
       requestBodyByServer: {
         A: [
           {
@@ -239,12 +256,12 @@ describe('bundleRequestsByServer', () => {
   });
 
   it('returns the same array when all servers are unique', () => {
-    expect(
-      bundleRequestsByServer([
-        { server: 'X', ids: ['foo.10'] },
-        { server: 'Y', ids: ['bar.20', 'bar.30'] },
-      ]),
-    ).toEqual({
+    const result = bundleRequestsByServer([
+      { server: 'X', ids: ['foo.10'] },
+      { server: 'Y', ids: ['bar.20', 'bar.30'] },
+    ]);
+    expect(result).toMatchInlineSnapshot();
+    expect(toLegacy(result)).toEqual({
       requestBodyByServer: {
         X: [],
         Y: [],
@@ -257,11 +274,6 @@ describe('bundleRequestsByServer', () => {
   });
 
   it('returns an empty array when input is empty', () => {
-    expect(bundleRequestsByServer([])).toMatchInlineSnapshot(`
-      {
-        "requestBodyByServer": {},
-        "requestsByServer": {},
-      }
-    `);
+    expect(bundleRequestsByServer([])).toMatchInlineSnapshot([]);
   });
 });

--- a/test/tile-proxy.test.js
+++ b/test/tile-proxy.test.js
@@ -185,7 +185,29 @@ describe('bundleRequestsByServer', () => {
       { server: 'A', ids: ['AA.4', 'AA.5'] },
       { server: 'A', ids: ['BB.4', 'BB.5'] },
     ]);
-    expect(result).toMatchInlineSnapshot();
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "body": [],
+          "ids": [
+            "AA.1",
+            "AA.2",
+            "AA.4",
+            "AA.5",
+            "BB.4",
+            "BB.5",
+          ],
+          "server": "A",
+        },
+        {
+          "body": [],
+          "ids": [
+            "BB.3",
+          ],
+          "server": "B",
+        },
+      ]
+    `);
     expect(toLegacy(result)).toMatchInlineSnapshot(`
       {
         "requestBodyByServer": {
@@ -214,15 +236,46 @@ describe('bundleRequestsByServer', () => {
       { server: 'A', ids: ['AA.1', 'AA.2'], options: { answer: 42 } },
       { server: 'B', ids: ['BB.3'], options: { name: 'monty' } },
       { server: 'A', ids: ['AA.4', 'AA.5'] },
+      { server: 'A', ids: ['AA.6'], options: { answer: 51 } },
       { server: 'A', ids: ['BB.4', 'BB.5'], options: { name: 'python' } },
     ]);
-    expect(result).toMatchInlineSnapshot();
+    expect(result).toEqual([
+      {
+        ids: ['AA.1', 'AA.2', 'AA.4', 'AA.5', 'AA.6', 'BB.4', 'BB.5'],
+        server: 'A',
+        options: { answer: 42 },
+        body: [
+          {
+            tilesetUid: 'AA',
+            tileIds: ['1', '2', '6'],
+            options: { answer: 42 },
+          },
+          {
+            tilesetUid: 'BB',
+            tileIds: ['4', '5'],
+            options: { name: 'python' },
+          },
+        ],
+      },
+      {
+        ids: ['BB.3'],
+        server: 'B',
+        options: { name: 'monty' },
+        body: [
+          {
+            tilesetUid: 'BB',
+            tileIds: ['3'],
+            options: { name: 'monty' },
+          },
+        ],
+      },
+    ]);
     expect(toLegacy(result)).toEqual({
       requestBodyByServer: {
         A: [
           {
             tilesetUid: 'AA',
-            tileIds: ['1', '2'],
+            tileIds: ['1', '2', '6'],
             options: { answer: 42 },
           },
           {
@@ -245,6 +298,7 @@ describe('bundleRequestsByServer', () => {
           'AA.2': true,
           'AA.4': true,
           'AA.5': true,
+          'AA.6': true,
           'BB.4': true,
           'BB.5': true,
         },
@@ -260,7 +314,18 @@ describe('bundleRequestsByServer', () => {
       { server: 'X', ids: ['foo.10'] },
       { server: 'Y', ids: ['bar.20', 'bar.30'] },
     ]);
-    expect(result).toMatchInlineSnapshot();
+    expect(result).toEqual([
+      {
+        ids: ['foo.10'],
+        server: 'X',
+        body: [],
+      },
+      {
+        ids: ['bar.20', 'bar.30'],
+        server: 'Y',
+        body: [],
+      },
+    ]);
     expect(toLegacy(result)).toEqual({
       requestBodyByServer: {
         X: [],


### PR DESCRIPTION
As a first step, moves the server-bundling of requests into a helper
which we can unit test separately.

## Description

> What was changed in this pull request?



> Why is it necessary?

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
