### PR TITLE
fix: Handle clicks on drag listening divs as if they were drag droppe…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## Next
+
+- Handle clicks on DragListeningDivs
+
 ## 2.1.2
 
 - Fixed another bug where higlass would crash on empty tiles due to unitialized valueScale

--- a/app/scripts/DragListeningDiv.jsx
+++ b/app/scripts/DragListeningDiv.jsx
@@ -18,6 +18,29 @@ class DragListeningDiv extends React.Component {
     };
   }
 
+  handleDrop() {
+    if (!this.props.enabled) return;
+
+    const evtJson = this.props.draggingHappening;
+
+    const newTrack = {
+      type: this.props.defaultTrackType,
+      uid: slugid.nice(),
+    };
+
+    if (evtJson.tilesetUid && evtJson.server) {
+      newTrack.tilesetUid = evtJson.tilesetUid;
+      newTrack.server = evtJson.server;
+    }
+
+    if (evtJson.data) {
+      newTrack.data = evtJson.data;
+    }
+
+    this.props.onTrackDropped(newTrack);
+    this.props.pubSub.publish('trackDropped', newTrack);
+  }
+
   render() {
     // color red if not enabled, green if a track is not top and blue otherwise
     let background = 'red';
@@ -33,6 +56,7 @@ class DragListeningDiv extends React.Component {
         className={clsx('DragListeningDiv', {
           [classes['drag-listening-div-active']]: this.props.enabled,
         })}
+        onClick={this.handleDrop.bind(this)}
         onDragEnter={() => {
           this.setState({ dragOnTop: true });
         }}
@@ -42,20 +66,16 @@ class DragListeningDiv extends React.Component {
         onDragOver={(evt) => {
           evt.preventDefault();
         }}
-        onDrop={() => {
-          if (!this.props.enabled) return;
-
-          const evtJson = this.props.draggingHappening;
-
-          const newTrack = {
-            type: this.props.defaultTrackType,
-            uid: slugid.nice(),
-            tilesetUid: evtJson.tilesetUid,
-            server: evtJson.server,
-          };
-
-          this.props.onTrackDropped(newTrack);
-          this.props.pubSub.publish('trackDropped', newTrack);
+        onDrop={this.handleDrop.bind(this)}
+        onMouseEnter={() => {
+          this.setState({
+            dragOnTop: true,
+          });
+        }}
+        onMouseLeave={() => {
+          this.setState({
+            dragOnTop: false,
+          });
         }}
         style={{
           background,


### PR DESCRIPTION
…d events

## Description

> What was changed in this pull request?

- Added mouseenter and click events as handlers on drag listening divs

> Why is it necessary?

- So that someone without dragging capabilities can interact with drag listening divs

<img width="544" height="708" alt="image" src="https://github.com/user-attachments/assets/0782121e-be1d-48c8-8c5d-14bd8e4f4d7d" />

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [x] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
