### PR TITLE
fix: Added styles for track chooser

### DIFF
--- a/app/scripts/TiledPlot.jsx
+++ b/app/scripts/TiledPlot.jsx
@@ -244,15 +244,11 @@ export class TiledPlot extends React.Component {
       }
     }
 
-    // console.log('extent:', extent);
-
     const trackDatas = [];
 
     // get data
     for (const track of tracks) {
       if (track.type === 'heatmap') {
-        // console.log('trackDefObjs', this.trackRenderer.trackDefObjects);
-
         const trackObj = allTrackObjs.filter((x) => x.id === track.uid)[0];
 
         const x1 = trackObj._xScale(extent[0][0]);

--- a/app/styles/TiledPlot.module.scss
+++ b/app/styles/TiledPlot.module.scss
@@ -63,3 +63,23 @@
 path.domain {
   stroke-width: 0px;
 }
+
+.tiled-plot-track-overlay-plain {
+  background: transparent;
+  z-index: 1;
+}
+
+.tiled-plot-track-overlay-animate {
+  background: yellow;
+  opacity: 0.3;
+  outline: 2px solid rgba(255, 0, 0, 0.8);
+  z-index: 1;
+  animation: appear 1s;
+}
+
+.tiled-plot-track-overlay-selected {
+  border: 5px solid black;
+  background: yellow;
+  opacity: 0.4;
+  z-index: 1;
+}


### PR DESCRIPTION
## Description

> What was changed in this pull request?

- Added the styles that enabled the track chooser to be visible

<img width="853" height="379" alt="image" src="https://github.com/user-attachments/assets/70ec2d0b-4580-450b-b80d-086fba95705d" />

> Why is it necessary?

- So that the track chooser is visible

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [x] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
