### PR TITLE
fix: Avoid crashing error on empty tiles that don't initialize valueS…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed bug where track controls were being displayed on top of each other
 - Fixed bug where expand / collapse buttons were visible on center track
+- Fixed bug where higlass would crash on empty tiles due to unitialized valueScale
 
 ## v2.1.0
 

--- a/app/scripts/BarTrack.js
+++ b/app/scripts/BarTrack.js
@@ -110,6 +110,8 @@ class BarTrack extends HorizontalLine1DPixiTrack {
       0,
     );
 
+    if (!valueScale) return;
+
     // Important when when using `options.valueScaleMin` or
     // `options.valueScaleMax` such that the y position later on doesn't become
     // negative
@@ -302,6 +304,8 @@ class BarTrack extends HorizontalLine1DPixiTrack {
     else this.zeroLine.clear();
 
     Object.values(this.fetchedTiles).forEach((tile) => {
+      if (!tile.drawnAtScale) return;
+
       const [graphicsXScale, graphicsXPos] = this.getXScaleAndOffset(
         tile.drawnAtScale,
       );

--- a/app/scripts/HorizontalLine1DPixiTrack.js
+++ b/app/scripts/HorizontalLine1DPixiTrack.js
@@ -89,7 +89,9 @@ class HorizontalLine1DPixiTrack extends HorizontalTiled1DPixiTrack {
     // this function is just so that we follow the same pattern as
     // HeatmapTiledPixiTrack.js
     this.drawTile(tile);
-    this.drawAxis(this.valueScale);
+    if (this.valueScale) {
+      this.drawAxis(this.valueScale);
+    }
   }
 
   drawTile(tile) {


### PR DESCRIPTION
…cale

## Description

> What was changed in this pull request?

Fixed an error where higlass would crash if an empty tile caused the value scale to not be initialized.

Example where this crashes: https://resgen.io/mirnylab/Hsieh2021bioRxiv/views/esd42ujTT0C1V0K5QKvA9Q

> Why is it necessary?

Prevent a crash.

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
