### PR TITLE
Allow configuration of max tiles per request limit in tile proxy

### DIFF
--- a/app/scripts/data-fetchers/DataFetcher.js
+++ b/app/scripts/data-fetchers/DataFetcher.js
@@ -14,6 +14,9 @@ import tts from '../utils/trim-trailing-slash';
 import * as tileProxy from '../services/tile-proxy';
 import { isResolutionsTilesetInfo } from '../utils/type-guards';
 
+/** @type {number} */
+const MAX_FETCH_TILES = 15;
+
 /** @import { PubSub } from 'pub-sub-es' */
 /** @import { TilesetInfo, AbstractDataFetcher, TileSource, DataConfig, HandleTilesetInfoFinished } from '../types' */
 /** @import { CompletedTileData, TileResponse } from '../services/worker' */
@@ -54,10 +57,13 @@ function isTuple(x) {
  */
 function createDefaultTileSource(pubSub) {
   return {
+    // @ts-expect-error - TODO: Need to resolve these types together
     async fetchTiles(request) {
-      /** @type {Record<string, Tile>} */
-      // @ts-expect-error - TODO: Need to resolve these types together
-      const tileData = await tileProxy.fetchTilesDebounced(request, pubSub);
+      const tileData = await tileProxy.fetchTilesDebounced(request, {
+        pubSub,
+        // TODO: Get this from DataConfig or HiGlass API?
+        maxTilesPerServerRequest: MAX_FETCH_TILES,
+      });
       return tileData;
     },
     fetchTilesetInfo({ server, tilesetUid }) {


### PR DESCRIPTION
This is still incomplete. I wanted to open a PR to facilitate discussion since I can see this API going in a couple of different directions.

One approach would be to follow how `authHeader` currently works, setting something globally for the entire lifespan of a HiGlass instance. However, I have some reservations about that approach.

Another approach would be to use more fine-grained permissions, passing configuration as props to avoid relying on globals. The oddity right now is that if you have the HiGlass API and create two viewers, they don't operate in isolation:

To illustrate:

```ts
let api1 = await hglib.viewer(el, viewconf1);
let api2 = await hglib.viewer(el, viewconf2);
api2.setAuthHeader("blah"); // sets auth header for both api1 and api2.
```

If that's the API we want to keep, I think a top-level function would be preferable to make it explicit that instances don't operate independently:

```ts
import * as hglib from "higlass";

hglib.setAuthHeader("blah");
let api1 = await hglib.viewer(el, viewconf1);
let api2 = await hglib.viewer(el, viewconf2);
```

or at least change the name on the `api` to something like `api.setGlobalAuthHeader`.

Using globals would certainly be the easiest to implement, but I can see how that might be confusing. If possible, I'd like to avoid them and have a more local context.

Whatever we decide, I think we should apply the same approach to `maxTilesPerServerRequest`. 

Now, regarding the specifics of this API, I’m wondering if a single `maxTilesPerServerRequest` value is the best approach. @pkerpedjiev mentioned this on the HiGlass Slack as motivation for the feature:

> If there's one server backing HiGlass, then it's best to send as many tile
> requests as possible at once because it saves on request handling overhead
> and the server can best parallelize their execution.

How often are HiGlass viewers backed by a single service? My understanding is that data can be federated across multiple remote sources (e.g., `higlass.io`, `resgen.io`, or now even `jupyter`). In those cases, would it be useful to make configure this setting per server rather than globally.

Currently, our tile request bundling consolidates requests by server and then splits each batch into smaller chunks based on fixed `MAX_FETCH_TILES`. 

Thinking something like this:

```ts
import * as hglib from "higlass";

hglib.setMaxTilesPerServerRequest({
    'higlass.io': 100,
    'region.io': 1,
    'jupyter': 100,
});
```

or:

```ts
hglib.setMaxTilesPerServerRequest("resglass.io", 100);
hglib.setMaxTilesPerServerRequest("higlass.io", 1);
hglib.setMaxTilesPerServerRequest("jupyter", 100);
```

Then, we could look for this setting by each bundled `request.server` falling back to some default is none is specified.

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
