### PR TITLE
Fix typo in docs (track-type for chromosome labels)

### DIFF
--- a/docs/track_types.rst
+++ b/docs/track_types.rst
@@ -411,7 +411,7 @@ Chromosome Labels
 .. image:: img/chromosome-labels-thumb.png
     :align: right
 
-track-type: ``chromosome-labes``
+track-type: ``chromosome-labels``
 datatype: ``chromsizes`` or ``cooler``
 filetypes: ``chromsizes-tsv``
 


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Just a small docs typo correction...
