### PR TITLE
feat: Support loading chromsizes from tileset info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix: Add missing initializer value to `utils.reduce`
 - Fix `api.hideTrackChooser`
 - Use bins_per_dimension or tile_size when calculating 1D visible tiles
+- Allow chromosome tracks to reach chrominfo objects from tileset info
 
 ## v1.13.5
 

--- a/app/scripts/ChromosomeGrid.js
+++ b/app/scripts/ChromosomeGrid.js
@@ -111,8 +111,6 @@ class ChromosomeGrid extends TiledPixiTrack {
       graphics.lineTo(this.dimensions[0] + left, this._yScale(0) + top);
     }
 
-    let currPos = 0;
-
     for (let i = 0; i < this.chromInfo.cumPositions.length; i++) {
       const chrPos = this.chromInfo.cumPositions[i];
       const chrEnd = chrPos.pos + +this.chromInfo.chromLengths[chrPos.chr] + 1;

--- a/app/scripts/ChromosomeGrid.js
+++ b/app/scripts/ChromosomeGrid.js
@@ -113,9 +113,9 @@ class ChromosomeGrid extends TiledPixiTrack {
 
     let currPos = 0;
 
-    for (let i = 0; i < this.tilesetInfo.chromsizes.length; i++) {
-      const chrPos = currPos;
-      const chrEnd = currPos + this.tilesetInfo.chromsizes[i][1] + 1;
+    for (let i = 0; i < this.chromInfo.cumPositions.length; i++) {
+      const chrPos = this.chromInfo.cumPositions[i];
+      const chrEnd = chrPos.pos + +this.chromInfo.chromLengths[chrPos.chr] + 1;
 
       // Vertical lines
       if (orientation === '2d' || orientation === '1d-horizontal') {

--- a/app/scripts/ChromosomeGrid.js
+++ b/app/scripts/ChromosomeGrid.js
@@ -126,7 +126,6 @@ class ChromosomeGrid extends TiledPixiTrack {
         graphics.moveTo(left, this._yScale(chrEnd) + top);
         graphics.lineTo(this.dimensions[0] + left, this._yScale(chrEnd) + top);
       }
-      currPos += this.tilesetInfo.chromsizes[i][1];
     }
   }
 

--- a/app/scripts/HiGlassComponent.jsx
+++ b/app/scripts/HiGlassComponent.jsx
@@ -1201,8 +1201,9 @@ class HiGlassComponent extends React.Component {
       )
       // filter out stale locks with non-existant tracks
       .filter((track) => track)
-      // filter out tracks that don't have values scales (e.g. chromosome tracks)
-      .filter((track) => track.valueScale)
+      // Filter out tracks that don't have values scales (e.g. chromosome tracks).
+      // The .originalTrack check covers LeftTrackModifier style tracks.
+      .filter((track) => track.valueScale || track.originalTrack?.valueScale)
       // if the track is a LeftTrackModifier we want the originalTrack
       .map((track) =>
         track.originalTrack === undefined ? track : track.originalTrack,

--- a/app/scripts/HiGlassComponent.jsx
+++ b/app/scripts/HiGlassComponent.jsx
@@ -1201,6 +1201,8 @@ class HiGlassComponent extends React.Component {
       )
       // filter out stale locks with non-existant tracks
       .filter((track) => track)
+      // filter out tracks that don't have values scales (e.g. chromosome tracks)
+      .filter((track) => track.valueScale)
       // if the track is a LeftTrackModifier we want the originalTrack
       .map((track) =>
         track.originalTrack === undefined ? track : track.originalTrack,

--- a/app/scripts/HorizontalChromosomeLabels.js
+++ b/app/scripts/HorizontalChromosomeLabels.js
@@ -5,7 +5,6 @@ import { scaleLinear } from 'd3-scale';
 
 import ChromosomeInfo from './ChromosomeInfo';
 import TiledPixiTrack from './TiledPixiTrack';
-import SearchField from './SearchField';
 
 import {
   absToChr,
@@ -28,7 +27,6 @@ class HorizontalChromosomeLabels extends TiledPixiTrack {
     const { dataConfig, animate, chromInfoPath, isShowGlobalMousePosition } =
       context;
 
-    this.searchField = null;
     this.chromInfo = null;
     this.dataConfig = dataConfig;
 

--- a/app/scripts/TiledPixiTrack.js
+++ b/app/scripts/TiledPixiTrack.js
@@ -238,6 +238,12 @@ class TiledPixiTrack extends PixiTrack {
 
       if (isTilesetInfo(tilesetInfo)) {
         this.tilesetInfo = tilesetInfo;
+
+        if (this.tilesetInfo.chromsizes) {
+          // We got chromosome info from the tileset info so let's parse it
+          // into an object we can use
+          this.chromInfo = parseChromsizesRows(this.tilesetInfo.chromsizes);
+        }
       } else {
         // no tileset info for this track
         console.warn(
@@ -283,6 +289,10 @@ class TiledPixiTrack extends PixiTrack {
 
       this.refreshTiles();
 
+      // Let this track know that tileset info was received
+      this.tilesetInfoReceived();
+
+      // Let external listeners know that tileset info was received
       if (handleTilesetInfoReceived) handleTilesetInfoReceived(tilesetInfo);
 
       // @ts-expect-error This should never happen since options is set in Track
@@ -397,6 +407,13 @@ class TiledPixiTrack extends PixiTrack {
       }
     }
   }
+
+  /** Called when tileset info is received. The actual tileset info
+   * can be found in this.tilesetInfo.
+   *
+   * Child tracks can implement this method.
+   */
+  tilesetInfoReceived() {}
 
   /**
    * Return the set of ids of all tiles which are both visible and fetched.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "typecheck": "tsc",
     "format": "biome format --write",
     "lint": "biome ci",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test-watch": "vitest watch --browser.headless=false"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

> What was changed in this pull request?

- Support loading chromsizes from a tileset info object

> Why is it necessary?

- This lets us support passing in chromsizes in higlass-python as part of tileset objects


Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [x] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
