### PR TITLE
fix: Pass in a pixelsPerTile value (either tile_size or bins_per_dime…

### DIFF
--- a/app/scripts/track-utils.js
+++ b/app/scripts/track-utils.js
@@ -238,6 +238,7 @@ const calculate1DVisibleTiles = (tilesetInfo, scale) => {
       scale,
       tilesetInfo.min_pos[0],
       tilesetInfo.max_pos[0],
+      tilesetInfo.tile_size || tilesetInfo.bins_per_dimension || 256,
     );
 
     const tiles = xTiles.map((x) => [zoomLevel, x]);

--- a/package.json
+++ b/package.json
@@ -15,16 +15,8 @@
     },
     "./dist/*": "./dist/*"
   },
-  "files": [
-    "app",
-    "dist"
-  ],
-  "keywords": [
-    "hi-c",
-    "genomics",
-    "matrix",
-    "tracks"
-  ],
+  "files": ["app", "dist"],
+  "keywords": ["hi-c", "genomics", "matrix", "tracks"],
   "scripts": {
     "start": "vite",
     "build": "tsc -p tsconfig.emit.json && node ./scripts/build.mjs",


### PR DESCRIPTION
…nsion)

## Description

> What was changed in this pull request?

- Pass in a value for pixelsPerTile so that the value that is passed in from tilesetInfo isn't ignored


> Why is it necessary?

Fixes #___

## Checklist

- [ ] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [ ] Unit tests added or updated
- [ ] Documentation added or updated
- [ ] Example(s) added or updated
- [ ] Update schema.json if there are changes to the viewconf JSON structure format
- [ ] Screenshot for visual changes (e.g. new tracks or UI changes)
- [ ] Updated CHANGELOG.md
