### PR TITLE
Fix zoomedY not firing with mouse wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## 2.3.3
+
+- Fix value-scale zoom (`zoomedY`) not firing with a mouse wheel by checking the shift key on the current source event and falling back to `deltaX` when `deltaY` is zero
+
 ## 2.3.2
 
 - Fix horizontal cross sections on tilesets with resolutions

--- a/app/scripts/TrackRenderer.jsx
+++ b/app/scripts/TrackRenderer.jsx
@@ -1467,7 +1467,11 @@ export class TrackRenderer extends React.Component {
     if (trackOrientation && event.sourceEvent) {
       // if somebody is holding down the shift key and is zooming over
       // a 1d track, try to apply value scale zooming
-      if (event.shiftKey || this.valueScaleZooming || event.sourceEvent?.shiftKey) {
+      if (
+        event.shiftKey ||
+        this.valueScaleZooming ||
+        event.sourceEvent?.shiftKey
+      ) {
         if (event.sourceEvent.deltaY !== undefined) {
           this.valueScaleZoom(event, trackOrientation);
           return;

--- a/app/scripts/TrackRenderer.jsx
+++ b/app/scripts/TrackRenderer.jsx
@@ -1400,7 +1400,7 @@ export class TrackRenderer extends React.Component {
     if (!isWheelEvent(event.sourceEvent)) {
       return;
     }
-    const mdy = event.sourceEvent.deltaY;
+    const mdy = event.sourceEvent.deltaY || event.sourceEvent.deltaX;
     const mdm = event.sourceEvent.deltaMode;
 
     /**
@@ -1467,7 +1467,7 @@ export class TrackRenderer extends React.Component {
     if (trackOrientation && event.sourceEvent) {
       // if somebody is holding down the shift key and is zooming over
       // a 1d track, try to apply value scale zooming
-      if (event.shiftKey || this.valueScaleZooming) {
+      if (event.shiftKey || this.valueScaleZooming || event.sourceEvent?.shiftKey) {
         if (event.sourceEvent.deltaY !== undefined) {
           this.valueScaleZoom(event, trackOrientation);
           return;

--- a/package.json
+++ b/package.json
@@ -15,16 +15,8 @@
     },
     "./dist/*": "./dist/*"
   },
-  "files": [
-    "app",
-    "dist"
-  ],
-  "keywords": [
-    "hi-c",
-    "genomics",
-    "matrix",
-    "tracks"
-  ],
+  "files": ["app", "dist"],
+  "keywords": ["hi-c", "genomics", "matrix", "tracks"],
   "scripts": {
     "start": "vite",
     "build": "tsc -p tsconfig.emit.json && node ./scripts/build.mjs",


### PR DESCRIPTION
## Summary

- Check `event.sourceEvent?.shiftKey` directly in `zoomed` so value-scale zoom triggers even when Shift is pressed after a gesture has started (the cached `valueScaleZooming` flag is only set at gesture start via `zoomStarted`)
- Fall back to `deltaX` when `deltaY` is zero in `valueScaleZoom`, handling the macOS behaviour where Shift+scroll with a physical mouse wheel converts vertical scroll to horizontal

## Test plan

- [ ] Hold Shift and scroll over a 1d-horizontal track with a **trackpad** — value scale should zoom as before
- [ ] Hold Shift and scroll over a 1d-horizontal track with a **mouse wheel** — value scale should now zoom
- [ ] Confirm regular pan/zoom (no Shift) is unaffected for both input devices