### PR TITLE
NickAkhmetov/fix #1300: update external dependencies in build script to include React JSX runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## 2.3.3
+- Externalize JSX runtime to ensure compatibility
+
+
 ## 2.3.2
 
 - Fix horizontal cross sections on tilesets with resolutions

--- a/package.json
+++ b/package.json
@@ -15,16 +15,8 @@
     },
     "./dist/*": "./dist/*"
   },
-  "files": [
-    "app",
-    "dist"
-  ],
-  "keywords": [
-    "hi-c",
-    "genomics",
-    "matrix",
-    "tracks"
-  ],
+  "files": ["app", "dist"],
+  "keywords": ["hi-c", "genomics", "matrix", "tracks"],
   "scripts": {
     "start": "vite",
     "build": "tsc -p tsconfig.emit.json && node ./scripts/build.mjs",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -79,12 +79,14 @@ async function build() {
         formats: ['umd', 'es'],
       },
       rollupOptions: {
-        external: ['react', 'react-dom', 'react-dom/client', 'pixi.js'],
+        external: ['react', 'react-dom', 'react-dom/client', 'react/jsx-runtime', 'react/jsx-dev-runtime', 'pixi.js'],
         output: {
           globals: {
             react: 'React',
             'react-dom': 'ReactDOM',
             'react-dom/client': 'ReactDOM',
+            'react/jsx-runtime': 'ReactJSXRuntime',
+            'react/jsx-dev-runtime': 'ReactJSXDevRuntime',
             'pixi.js': 'PIXI',
           },
         },

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -79,7 +79,14 @@ async function build() {
         formats: ['umd', 'es'],
       },
       rollupOptions: {
-        external: ['react', 'react-dom', 'react-dom/client', 'react/jsx-runtime', 'react/jsx-dev-runtime', 'pixi.js'],
+        external: [
+          'react',
+          'react-dom',
+          'react-dom/client',
+          'react/jsx-runtime',
+          'react/jsx-dev-runtime',
+          'pixi.js',
+        ],
         output: {
           globals: {
             react: 'React',


### PR DESCRIPTION
## Description

> What was changed in this pull request?

This PR adds the react jsx runtime and jsx dev runtime to the externalized libraries.

> Why is it necessary?

The bundled runtimes otherwise cause Higlass to crash when embedded in React 19 sites.

Fixes #1300

## Checklist

- [x] Set proper GitHub labels (e.g. v1.6+, ignore if you don't know)
- [x] Unit tests added or updated
- [x] Documentation added or updated
- [x] Example(s) added or updated
- [x] Update schema.json if there are changes to the viewconf JSON structure format
- [x] Screenshot for visual changes (e.g. new tracks or UI changes)
- [x] Updated CHANGELOG.md
