### PR TITLE
Emit TypeScript types

### DIFF
--- a/app/scripts/hglib.jsx
+++ b/app/scripts/hglib.jsx
@@ -49,7 +49,7 @@ export { getTrackObjectFromHGC } from './utils';
  *
  * @returns {Promise<HiGlassComponent>}
  */
-const launch = async (element, config, options) => {
+const launch = async (element, config, options = {}) => {
   return new Promise((resolve) => {
     ReactDOM.render(
       <HiGlassComponent
@@ -57,7 +57,7 @@ const launch = async (element, config, options) => {
           // Wait to resolve until React gives us a ref
           ref && resolve(ref);
         }}
-        options={options || {}}
+        options={options}
         viewConfig={config}
       />,
       element,
@@ -70,7 +70,7 @@ const launch = async (element, config, options) => {
  *
  * @param {HTMLElement} element - DOM element to render the HiGlass component.
  * @param {HiGlassViewConfig | string} viewConfig - The view config to load.
- * @param {HiGlassOptions} options - Additional options for how the HiGlass component is drawn and behaves
+ * @param {HiGlassOptions} [options] - Additional options for how the HiGlass component is drawn and behaves
  * @returns  {Promise<HiGlassApi>}  Newly created HiGlass component.
  *
  * Note: If `viewConfig` is a string, it will be interpreted as a url from which to retrieve the viewconf.
@@ -88,7 +88,7 @@ const launch = async (element, config, options) => {
  * });
  * ```
  */
-export const viewer = async (element, viewConfig, options) => {
+export const viewer = async (element, viewConfig, options = {}) => {
   const hg = await launch(
     element,
     typeof viewConfig === 'string'

--- a/app/scripts/hglib.jsx
+++ b/app/scripts/hglib.jsx
@@ -20,7 +20,8 @@ export const tracks = {
   HorizontalGeneAnnotationsTrack,
 };
 
-export { default as schema } from '../schema.json';
+export { default as schema } from '../schema.json' with { type: 'json' };
+export { version } from '../../package.json' with { type: 'json' };
 
 /** @import * as api from './api' */
 /** @import * as types from './types' */
@@ -38,8 +39,6 @@ export {
 } from './test-helpers';
 
 export { getTrackObjectFromHGC } from './utils';
-
-export { version } from '../../package.json';
 
 /**
  * Create a `HiGlassComponent` instance.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "css": "dist/hglib.css",
   "exports": {
     ".": {
+      "types": "./dist/app/scripts/hglib.d.ts",
       "import": "./dist/higlass.mjs"
     },
     "./dist/*": "./dist/*"
@@ -17,7 +18,7 @@
   "keywords": ["hi-c", "genomics", "matrix", "tracks"],
   "scripts": {
     "start": "vite",
-    "build": "node ./scripts/build.mjs",
+    "build": "tsc -p tsconfig.emit.json && node ./scripts/build.mjs",
     "compile": "npm run build && zip -r dist.zip dist",
     "typecheck": "tsc",
     "format": "biome format --write",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "unpkg": "dist/hglib.min.js",
   "jsdelivr": "dist/hglib.min.js",
   "css": "dist/hglib.css",
+  "types": "dist/app/scripts/hglib.d.ts",
   "exports": {
     ".": {
       "types": "./dist/app/scripts/hglib.d.ts",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -101,6 +101,7 @@ async function build() {
           configFile: false,
           presets: ['@babel/preset-react'],
           plugins: ['@babel/plugin-transform-classes'],
+          generatorOpts: { importAttributesKeyword: 'with' },
         },
       }),
       injectCssByJs(),
@@ -193,6 +194,15 @@ async function main({ outDir }) {
       globalThis.hglib = hglib;
     </script>
   `),
+    ),
+    // for the types output
+    fs.promises.copyFile(
+      path.resolve(__dirname, '../package.json'),
+      path.resolve(outDir, 'package.json'),
+    ),
+    fs.promises.copyFile(
+      path.resolve(__dirname, '../app/schema.json'),
+      path.resolve(outDir, 'app/schema.json'),
     ),
   ]);
 }

--- a/tsconfig.emit.json
+++ b/tsconfig.emit.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "noEmit": false,
+    "emitDeclarationOnly": true
+  },
+  "include": ["app/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "exclude": ["node_modules", "dist"],
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",


### PR DESCRIPTION
Fixes #1108 

## Description

> What was changed in this pull request?

Adds the export of TypeScript types as a part of the build process. Using HiGlass as a library will now have autocomplete.

**`hg.viewer` docs**
<img width="400" alt="image" src="https://github.com/user-attachments/assets/0f823eff-f21a-476a-97bc-c62edea81958" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/14b1b56b-910b-4847-a7a1-3175bec3242c" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/83cd93d0-5c33-4e3e-b6fa-12fdba299c0a" />

**inline docs for `api`**
<img  alt="image" src="https://github.com/user-attachments/assets/bad2465d-83d0-4e4a-9803-6ee046467468" />


There is a lot more to do to make some of inline documentation use proper JSDoc annotations to get nicer in-editor rendering, but it's really nice to have these "hover" docs working! 


## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
